### PR TITLE
docs(spec-dock): iss-00082 の実装仕様を実装着手可能な状態に整備

### DIFF
--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/design.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/design.md
@@ -5,81 +5,85 @@ ID: "init-00079"
 関連GitHub: ["#79"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 依存: ["requirement.md"]
 ---
 
 # init-00079 minor bugfix maintenance — 設計（HOW / Guardrails）
 
 ## アーキテクチャ上の狙い
-- ...
+- bug report の入口を 1 つに寄せつつ、architecture / feature / external-consumer concern をこの bucket から分離する。
 
 ## 現状と目指す姿
 - As-Is:
-  - ...
+  - `init-00079 / epic-00080` は存在するが、docs がテンプレートのままで具体的な routing guardrail がない。
 - To-Be:
-  - ...
+  - repo-local actionable bug はこの initiative 配下へ issue 化する。
+  - external consumer app 側の flaky CI は背景 evidence としては参照できるが、本 repo の修正対象に自動昇格しない。
 
 ### UML（任意: high-level context / target-state）
 ```plantuml
 @startuml
-' 必要なら high-level context / target-state を記載
+skinparam monochrome true
+left to right direction
+
+rectangle "dogfooding bug report" as report
+rectangle "init-00079 / epic-00080" as bucket
+rectangle "repo-local issue" as local_issue
+rectangle "external consumer issue" as external_issue
+
+report --> bucket
+bucket --> local_issue
+report --> external_issue : background only
 @enduml
 ```
 
 ## 対象境界 / 依存
 - in scope:
-  - ...
+  - repo 内で再現・修正・検証できる minor runtime / installer / docs / mirror parity bug
 - external dependency:
-  - ...
+  - GitHub issue linkage
+  - dogfooding 中に収集される PR review / CI evidence
 - boundary policy:
-  - ...
+  - root cause が本 repo の contract にある場合だけ issue を切る。
+  - root cause が外部 consumer app に閉じる場合は、別 issue / 別 repo で管理する。
 
 ## ガードレール
 - 互換性:
-  - ...
+  - provider-side source of truth と dogfooding mirror の差異を放置しない。
 - セキュリティ:
-  - ...
+  - issue / research / report には必要十分な evidence だけを残し、秘匿情報は持ち込まない。
 - データ境界:
-  - ...
+  - issue ごとの spec docs が正本であり、会話ログは正本にしない。
 - 品質条件:
-  - ...
+  - issue は single actionable bug に閉じ、requirement / design / plan / report が具体化されていること。
 
 ## ロールアウト原則
 - rollout strategy:
-  - ...
+  - parent bucket docs は最小限の guardrail のみを持ち、具体的な修正契約は issue docs で閉じる。
 - rollback principle:
-  - ...
+  - bucket 自体は rollback せず、個別 bugfix issue の差分単位で戻す。
 - feature flag principle:
-  - ...
+  - minor bug bucket では feature flag を前提にしない。必要なら個別 issue で判断する。
 
 ## 観測性 / NFR 原則
 - observability:
-  - ...
+  - bug report の出典、観測点、repo-local / external の切り分けを issue docs か research に残す。
 - performance / reliability:
-  - ...
+  - minor bug 対応でも validate / sync / report evidence を残せる運用を維持する。
 - audit / compliance:
-  - ...
+  - GitHub issue 番号と issue docs の対応を保つ。
 
 ## 主要リスク
 - R-001:
-  - ...
+  - external flaky issue を本 repo の bug と誤認する。
 - R-002:
-  - ...
+  - parent bucket docs を薄くしすぎて、issue 作成判断が人依存になる。
 
 ## 関連 ADR
-- adr-...:
-  - ...
+- なし:
+  - 現時点では initiative-level ADR は不要。長期方針変更が出たら architecture initiative 側で扱う。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - minor bug bucket は route-first の軽量運用で開始する。

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/design.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/design.md
@@ -5,7 +5,7 @@ ID: "epic-00080"
 関連GitHub: ["#80"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 依存: ["requirement.md"]
 親: ["init-00079"]
 ---
@@ -14,16 +14,28 @@ ID: "epic-00080"
 
 ## 全体像
 - target boundary:
-  - ...
+  - repo-local actionable bug の reusable bucket
 - impacted area:
-  - ...
+  - runtime / installer / docs / dogfooding mirror の minor contract bugs
 - existing relation:
-  - ...
+  - initiative `init-00079` の唯一の execution epic として機能する
 
 ### UML（推奨: module / context）
 ```plantuml
 @startuml
-' module / context diagram
+skinparam monochrome true
+left to right direction
+
+rectangle "dogfooding evidence" as evidence
+rectangle "epic-00080" as epic
+rectangle "issue spec" as issue
+rectangle "repo-local implementation" as impl
+rectangle "external consumer repo" as external
+
+evidence --> epic
+epic --> issue
+issue --> impl
+evidence --> external : background only
 @enduml
 ```
 
@@ -31,98 +43,105 @@ ID: "epic-00080"
 ### API（必要時）
 - API-001:
   - Request:
+    - bug report / review comment / CI evidence
   - Response:
+    - concrete issue spec under `epic-00080`
   - Errors:
+    - repo-local actionable bug でない場合は本 epic の対象外とする
 
 ### Event（必要時）
-- EVT-001:
-  - Producer:
-  - Consumer:
-  - Payload:
+- なし:
+  - event contract は issue ごとに定義する
 
 ### Data boundary
 - SoR:
-  - ...
+  - issue requirement / design / plan / report
 - consistency model:
-  - ...
+  - parent docs は routing guardrail、具体的な修正契約は issue docs に委譲する
 
 ## データモデル
 - model / table changes:
-  - ...
+  - epic 自体では持たない
 - invariants:
-  - ...
+  - issue は single actionable bug に閉じる
+  - external evidence は non-goal として明示する
 
 ### UML（任意: data model）
 ```plantuml
 @startuml
-' data / entity diagram
+rectangle "epic-00080" as epic
+rectangle "iss-00082" as issue
+rectangle "research doc" as research
+epic --> issue
+issue --> research
 @enduml
 ```
 
 ## 主要フロー
 - Flow-A:
-  1. ...
-  2. ...
-  3. ...
+  1. dogfooding で bug report を受ける
+  2. repo-local actionable bug かを判定する
+  3. `epic-00080` 配下に issue を作成し、spec を固定する
 - Flow-B:
-  - ...
+  1. external staging failure などの evidence を受ける
+  2. repo-local bug でない場合は background evidence としてだけ残す
+  3. 必要なら別 repo / 別 issue を案内する
 
 ### UML（任意: sequence / flow）
 ```plantuml
 @startuml
-' sequence / flow diagram
+actor Maintainer
+participant "Bug report" as Report
+participant "epic-00080" as Epic
+participant "issue spec" as Issue
+
+Maintainer -> Report: collect evidence
+Maintainer -> Epic: evaluate scope
+Epic -> Issue: create issue when repo-local
 @enduml
 ```
 
 ## 失敗設計
 - failure mode:
-  - ...
+  - external issue を誤って repo-local issue にしてしまう
 - retry:
-  - ...
+  - scope を research / requirement で切り直す
 - idempotency:
-  - ...
+  - 既存 issue に収まるなら新規作成せず更新する
 - partial failure:
-  - ...
+  - issue 作成だけ成功し spec が未記入のままになると incomplete とみなす
 
 ## 移行戦略
 - migration strategy:
-  - ...
+  - 既存 reusable bucket をそのまま利用する
 - dual write/read if needed:
-  - ...
+  - 不要
 - rollback:
-  - ...
+  - issue 単位で元に戻す
 
 ## 観測性 / セキュリティ
 - observability:
-  - ...
+  - GitHub issue 番号、issue docs、research doc を相互参照可能にする
 - role / auth:
-  - ...
+  - GitHub-backed node creation に依存する
 - audit / pii:
-  - ...
+  - 秘匿情報を docs に持ち込まない
 
 ## テスト戦略
 - Unit:
-  - ...
+  - epic 自体では持たない
 - Integration:
-  - ...
+  - issue 作成後に validate / sync で tree projection が更新されること
 - E2E:
-  - ...
+  - first issue `iss-00082` が active issue として参照できること
 - E-AC mapping:
-  - E-AC-001 -> ...
+  - E-AC-001 -> `iss-00082` creation + issue docs authoring
+  - E-AC-002 -> issue / research scope wording
 
 ## 関連 ADR
-- adr-...:
-  - ...
+- なし:
+  - epic レベルの ADR は不要
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - individual bug design decisions は issue docs で扱う

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/.meta.json
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00082",
+  "title": "Fail fast on malformed node metadata",
+  "slug": "fail-fast-on-malformed-node-metadata",
+  "created_at": "2026-04-17T11:37:44+09:00",
+  "updated_at": "2026-04-17T11:37:44+09:00",
+  "parent_id": "epic-00080",
+  "initiative_id": "init-00079",
+  "epic_id": "epic-00080",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 82,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/design.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/design.md
@@ -1,0 +1,186 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00082"
+タイトル: "Fail fast on malformed node metadata"
+関連GitHub: ["#82"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-04-20"
+依存: ["requirement.md"]
+親: ["epic-00080", "init-00079"]
+---
+
+# iss-00082 Fail fast on malformed node metadata — 設計（HOW）
+
+## 目的・制約
+- 目的:
+  - malformed node metadata の silent skip を廃止し、graph load を fail-fast に寄せる。
+- MUST / MUST NOT:
+  - MUST:
+    - `type` / `id` が正規化後に非空文字列でない場合に RuntimeError を投げる
+    - error に `meta_path` を含める
+    - provider-side source と dogfooding mirror を揃える
+  - MUST NOT:
+    - malformed node を読み飛ばさない
+    - valid nodes の読み込みを変えない
+    - external staging failure 対応を混ぜない
+- 非交渉制約:
+  - implementation source of truth は `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - checked-in dogfooding mirror も同一 contract を保つ
+- 前提:
+  - `load_node_records()` は graph load / repo read path の共通入口である
+
+## 既存実装 / 規約の理解
+- 参照した実装 / docs:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/phase_requirement.md`
+  - `spec-dock/docs/phase_design.md`
+  - `spec-dock/docs/phase_plan_issue.md`
+- 現状理解:
+  - `load_node_records()` は `.meta.json` が object でない場合は fail するが、`type` / `id` を `str(...).strip()` した結果が空文字のときは `continue` している。
+- 採用するパターン:
+  - existing invalid metadata handling を拡張し、required field が非空文字列でないケースを RuntimeError として扱う。
+- 採用しないもの:
+  - warning-only handling
+  - malformed node の best-effort load
+  - issue scope 外の schema expansion
+- 影響範囲:
+  - provider-side runtime asset
+  - checked-in dogfooding runtime mirror
+  - targeted tests
+
+## 採用方針 / トレードオフ
+- 論点:
+  - malformed node を skip するか fail-fast するか
+  - missing key だけを対象にするか、blank / whitespace-only / non-string まで integrity violation に含めるか
+  - provider-side fix だけで済ませるか mirror parity まで同一 issue で閉じるか
+- 選択肢:
+  - Option A:
+    - 現状どおり skip し続ける
+  - Option B:
+    - required field が非空文字列でない場合を RuntimeError に昇格する
+  - Option C:
+    - provider-side だけ直し、mirror は後続 issue に送る
+- 決定:
+  - Option B を採用する
+  - parity drift を避けるため Option C は採用しない
+
+## 依存関係分析
+- upstream / prerequisite:
+  - `load_node_records()` の既存 invalid-object error path
+  - issue requirement の fail-fast contract
+- downstream / dependent:
+  - graph load / repo read callers
+  - dogfooding runtime validation
+- 実装起点:
+  - SG1 spec review で issue contract を固定し、その後 `load_node_records()` の red test を先に固定して最小変更で fail-fast contract を入れる
+- sequencing implications:
+  - provider-side contract を先に固定し、その後 mirror parity と docs/report evidence を揃える
+
+### UML（必須: module / dependency）
+```plantuml
+@startuml
+top to bottom direction
+skinparam monochrome true
+
+rectangle "targeted tests" as tests
+rectangle "provider fs_repo.py\nload_node_records()" as provider
+rectangle "dogfooding fs_repo.py\nmirror" as mirror
+rectangle "graph load / repo read callers" as callers
+
+tests --> provider
+provider --> mirror : parity
+callers --> provider
+@enduml
+```
+
+## インターフェース契約
+- API / function / protocol / data boundary:
+  - function:
+    - `load_node_records(specdock_dir: Path) -> list[StoredMetaRecord]`
+  - before:
+    - `type` / `id` を `str(...).strip()` した結果が空なら `continue`
+  - after:
+    - `type` が非文字列または `.strip()` 後に空なら RuntimeError
+    - `id` が非文字列または `.strip()` 後に空なら RuntimeError
+    - error message は `meta_path` を含む
+    - valid node behavior は unchanged
+
+## クラス / インターフェース詳細設計（必要時）
+- Class / Interface:
+  - `StoredMetaRecord` loader path in `fs_repo.py`
+- responsibility:
+  - node metadata を完全性付きで records へ変換する
+- collaboration:
+  - `load_json`
+  - graph load / repo read callers
+  - targeted regression tests
+
+### UML（任意: class / interface）
+```plantuml
+@startuml
+class fs_repo {
+  load_node_records()
+}
+
+class StoredMetaRecord
+
+fs_repo --> StoredMetaRecord
+@enduml
+```
+
+## 変更計画
+- Add:
+  - missing / blank / whitespace-only / non-string required field 用の targeted regression cases
+- Modify:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - relevant tests
+- Delete:
+  - なし
+- Move/Rename:
+  - なし
+- Read only:
+  - issue research note
+  - staging failure evidence
+
+## 要件 → 設計マッピング
+- AC-001 -> malformed `type` branch is RuntimeError
+- AC-002 -> malformed `id` branch is RuntimeError
+- AC-003 -> valid records path remains unchanged
+- AC-004 -> staging failure remains research / non-goal only
+- EC-001 -> existing invalid-object error path unchanged
+- EC-002 -> mirror parity update in same issue
+- constraint -> provider-side source of truth first
+
+## テスト戦略
+- Unit:
+  - malformed `.meta.json` invalid `type` (`missing`, `""`, whitespace-only, non-string)
+  - malformed `.meta.json` invalid `id` (`missing`, `""`, whitespace-only, non-string)
+- Integration:
+  - valid metadata load still passes
+- Manual / operational evidence:
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync --github` は optional な repo-state refresh evidence とし、この issue の pass/fail gate には含めない
+- migration / rollback / feature flag if needed:
+  - feature flag 不要
+  - rollback は issue diff 単位
+
+## 要件 / 例外 -> verification mapping
+- AC-001 -> targeted test for malformed `type`
+- AC-002 -> targeted test for malformed `id`
+- AC-003 -> existing valid-load regression
+- AC-004 -> spec / research review
+- EC-001 -> invalid-object regression unchanged
+- EC-002 -> changed-files parity check
+- constraint -> provider + mirror both touched or justified no-op
+
+## リスク / 移行 / ロールバック（必要時）
+- risk:
+  - error message wording を変えすぎると既存 test が brittle になる
+- mitigation:
+  - include assertion on path and missing-field intent
+- rollback:
+  - revert issue diff if fail-fast contract causes unexpected breakage

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/discussions/20260417t023838z-research-pr-review-and-staging-failure-analysis.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/discussions/20260417t023838z-research-pr-review-and-staging-failure-analysis.md
@@ -1,0 +1,43 @@
+---
+種別: research
+ID: "20260417t023838z-research"
+タイトル: "pr review and staging failure analysis"
+状態: "completed"
+作成者: "iwasawayuuta"
+最終更新: "2026-04-17"
+親: ["iss-00082"]
+関連: ["#1778", "#1821", "#82"]
+---
+
+# 20260417t023838z-research pr review and staging failure analysis
+
+## 調査目的 (必須)
+- PR `#1821` の Codex review P1 が `spec-dock` runtime 側の bug かを切り分ける。
+- staging workflow failure が今回の repo-local bugfix issue の修正対象かどうかを整理する。
+
+## 調査方法 (必須)
+- PR review comment の対象 file / 指摘内容を確認した。
+- workflow run `24541771497` と `management_api_test` failure summary を確認した。
+- branch diff の変更範囲と、`spec-dock` runtime path の責務を照合した。
+
+## 調査結果 (必須)
+- Codex の P1 指摘対象は `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py` で、`.meta.json` の `type` または `id` が欠けている malformed node を loader が silent skip している点だった。
+- 指摘の論点は migration docs ではなく runtime の metadata integrity contract であり、本 repo の `spec-dock` 本体に属する。
+- staging failure は既存 workflow `Test and Deploy for Staging` の `management_api_test` failure で、failing assertion は async outbox delivery の観測タイミング依存だった。
+- failing assertion は `pending` / `in_progress` のみを期待していたが、実際には `delivered` まで進行していた。
+- branch diff 上、management API 本体や staging workflow そのものは今回の spec-dock migration 差分で変更していなかった。
+
+## 結論 (必須)
+- repo-local actionable bug として追うべきなのは、`spec-dock` runtime 側の malformed metadata silent skip である。
+- staging failure は external consumer app 側の flaky / overspecified integration assertion とみるのが自然であり、本 issue `iss-00082` の修正対象には含めない。
+- したがって `iss-00082` は malformed metadata fail-fast に閉じ、staging failure は background evidence としてのみ参照する。
+
+## リスク/制約 (任意)
+- staging failure 自体の根本原因修正は別 issue / 別 repo トラックが必要になる可能性が高い。
+- 本 research は issue scoping の材料であり、implementation proof ではない。
+
+## 参考（References） (任意)
+- GitHub PR comments on `#1821`
+- GitHub workflow run `24541771497`
+- job `management_api_test`
+- `gh run view 24541771497 --job 71748942532 --log`

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/discussions/rules.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/plan.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/plan.md
@@ -1,0 +1,373 @@
+---
+種別: 実装計画書（Issue）
+ID: "iss-00082"
+タイトル: "Fail fast on malformed node metadata"
+関連GitHub: ["#82"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-04-20"
+依存: ["requirement.md", "design.md"]
+親: ["epic-00080", "init-00079"]
+---
+
+# iss-00082 Fail fast on malformed node metadata — 実装計画（Execution Contract）
+
+## この計画で満たす要件ID
+- AC:
+  - AC-001
+  - AC-002
+  - AC-003
+  - AC-004
+- EC:
+  - EC-001
+  - EC-002
+  - EC-003
+- 制約:
+  - fix scope は malformed metadata fail-fast に限定する
+  - provider-side source of truth と mirror parity を維持する
+  - external staging failure は non-goal のまま扱う
+  - malformed 判定は `type` / `id` が `.strip()` 後に非空文字列でないケースへ閉じる
+
+## マイルストーン一覧
+- M1:
+  - 対象:
+    - pre-implementation spec lock
+  - exit:
+    - requirement / design / plan が `approved` で、SG1 spec review が `pass` になっている
+- M2:
+  - 対象:
+    - red test 固定と provider-side fail-fast 実装
+  - exit:
+    - malformed `type` / `id` が RuntimeError になり targeted tests が pass する
+- M3:
+  - 対象:
+    - mirror parity / error wording / issue evidence
+  - exit:
+    - dogfooding mirror が揃い、background evidence の non-goal 境界が docs に反映される
+- M4:
+  - 対象:
+    - final validation and review closure
+  - exit:
+    - local validation / final diff review / final review evidence が `report.md` に残る
+
+## 実装順序の根拠
+- 依存関係の正本:
+  - `design.md` の `依存関係分析` と module/dependency UML を参照する
+- sequencing rule:
+  - SG1 spec review で実装前 readiness を固定する
+  - その後 `load_node_records()` の red test を先に固定する
+  - provider-side contract を先に変え、そのあと mirror parity を揃える
+- step ordering notes:
+  - S00 は pre-implementation spec review gate
+  - S01 は現状 bug の red test 固定
+  - S02 は provider-side source of truth の修正
+  - S03 は mirror parity と issue docs / report 整理
+  - S90 は docs/report refresh
+  - S99 は final validation and review
+
+## ステップ一覧
+- S00:
+  - 観測可能な振る舞い:
+    - issue docs だけで implementation-ready と判断できる
+  - closes:
+    - AC-004 baseline
+  - review gate:
+    - SG1 spec review pass
+- S01:
+  - 観測可能な振る舞い:
+    - malformed metadata skip の現状が red test で再現される
+  - closes:
+    - AC-001 baseline
+    - AC-002 baseline
+  - review gate:
+    - baseline evidence recorded in `report.md`
+- S02:
+  - 観測可能な振る舞い:
+    - malformed `type` / `id` が RuntimeError になる
+  - closes:
+    - AC-001
+    - AC-002
+    - AC-003
+    - EC-001
+  - review gate:
+    - RG1 implementation review pass
+    - QG1 targeted tests pass
+- S03:
+  - 観測可能な振る舞い:
+    - dogfooding mirror と docs / evidence が provider-side contract に追従する
+  - closes:
+    - AC-004
+    - EC-002
+    - EC-003
+  - review gate:
+    - RG1 implementation review pass
+- S90:
+  - 観測可能な振る舞い:
+    - issue docs / report が実際の review 結果と verification scope を反映している
+  - closes:
+    - AC-004
+  - review gate:
+    - SG1 spec review pass
+- S99:
+  - 観測可能な振る舞い:
+    - final validate / diff review / final review evidence が揃う
+  - closes:
+    - final exit contract
+  - review gate:
+    - SG1 final spec review pass
+    - RG1 implementation review pass
+    - QG1 QA review pass
+
+## 要件 ↔ ステップ対応
+- AC-001 -> S01, S02
+- AC-002 -> S01, S02
+- AC-003 -> S02
+- AC-004 -> S00, S03, S90, S99
+- EC-001 -> S02
+- EC-002 -> S03, S99
+- EC-003 -> S03
+
+## レビュー / QA ゲート方針
+- RG1 implementation review:
+  - timing:
+    - S02 後
+    - S03 後
+  - scope:
+    - fail-fast contract
+    - provider / mirror parity
+  - commit gate:
+    - pass まで review loop を回し、pass 後に `report.md` を更新して差分確認後にコミットする
+- QG1 QA review:
+  - timing:
+    - S02 後
+    - S99 前
+  - scope:
+    - green 状態の targeted tests
+    - `validate` evidence
+  - commit gate:
+    - pass まで test loop を回し、pass 後に `report.md` を更新して差分確認後にコミットする
+- SG1 spec review:
+  - timing:
+    - S00 後
+    - S90 後
+    - S99 前
+  - scope:
+    - issue scope closure
+    - staging failure non-goal boundary
+    - implementation readiness
+  - commit gate:
+    - pass まで review loop を回し、pass 後に `report.md` を更新してドキュメントだけをコミットする
+
+## 実行ルール（全ステップ共通）
+- plan 全体は実装着手前に承認する。
+- cadence / approval policy は `workflow_issue.md` を正本とする。
+- 互換参照: `Red → Green → Refactor → review → fix → re-review → report → commit/no-op`
+- 各 step は 1 つの観測可能な振る舞いを単位とする。
+- `block` は optional concern group。単純な step では最小 wrapper 1 個でよい。
+- `iteration` は 1 回の TDD cycle とし、各 iteration は `Red → Green → Refactor` で閉じる。
+- failing test は iteration ごとに 1 本ずつ進める。
+- `Green` は最小実装、`Refactor` は green 維持を前提とする。
+- shared minimum gate と scope-specific readiness contract / final exit contract を満たす。
+- docs impact が `none` でなければ `S90` を実行する。
+- 最後に `git diff <base>...HEAD` を対象に `S99 final diff review quality gate` を実施する。
+- reviewer verdict は `report.md` に残す。
+- 各 stage gate（SG/RG/QG）は `pass` まで回す。
+- 各 stage gate の `pass` 後は、`report.md` を更新し、差分確認後に report とまとめてコミットする。
+- no-op の場合のみ `report.md` に理由を残し、commit を省略できる。
+
+## 実装ステップ
+
+### S01 — malformed metadata skip is fixed as a red test
+- target:
+  - relevant tests for `load_node_records()`
+- design refs:
+  - `design.md`
+- step boundary:
+  - missing `type` / `id` currently being skipped is demonstrated before implementation starts
+
+#### update_plan（着手時に登録）
+- [ ] `update_plan` に step の作業単位を登録した
+- [ ] `./spec-dock/active/issue/report.md` の追記位置を決めた
+
+#### B1 — fail-fast red coverage
+- purpose:
+  - silent skip を bug として固定する
+- files:
+  - relevant tests
+
+##### I1 — missing required metadata fields
+- slice goal:
+  - malformed `type` / `id` が fail すべきことを表現する
+
+###### Red
+- failing test:
+  - malformed `type`
+  - malformed `id`
+- expected failure:
+  - current implementation は `continue` してしまう
+
+###### Green
+- minimum implementation:
+  - なし
+- pass condition:
+  - failing baseline と failure message expectation が `report.md` に記録される
+
+###### Refactor
+- 目的:
+  - test naming と fixture を fail-fast intent に揃える
+- guardrail:
+  - production code はまだ変えない
+
+### S02 — provider-side fail-fast contract
+- target:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - relevant tests
+- design refs:
+  - `design.md`
+- step boundary:
+  - provider-side source of truth で malformed `type` / `id` が RuntimeError になる
+
+#### B1 — minimal contract change
+- purpose:
+  - silent skip を RuntimeError に置き換える
+- files:
+  - provider-side fs repo
+  - tests
+
+##### I1 — malformed type
+- slice goal:
+  - malformed `type` は fail-fast
+
+###### Red
+- failing test:
+  - malformed `type` regression
+- expected failure:
+  - current code skips
+
+###### Green
+- minimum implementation:
+  - raise RuntimeError with `meta_path`
+- pass condition:
+  - test passes
+
+###### Refactor
+- 目的:
+  - share error wording helper only if it reduces duplication
+- guardrail:
+  - valid-node path は変えない
+
+##### I2 — malformed id
+- slice goal:
+  - malformed `id` は fail-fast
+
+###### Red
+- failing test:
+  - malformed `id` regression
+- expected failure:
+  - current code skips
+
+###### Green
+- minimum implementation:
+  - raise RuntimeError with `meta_path`
+- pass condition:
+  - test passes
+
+###### Refactor
+- 目的:
+  - error wording consistency
+- guardrail:
+  - invalid-object / duplicate-id contract を壊さない
+
+### S03 — mirror parity and issue evidence
+- target:
+  - `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - issue docs / report
+- design refs:
+  - `design.md`
+- step boundary:
+  - mirror parity と non-goal boundary を issue docs / report に反映する
+
+#### B1 — parity and evidence
+- purpose:
+  - provider-side and mirror drift を残さない
+- files:
+  - dogfooding mirror
+  - issue docs / report
+
+##### I1 — parity sync
+- slice goal:
+  - mirror follows provider-side fail-fast contract
+
+###### Red
+- failing test:
+  - changed-files parity review
+- expected failure:
+  - provider and mirror diverge
+
+###### Green
+- minimum implementation:
+  - update mirror
+- pass condition:
+  - parity confirmed
+
+###### Refactor
+- 目的:
+  - docs wording cleanup if needed
+- guardrail:
+  - do not widen scope beyond malformed metadata fail-fast
+
+### S90 — docs impact resolution / docs refresh
+- target:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md`
+- design refs:
+  - `design.md`
+- step boundary:
+  - reviewer 指摘、verification scope、optional operational evidence の扱いが issue docs に整合して反映される
+
+#### step gate
+- review:
+  - SG1 spec review pass
+- expected checks:
+  - malformed 判定が `missing / blank / whitespace-only / non-string` に閉じている
+  - `sync --github` が required completion gate から切り離されている
+- report update:
+  - review fail -> fix -> re-review -> pass の履歴を `report.md` に残す
+
+### S99 — final validation and review closure
+- target:
+  - final diff
+  - `report.md`
+- design refs:
+  - `design.md`
+- step boundary:
+  - required validation と final review evidence が complete で、optional operational evidence は分離して記録される
+
+#### step gate
+- review:
+  - SG1 final spec review pass
+- expected tests:
+  - `./spec-dock/scripts/spec-dock validate`
+  - targeted unit / runtime tests
+- optional operational evidence:
+  - `./spec-dock/scripts/spec-dock sync --github`
+- report update:
+  - final evidence、scope spill の有無、optional `sync --github` を実行しない場合の理由を残す
+- commit expectation:
+  - `report.md` 更新後に差分確認し、この issue scope の最終コミットまたは no-op を判断する
+
+## 未確定事項
+- なし:
+  - malformed 判定、pre-implementation SG1、optional operational evidence の boundary はこの plan で固定する
+
+## final exit contract
+- AC/EC 達成:
+  - malformed `type` / `id` が fail-fast し、valid metadata path と invalid-object contract は維持されている
+  - provider-side source of truth と dogfooding mirror が同じ fail-fast contract を持つ
+- readiness / docs impact resolved:
+  - implementation 開始前に SG1 spec review が `pass` である
+  - `report.md` に spec review fail -> fix -> re-review -> pass の履歴と最終 verdict が残る
+- final diff approved:
+  - diff は malformed metadata fail-fast issue の範囲に閉じており、external staging failure remediation を含まない

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
@@ -1,0 +1,207 @@
+---
+種別: 実装報告書（Issue）
+ID: "iss-00082"
+タイトル: "Fail fast on malformed node metadata"
+関連GitHub: ["#82"]
+状態: "draft"
+作成者: "iwasawayuuta"
+最終更新: "2026-04-20"
+依存: ["requirement.md", "design.md", "plan.md"]
+親: ["epic-00080", "init-00079"]
+---
+
+# iss-00082 Fail fast on malformed node metadata — 実装報告（LOG）
+
+## 実装サマリー (任意)
+- 本セッションでは `epic-00080` 配下に `iss-00082` を作成し、minor bug bucket と issue spec を具体化した。
+- 実装修正そのものは未着手で、scope は malformed metadata fail-fast に固定した。
+
+## 実装記録（セッションログ） (必須)
+
+### 2026-04-17 11:37 - 11:45
+
+#### 対象
+- Step: issue bootstrap, spec authoring
+- AC/EC: AC-004, EC-002, EC-003
+
+#### 実施内容
+- `epic-00080` 配下に GitHub-backed issue `iss-00082` / `#82` を作成した。
+- active issue を `iss-00082` へ切り替え、research / requirement / design / plan を malformed metadata fail-fast に閉じて作成した。
+- `active set --checkout` は untracked diff があるため safety guard で停止したので、active set は no-checkout で確定した。
+
+#### 実行コマンド / 結果
+```bash
+./spec-dock/scripts/spec-dock new issue --epic epic-00080 --title "Fail fast on malformed node metadata" --slug fail-fast-on-malformed-node-metadata
+spec-dock: ok (new issue) id=iss-00082 epic=epic-00080 initiative=init-00079 ... github=#82
+
+./spec-dock/scripts/spec-dock deps check iss-00082 --github
+spec-dock: ok (deps check) target=iss-00082 ... ready=true blockers=0
+
+./spec-dock/scripts/spec-dock sync --github
+spec-dock: ok (sync) wrote=spec-dock/.agent/index-all.json,...
+
+./spec-dock/scripts/spec-dock active set iss-00082 --checkout
+error: Working tree is not clean; aborting checkout for safety.
+
+./spec-dock/scripts/spec-dock active set iss-00082
+spec-dock: ok (active set) target=iss-00082 initiative=init-00079 epic=epic-00080 issue=iss-00082
+
+./spec-dock/scripts/spec-dock new doc research --issue iss-00082 --title "pr review and staging failure analysis"
+spec-dock: ok (new doc) type=research id=20260417t023838z-research ...
+```
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/requirement.md` - initiative bucket boundary を具体化
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/design.md` - initiative guardrail を具体化
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/plan.md` - first issue creation までの roadmap を固定
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/{requirement,design,plan}.md` - epic boundary と first issue tranche を具体化
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/{requirement,design,plan,report}.md` - issue spec を作成
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/discussions/20260417t023838z-research-pr-review-and-staging-failure-analysis.md` - evidence note を作成
+
+#### コミット
+- なし
+
+#### メモ
+- issue readiness は `deps check` 上 ready=true を確認済み
+- checkout blocker は environment / safety guard であり、issue spec completeness そのものの blocker ではない
+
+### 2026-04-17 11:45 - 11:49
+
+#### 対象
+- Step: spec closure, state validation
+- AC/EC: AC-004
+
+#### 実施内容
+- issue docs の placeholder 取り残しを確認した。
+- `validate` と `sync --github` を実行し、state projection を更新した。
+- `sync --github` が current branch 由来で active を `iss-00078` 側へ戻したため、最後に `iss-00082` を no-checkout で再設定し、active show で確認した。
+
+#### 実行コマンド / 結果
+```bash
+./spec-dock/scripts/spec-dock validate
+spec-dock: ok (validate) nodes=36
+
+./spec-dock/scripts/spec-dock sync --github
+spec-dock: sync: active updated (matched id in branch: iss-00078)
+spec-dock: ok (sync) wrote=spec-dock/.agent/index-all.json,...
+
+./spec-dock/scripts/spec-dock active set iss-00082
+spec-dock: ok (active set) target=iss-00082 initiative=init-00079 epic=epic-00080 issue=iss-00082
+
+./spec-dock/scripts/spec-dock active show
+initiative: init-00079 (...)
+epic: epic-00080 (...)
+issue: iss-00082 (...)
+```
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md` - validate / sync / active state の最終証跡を追記
+
+#### コミット
+- なし
+
+#### メモ
+- branch 名が `iss-00078` のままなので、`sync --github` は branch-to-active reconciliation により active を戻しうる
+- issue active state の最終値は `iss-00082` に再設定済み
+
+## 遭遇した問題と解決 (任意)
+- 問題: `active set --checkout` が dirty worktree safety guard で失敗
+  - 解決: `active set` を no-checkout で実行し、issue active state を確定した
+
+## 学んだこと (任意)
+- issue creation 直後の untracked diff がある状態では `--checkout` は安全装置に止められる
+- reusable bucket を運用するには、親 initiative / epic docs の最小 guardrail を先に具体化しておくと routing が安定する
+- branch-driven active reconciliation があるため、no-checkout 運用では `sync --github` 後に active を再確認した方が安全
+
+## 今後の推奨事項 (任意)
+- 実装着手時は S01 red test から始め、provider-side source of truth を先に修正する
+- commit 後に branch 移動が必要なら `active set iss-00082 --checkout` を再実行する
+
+## 省略/例外メモ (必須)
+- `--checkout` は working tree safety guard により未完了。active issue 自体は no-checkout で設定済み。
+
+### 2026-04-20 15:20 - 15:45
+
+#### 対象
+- Step: SG1 spec review fix / re-review
+- AC/EC: AC-001, AC-002, AC-004, EC-002, EC-003
+
+#### 実施内容
+- spec reviewer から 2 件の P1 と 1 件の P2 を受領した。
+- P1-1 に対応して、`malformed` の定義を欠落だけでなく `missing / blank / whitespace-only / non-string` まで明文化し、requirement / design / plan の AC と test strategy を揃えた。
+- P1-2 に対応して、pre-implementation readiness gate を `S00` として分離し、red test を含む実装 step は SG1 pass 後に進む構成へ計画を組み替えた。
+- P2 に対応して、`sync --github` を optional operational evidence へ格下げし、この issue の required completion gate から切り離した。
+- requirement / design / plan の frontmatter `状態` を `approved` に更新し、issue docs を implementation-ready として固定した。
+
+#### 実行コマンド / 結果
+```text
+spec review (SG1)
+
+review_status=fail
+findings:
+- malformed 判定が欠落だけに閉じており、blank / whitespace-only / non-string が漏れている
+- pre-implementation readiness gate が red test 作成後にしか判定できない
+- sync --github を required gate から外すべき
+
+spec review (SG1 re-review)
+
+review_status=pass
+findings=[]
+focus:
+- malformed metadata boundary
+- pre-implementation SG1 gate
+- optional sync evidence boundary
+```
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/requirement.md` - malformed 定義と AC を閉じた
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/design.md` - interface / test strategy / verification mapping を更新した
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/plan.md` - `S00` / `S90` / `final exit contract` を追加し、required gate を整理した
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md` - SG1 fail / fix / re-review / pass の証跡を追記した
+
+#### コミット
+- なし
+
+#### メモ
+- report 自体は実装未着手のため `draft` のままとし、spec readiness の証跡のみを追加した
+
+### 2026-04-20 15:45 - 15:55
+
+#### 対象
+- Step: SG1 spec re-review after plan gate clarification
+- AC/EC: AC-001, AC-002, AC-004
+
+#### 実施内容
+- spec reviewer から、`S01` が red baseline step なのに `QG1 targeted tests pass` を要求している矛盾が P1 として指摘された。
+- `S01` を「failing baseline を固定して `report.md` に残す step」と明示し、QG1 は `S02` 以降の green 状態 test / final validation に限定した。
+- あわせて `S99` の step boundary から `sync --github` 必須含みを除去し、required evidence と optional operational evidence を文言上も分離した。
+- 修正後に SG1 を再レビューし、implementation-ready の最終 `pass` を確認した。
+
+#### 実行コマンド / 結果
+```text
+spec review (SG1 re-review 2)
+
+review_status=fail
+findings:
+- S01 が red baseline なのか QG1 pass gate なのか矛盾している
+- S99 の step boundary が sync required に読める
+
+spec review (SG1 final re-review)
+
+review_status=pass
+findings=[]
+focus:
+- S01 red baseline contract
+- QG1 timing
+- S99 required vs optional evidence wording
+```
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/plan.md` - S01/QG1/S99 の gate 文言を整合させた
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md` - final re-review pass を追記した
+
+#### コミット
+- なし
+
+#### メモ
+- SG1 final re-review の `review_status=pass` をもって、issue docs は実装着手可能な spec と判断する

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/requirement.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/requirement.md
@@ -1,0 +1,170 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00082"
+タイトル: "Fail fast on malformed node metadata"
+関連GitHub: ["#82"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-04-20"
+親: ["epic-00080", "init-00079"]
+---
+
+# iss-00082 Fail fast on malformed node metadata — 要件定義（WHAT / WHY）
+
+## 目的
+- `load_node_records()` が malformed `.meta.json` を silent skip して graph を部分的に読み込む挙動を廃止し、node metadata integrity violation として fail-fast させる。
+- maintainer が壊れた metadata の path を即座に特定できる error contract を導入する。
+
+## 背景・現状
+- 現状の挙動:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py` と dogfooding mirror の `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py` では、`load_node_records()` が `.meta.json` を読み込んだあと、`type` または `id` を `str(...).strip()` で正規化し、結果が空なら `continue` している。
+- 現状の課題:
+  - malformed node が fail せず読み飛ばされるため、maintainer は metadata corruption に気づけないまま partial graph を扱ってしまう。
+  - PR review では、この silent skip が node integrity contract を壊す P1 として指摘されている。
+- 再現手順:
+  1. node directory の `.meta.json` の `type` または `id` を欠落、空文字、空白のみ、または非文字列値にする。
+  2. graph load / repo read path から `load_node_records()` を通す。
+  3. 現状は RuntimeError にならず、その node だけ読み飛ばされる。
+- 観測点:
+  - Code:
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+    - `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+  - Review:
+    - Codex review on PR `#1821`
+  - Runtime behavior:
+    - graph load / repo read path
+- 情報源:
+  - 2026-04-17 `pr review and staging failure analysis`
+  - `load_node_records()` 実装
+  - `deps check` / `sync --github` による repo state 確認
+
+## 対象ユーザー / 利用シナリオ（必要時）
+- 主な利用者:
+  - corrupted metadata を修復したい maintainer
+  - runtime contract を保守する implementer / reviewer
+- 代表シナリオ:
+  - node metadata を誤編集した直後に graph load が fail-fast し、どの path が壊れているか即時に把握したい
+
+## スコープ
+- MUST:
+  - `.meta.json` の `type` が正規化後に非空文字列でない場合を integrity violation として fail-fast する
+  - `.meta.json` の `id` が正規化後に非空文字列でない場合を integrity violation として fail-fast する
+  - error message に壊れた `meta_path` を含める
+  - provider-side source of truth と dogfooding mirror の挙動を揃える
+- MUST NOT:
+  - malformed node を silent skip しない
+  - valid metadata の node 読み込み挙動を壊さない
+  - external staging failure をこの issue の修正対象に含めない
+- OUT OF SCOPE:
+  - external consumer repo の test / workflow 修正
+  - metadata schema の大規模再設計
+  - `type` / `id` 以外の validation 範囲拡張
+
+## 境界
+- Always:
+  - failure surface は graph load / repo read path に統一する
+  - malformed metadata は fail-closed で扱う
+- Ask:
+  - 追加 validation を広げる必要が本当にあるか
+- Never:
+  - node metadata corruption を warning や ignore で済ませない
+  - background evidence の staging flaky failure をこの issue の acceptance に入れない
+
+## 非交渉制約
+- provider-side source of truth は `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py`
+- dogfooding mirror `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py` も parity を保つ
+- spec は malformed metadata fail-fast に閉じる
+
+## 前提
+- `type` と `id` は node identity の最小必須フィールドであり、`.strip()` 後に非空文字列である必要がある
+- 現状の skip は intentional contract ではなく bug とみなす
+
+## 受け入れ条件
+- AC-001:
+  - Actor:
+    - maintainer
+  - Given:
+    - node directory の `.meta.json` の `type` が欠落している、空文字である、空白のみである、または非文字列値である
+  - When:
+    - `load_node_records()` を通る path を実行する
+  - Then:
+    - RuntimeError で fail し、error message に `meta_path` が含まれる
+  - 観測点:
+    - targeted unit / runtime tests
+- AC-002:
+  - Actor:
+    - maintainer
+  - Given:
+    - node directory の `.meta.json` の `id` が欠落している、空文字である、空白のみである、または非文字列値である
+  - When:
+    - `load_node_records()` を通る path を実行する
+  - Then:
+    - RuntimeError で fail し、error message に `meta_path` が含まれる
+  - 観測点:
+    - targeted unit / runtime tests
+- AC-003:
+  - Actor:
+    - maintainer
+  - Given:
+    - valid `.meta.json` を持つ node 群
+  - When:
+    - graph load / repo read path を実行する
+  - Then:
+    - 既存どおり node records が読み込まれる
+  - 観測点:
+    - regression tests
+- AC-004:
+  - Actor:
+    - reviewer
+  - Given:
+    - issue spec と research を確認する
+  - When:
+    - fix scope を判断する
+  - Then:
+    - external staging failure は background evidence としてのみ残り、この issue の修正対象に含まれていない
+  - 観測点:
+    - requirement / design / research
+
+## 例外・エッジケース
+- EC-001:
+  - 条件:
+    - `.meta.json` 自体が object ではない
+  - 期待:
+    - 既存の `Invalid .meta.json (expected object)` error contract を維持する
+  - 観測点:
+    - regression tests
+- EC-002:
+  - 条件:
+    - provider-side source を修正したが dogfooding mirror が古い
+  - 期待:
+    - parity 差分として扱い、mirror も揃える
+  - 観測点:
+    - changed files review
+- EC-003:
+  - 条件:
+    - staging failure analysis を issue に添付する
+  - 期待:
+    - research / non-goal としてのみ記録し、acceptance criteria へ混ぜない
+  - 観測点:
+    - requirement / research
+
+## 入力→出力例（必要時）
+- EX-001:
+  - Input:
+    - `.meta.json` with missing / blank / non-string `type`
+  - Output:
+    - `RuntimeError: Invalid .meta.json ... missing type ... <meta_path>`
+- EX-002:
+  - Input:
+    - `.meta.json` with missing / blank / non-string `id`
+  - Output:
+    - `RuntimeError: Invalid .meta.json ... missing id ... <meta_path>`
+
+## 用語（ドメイン語彙）
+- TERM-001:
+  - malformed node metadata:
+    - `type` / `id` など node identity に必要な必須項目が欠落、非文字列、または `.strip()` 後に空になる `.meta.json`
+
+## 未確定事項
+- なし:
+  - current scope is fixed to malformed metadata fail-fast

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/requirement.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/requirement.md
@@ -22,7 +22,7 @@ ID: "iss-00082"
   - malformed node が fail せず読み飛ばされるため、maintainer は metadata corruption に気づけないまま partial graph を扱ってしまう。
   - PR review では、この silent skip が node integrity contract を壊す P1 として指摘されている。
 - 再現手順:
-  1. node directory の `.meta.json` の `type` または `id` を欠落、空文字、空白のみ、または非文字列値にする。
+  1. node directory の `.meta.json` の `type` または `id` を欠落、空文字、または空白のみの文字列にする。
   2. graph load / repo read path から `load_node_records()` を通す。
   3. 現状は RuntimeError にならず、その node だけ読み飛ばされる。
 - 観測点:

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/plan.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/plan.md
@@ -5,7 +5,7 @@ ID: "epic-00080"
 関連GitHub: ["#80"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 依存: ["requirement.md", "design.md"]
 親: ["init-00079"]
 ---
@@ -14,78 +14,83 @@ ID: "epic-00080"
 
 ## この計画で閉じる E-RQ / E-AC
 - E-RQ:
-  - ...
+  - E-RQ-001
+  - E-RQ-002
+  - E-RQ-003
+  - E-RQ-004
 - E-AC:
-  - ...
+  - E-AC-001
+  - E-AC-002
 
 ## Issue 分割方針
 - slicing principle:
-  - ...
+  - 1 issue = 1 actionable bug または tightly coupled contract bug
+  - bug routing 用の parent docs と、実装-ready な issue docs を分離する
 - exceptions:
-  - ...
+  - 同一 root cause を共有する場合のみ 1 issue に束ねる
 
 ## Issue 一覧（順序 / tranche 付き）
-- iss-xxxx-...:
+- iss-00082-fail-fast-on-malformed-node-metadata:
   - 目的:
-    - ...
+    - malformed `.meta.json` の `type` / `id` 欠落を silent skip せず fail-fast にする
   - deliverable:
-    - ...
+    - issue spec
+    - research note
   - tranche:
-    - ...
+    - tranche-1
   - closes:
-    - ...
+    - E-RQ-001
+    - E-RQ-002
+    - E-RQ-003
+    - E-RQ-004
+    - E-AC-001
+    - E-AC-002
   - depends on:
-    - ...
-- iss-xxxx-...:
-  - ...
+    - なし
 
 ## 統合チェックポイント
 - G1 decomposition review:
-  - ...
+  - issue scope が single actionable bug に閉じているか
 - G2 integration readiness:
-  - ...
+  - issue docs が implementation-ready か
 - G3 rollout/docs impact:
-  - ...
+  - background evidence と fix scope が混線していないか
 - G9 final epic spec review:
-  - ...
+  - reusable bucket と first issue が整合しているか
 
 ## 品質ゲート
 - test / observability / migration / docs:
-  - ...
+  - issue 作成後に active set / validate / sync が成功する
+  - issue report に evidence を残す
 
 ## ロールアウト / docs impact
 - rollout order:
-  - ...
+  - parent bucket docs
+  - first issue creation
+  - issue spec / research authoring
 - contract / docs refresh:
-  - ...
+  - 新しい minor bug はこの epic 配下へ順次追加する
 
 ## Issue readiness contract
 - Issue に要求する最低条件:
-  - ...
+  - repo-local actionable bug に閉じている
+  - requirement / design / plan / report が具体化されている
+  - external staging failure などは non-goal として整理されている
 
 ## final exit contract
 - E-AC closure:
-  - ...
+  - first issue `iss-00082` が spec-authored 済み
 - integration / rollout complete:
-  - ...
+  - yes
 - docs impact resolved:
-  - ...
+  - yes
 
 ## 依存 / ブロッカー
 - D-001:
-  - ...
+  - GitHub-backed issue creation
 - D-002:
-  - ...
+  - issue docs を埋めるための evidence availability
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - future issues are appended when new repo-local bugs are confirmed

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/requirement.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/requirement.md
@@ -5,7 +5,7 @@ ID: "epic-00080"
 関連GitHub: ["#80"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 親: ["init-00079"]
 ---
 
@@ -13,74 +13,92 @@ ID: "epic-00080"
 
 ## 目的（Initiative との紐づき）
 - initiative goal / metric:
-  - ...
+  - `init-00079` の reusable bucket として、repo-local actionable bug を issue 単位で受け入れ、minor fix を継続運用できるようにする。
 - この epic が提供する能力:
-  - ...
+  - minor runtime / installer / docs contract bug を、single actionable issue に分割して追跡できる。
 
 ## ユースケース
 - happy path:
-  - ...
+  - maintainer が dogfooding 中に runtime bug を見つけ、`epic-00080` 配下へ新規 issue を作成する。
+  - issue は repo 内で修正可能な範囲に閉じ、必要なら research と issue spec を付けて実装準備する。
 - exception / operation scenario:
-  - ...
+  - 外部 consumer app の staging failure など、背景 evidence はあるが本 repo の直接修正対象ではない報告を受ける。
+  - その場合は background evidence として issue/research へ添付するだけに留め、修正対象には含めない。
 
 ## Epic requirements
 - E-RQ-001:
-  - ...
+  - repo 内で修正可能な minor runtime / installer / shipped docs / dogfooding mirror bug のみを受け入れること。
 - E-RQ-002:
-  - ...
+  - issue は single actionable bug または tightly coupled contract bug に閉じること。
+- E-RQ-003:
+  - 外部 consumer app 側の flaky CI / staging failureは、そのまま本 epic の fix scope に含めないこと。
+- E-RQ-004:
+  - 各 issue は requirement / design / plan を持ち、必要に応じて research で evidence を残すこと。
 
 ## Epic acceptance criteria
 - E-AC-001:
   - Given:
+    - dogfooding から repo-local actionable bug report が 1 件ある
   - When:
+    - `epic-00080` 配下に issue を作成する
   - Then:
+    - issue が GitHub-linked node として生成され、issue docs が bug 固有内容で埋められる
   - 観測点:
+    - `spec-dock/.agent/index.json`
+    - issue requirement / design / plan / report
 - E-AC-002:
-  - ...
+  - Given:
+    - bug report に external consumer app 側の staging failure evidence が含まれる
+  - When:
+    - issue scope を定義する
+  - Then:
+    - issue は repo-local fix scope に閉じ、staging failure は background evidence / non-goal として扱われる
+  - 観測点:
+    - epic requirement / design / plan
+    - issue requirement / design / research
 
 ## スコープ
 - MUST:
-  - ...
+  - minor bug issue の受け皿として機能する
+  - repo-local actionable bug の境界を明文化する
 - MUST NOT:
-  - ...
+  - architecture initiative の大規模構造変更を取り込まない
+  - external consumer app の症状をそのまま fix target にしない
 - OUT OF SCOPE:
-  - ...
+  - feature expansion
+  - large migration
+  - external consumer repo の pipeline 修正
 
 ## 境界
 - Always:
-  - ...
+  - issue ごとに修正対象を 1 つに閉じる
+  - background evidence と fix scope を分ける
 - Ask:
-  - ...
+  - その bug は repo 内で再現・検証できるか
 - Never:
-  - ...
+  - unrelated bug を 1 issue に束ねる
+  - background evidence だけで本 epic の bug と断定する
 
 ## 非機能要件
 - performance:
-  - ...
+  - bucket 自体に特別な性能要件はない
 - reliability / consistency:
-  - ...
+  - issue docs と GitHub issue の対応が一貫していること
 - security:
-  - ...
+  - evidence に秘匿情報を含めないこと
 - operations:
-  - ...
+  - issue 作成後に active set / validate / sync が可能であること
 
 ## 依存 / 影響範囲
 - impacted components:
-  - ...
+  - `src/spec_dock/`
+  - `spec-dock/`
+  - `tests/`
 - external dependency:
-  - ...
+  - GitHub issue creation / sync
 - compatibility:
-  - ...
+  - provider-side source of truth と dogfooding mirror parity を維持する
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - 最初の concrete issue は `iss-00082` とする

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/plan.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/plan.md
@@ -5,7 +5,7 @@ ID: "init-00079"
 関連GitHub: ["#79"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 依存: ["requirement.md", "design.md"]
 ---
 
@@ -13,85 +13,86 @@ ID: "init-00079"
 
 ## この計画が達成する Goal / Metric
 - Goal:
-  - ...
+  - dogfooding で見つかった minor bug を、既存 reusable bucket の中で継続的に issue 化できるようにする。
 - 対象 metric:
-  - ...
+  - Metric-001
+  - Metric-002
 
 ## マイルストーン
 - M1:
   - deliverable:
+    - `init-00079 / epic-00080` の boundary と out-of-scope が docs に固定されている
   - exit:
+    - initiative / epic requirement / design / plan がテンプレート状態を脱している
 - M2:
-  - ...
+  - deliverable:
+    - first minor bug issue が `epic-00080` 配下へ作成されている
+  - exit:
+    - `iss-00082` が active issue として spec 化され、research を伴って追跡可能になっている
 
 ## Epic ポートフォリオ
-- epic-xxxx-...:
+- epic-00080-minor-bug-fixes:
   - 目的:
-    - ...
+    - repo-local actionable bug を single-issue 単位で受け入れる。
   - deliverable:
-    - ...
+    - issue spec と evidence を伴う minor bug 対応トラック
   - metric link:
-    - ...
+    - Metric-001
+    - Metric-002
   - depends on:
-    - ...
-- epic-xxxx-...:
-  - ...
+    - なし
 
 ## 順序と理由
 - sequencing rationale:
-  - ...
+  - まず reusable bucket の guardrail を固定し、その後 concrete issue を追加する。
+  - 各 issue は互いに独立な minor bug として扱い、必要なものだけ active にする。
 - parallelizable:
-  - ...
+  - issue spec 作成は並行可能だが、active issue は 1 つずつ切り替えて運用する。
 
 ## 意思決定ゲート
 - G1 strategy review:
-  - ...
+  - その bug report は repo-local actionable bug か
 - G2 milestone readiness:
-  - ...
+  - 親 bucket docs が issue 作成の guardrail として十分か
 - G3 governance/docs impact:
-  - ...
+  - issue scope に external consumer concern を混ぜていないか
 - G9 final initiative plan review:
-  - ...
+  - 追加された issue が reusable bucket の趣旨に沿っているか
 
 ## 指標レビュー計画
 - review timing:
-  - ...
+  - issue 作成ごと
 - dashboard / source:
-  - ...
+  - `spec-dock/.agent/index.json`
+  - issue requirement / design / plan / report
 
 ## ロールアウト計画
 - rollout window:
-  - ...
+  - dogfooding 中に bug report が actionable と判定された時点
 - release / communication:
-  - ...
+  - issue docs と GitHub issue を正本とする
 
 ## Epic readiness contract
 - Epic に要求する最低条件:
-  - ...
+  - repo-local bug と external issue の境界が明確
+  - single actionable issue へ分割できる
+  - evidence を issue research / report に残せる
 
 ## final exit contract
 - milestone exit:
-  - ...
+  - M1: parent bucket docs fixed
+  - M2: first issue created and spec-authored
 - success metrics reviewed:
-  - ...
+  - yes
 - remaining follow-up ownership:
-  - ...
+  - future minor bug triage owner
 
 ## 依存 / ブロッカー
 - D-001:
-  - ...
+  - GitHub issue creation が利用可能であること
 - D-002:
-  - ...
+  - dogfooding report から repo-local actionable bug を抽出できること
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - 初回 issue は `iss-00082` として作成済み

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/requirement.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/requirement.md
@@ -5,87 +5,103 @@ ID: "init-00079"
 関連GitHub: ["#79"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-04-16"
+最終更新: "2026-04-17"
 ---
 
 # init-00079 minor bugfix maintenance — 要件定義（WHAT / WHY）
 
 ## 目的（Outcome）
 - Primary:
-  - ...
+  - dogfooding 中に見つかった minor bug を、既存の architecture / feature initiative を汚さずに継続投入できる受け皿を提供する。
 - Secondary:
-  - ...
+  - repo 内で修正可能な runtime / installer / docs contract bug と、外部 consumer app 側の問題を切り分けて管理できるようにする。
 
 ## 背景と Why now
 - 現状の課題:
-  - ...
+  - `spec-dock` をこの repo 自身で dogfooding しているため、小粒だが放置しづらい bug report が継続的に発生する。
+  - そのたびに新しい initiative / epic を起こすと、architecture 投資や feature work の正本が分散しやすい。
 - 影響:
-  - ...
+  - bug の受け皿が曖昧なままだと、local actionable bug と外部 repo 固有の不安定要因が同じトラックに混ざり、修正責務がぼやける。
 - なぜ今やるか:
-  - ...
+  - `epic-00080` を初回利用し、minor bug bucket を運用可能な形に固定しておくことで、今後の dogfooding bug を一貫した手順で issue 化できる。
 - 情報源:
-  - ...
+  - dogfooding 中の issue / PR / review feedback
+  - `spec-dock/initiatives/init-local-00003-*` 配下の既存 spec 運用
+  - 2026-04-17 の `pr review and staging failure analysis`
 
 ## 成功指標
 - Metric-001:
   - Baseline:
+    - minor bug 用 initiative / epic は存在するが、内容がテンプレートのままで運用境界が未固定である。
   - Target:
+    - dogfooding で見つかった repo-local minor bug を、`init-00079 / epic-00080` 配下へ issue として起票できる。
   - 計測方法:
+    - `epic-00080` 配下に concrete issue が作成され、requirement / design / plan が issue 固有内容で埋まっていること。
   - 判定時期:
+    - 各 minor bug issue 作成時
 - Metric-002:
-  - ...
+  - Baseline:
+    - 外部 consumer app 側の flaky CI と、`spec-dock` 本体で修正すべき bug の責務境界が曖昧である。
+  - Target:
+    - bucket docs に、repo 内で修正可能な bug と背景 evidence の線引きが明記されている。
+  - 計測方法:
+    - initiative / epic / issue の scope / out-of-scope に責務境界が記載されていること。
+  - 判定時期:
+    - 各 issue spec review 時
 
 ## スコープ
 - MUST:
-  - ...
+  - dogfooding で見つかった repo-local minor bug を issue 単位で受け入れる。
+  - runtime / installer / shipped docs / dogfooding mirror の contract bug を扱う。
+  - issue ごとに修正対象と背景 evidence を切り分ける。
 - MUST NOT:
-  - ...
+  - architecture initiative が扱う大規模構造変更を取り込まない。
+  - feature expansion backlog の受け皿にしない。
+  - 外部 consumer app 固有の flaky test を、そのまま本 repo の修正対象へ昇格しない。
 - OUT OF SCOPE:
-  - ...
+  - 新機能追加
+  - 大規模 migration / architecture realignment
+  - external consumer repo の staging / deploy pipeline 修正
 
 ## 境界
 - Always:
-  - ...
+  - 1 issue = 1 actionable bug または tightly coupled contract bug とする。
+  - 実装修正は repo 内で再現・検証できる範囲に閉じる。
 - Ask:
-  - ...
+  - その報告は `spec-dock` 本体の bug か、外部利用側の症状か。
+  - 既存 epic へ収まるか、それとも architecture / feature 側へ送るべきか。
 - Never:
-  - ...
+  - 背景 evidence だけの外部障害を、本 repo の修正 obligation として記録しない。
+  - minor bug bucket を generic todo リスト化しない。
 
 ## ステークホルダー / 影響範囲
 - 利用者:
-  - ...
+  - `spec-dock` を dogfooding して bug を報告・修正する maintainer
 - 運用者:
-  - ...
+  - initiative / epic / issue の routing を管理する maintainer
 - 開発者:
-  - ...
+  - `src/spec_dock/` と `spec-dock/` の contract parity を保守する implementer / reviewer
 - 影響システム / 領域:
-  - ...
+  - `src/spec_dock/`
+  - `spec-dock/`
+  - `tests/`
 
 ## 非交渉制約
 - 互換性:
-  - ...
+  - minor bug issue でも provider-side source of truth と dogfooding mirror の関係を崩さない。
 - セキュリティ / 監査:
-  - ...
+  - GitHub-backed issue linkage を維持し、report / research に evidence を残す。
 - 性能 / 可用性:
-  - ...
+  - bugfix bucket 自体は大規模 rollout を前提にしない。
 - 運用:
-  - ...
+  - 既存 initiative / epic を再利用し、新たな bug ごとに initiative / epic を増やさない。
 
 ## リスク / 依存
 - R-001:
-  - ...
+  - bucket が広すぎると、architecture concern や external issue を誤って吸い込む。
 - R-002:
-  - ...
+  - issue の境界が曖昧だと、1 issue に複数の無関係な bug を束ねてしまう。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - minor bug bucket は existing reusable bucket として継続運用する。

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -600,6 +600,7 @@ class TestInitUpdate(CliRuntimeHarness):
     _CHECKED_IN_DOGFOODING_META_JSON_PATHS = (
         "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/.meta.json",
         "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/.meta.json",
+        "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00048-agent-facing-interface-hardening-and-host-adapter-scaffolding/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00048-agent-facing-interface-hardening-and-host-adapter-scaffolding/issues/iss-00049-protocol-contract-and-runtime-alignment/.meta.json",
@@ -637,6 +638,7 @@ class TestInitUpdate(CliRuntimeHarness):
     _CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH = {
         "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/.meta.json": [],
         "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/.meta.json": [],
+        "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00048-agent-facing-interface-hardening-and-host-adapter-scaffolding/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00048-agent-facing-interface-hardening-and-host-adapter-scaffolding/issues/iss-00049-protocol-contract-and-runtime-alignment/.meta.json": [],


### PR DESCRIPTION
## 概要
- `iss-00082` の issue spec を実装着手可能な状態まで具体化
- malformed node metadata の判定境界を `missing / blank / whitespace-only / non-string` まで明文化
- spec reviewer の指摘を反映し、SG1・S01・QG1・S99 の gate 契約を整理

## 変更点
- `init-00079` / `epic-00080` 配下で minor bugfix bucket の requirement / design / plan を更新
- `iss-00082-fail-fast-on-malformed-node-metadata` の requirement / design / plan / report を整備
- pre-implementation SG1 を `S00` として分離し、`S01` を red baseline 記録 step として明確化
- `S99` では required validation と optional な `sync --github` 証跡を分離

## 検証
- spec reviewer: fail -> fix -> re-review -> pass
- `./spec-dock/scripts/spec-dock validate`

Refs #82
