### PR TITLE
fix: malformed node metadata を fail-fast 化

### DIFF
--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
@@ -242,3 +242,63 @@ ok
 #### メモ
 - error wording は `Invalid .meta.json` を維持しつつ `field=<name>` と `meta_path` を含める形にした
 - doctor 側は `.meta.json` を含む RuntimeError を `broken_meta` として既存どおり分類できている
+
+### 2026-04-20 16:20 - 16:55
+
+#### 対象
+- Step: S99 final validation and review closure
+- AC/EC: AC-001, AC-002, AC-003, AC-004, EC-002, EC-003
+
+#### 実施内容
+- `python -m unittest discover -v` をフルで実行し、suite 全体が `exit code 0` で完走することを確認した。
+- code reviewer と QA reviewer を実行し、どちらも `pass` を確認した。
+- QA reviewer からは、`infra/fs_repo.py` mirror parity を将来的に自動ガードするとより安全、という P2 提案が 1 件あったが、blocking finding はなかった。
+- `manual-tests/workspaces/2026-04-20-iss-00082-fail-fast-manual/trial-local/repo` に real manual workspace を作成し、baseline `validate` / `doctor` pass、`type` 欠落時の fail-fast、修復後の green 復帰まで手動で確認した。
+- manual workspace が親 Git repo の scope を拾って temporary GitHub issue `#84` を作成したため、manual validation 後に close して後始末した。
+- closure evidence を揃えた上で commit `91d5d36b26a70a3c5e49cd1217c9cee01bc83e3b` を作成した。
+
+#### 実行コマンド / 結果
+```bash
+python -m unittest discover -v
+exit code 0
+
+code-reviewer
+review_status=pass
+findings=[]
+
+qa-reviewer
+review_status=pass
+findings=[P2 non-blocking parity guard suggestion]
+
+./spec-dock/scripts/spec-dock validate
+spec-dock: ok (validate) nodes=1
+
+# remove "type" from the manual workspace .meta.json
+./spec-dock/scripts/spec-dock validate
+error: Invalid .meta.json (required non-empty string field=type): .../.meta.json
+
+./spec-dock/scripts/spec-dock doctor
+spec-dock: doctor: findings=1
+- [broken_meta] Invalid .meta.json (required non-empty string field=type): .../.meta.json
+
+# restore the file
+./spec-dock/scripts/spec-dock validate
+spec-dock: ok (validate) nodes=1
+
+./spec-dock/scripts/spec-dock doctor
+spec-dock: ok (doctor) findings=0
+
+gh issue close 84 --comment 'manual test workspace for iss-00082; closing temporary validation issue'
+✓ Closed issue chemitaro/spec-dock#84 (Manual fail fast initiative)
+```
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md` - final validation / review / manual test closure evidence を追記
+
+#### コミット
+- `91d5d36b26a70a3c5e49cd1217c9cee01bc83e3b` - `fix(runtime): malformed node metadata を fail-fast 化`
+
+#### メモ
+- manual test docs は ignore 配下のため repo commit には含めていないが、以下へ保存した
+- `manual-tests/reports/2026-04-20-iss-00082-fail-fast-manual/{plan,checklist,execution-log,summary}.md`
+- `manual-tests/workspaces/2026-04-20-iss-00082-fail-fast-manual/trial-local/repo`

--- a/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
+++ b/spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md
@@ -205,3 +205,40 @@ focus:
 
 #### メモ
 - SG1 final re-review の `review_status=pass` をもって、issue docs は実装着手可能な spec と判断する
+
+### 2026-04-20 16:00 - 16:20
+
+#### 対象
+- Step: S02/S03 implementation and targeted verification
+- AC/EC: AC-001, AC-002, AC-003, EC-001, EC-002
+
+#### 実施内容
+- `load_node_records()` の silent skip を廃止し、`.meta.json` の `type` / `id` が `missing / blank / whitespace-only / non-string` の場合は RuntimeError で fail-fast するよう変更した。
+- provider-side source of truth と checked-in dogfooding mirror の `fs_repo.py` を同一 contract に揃えた。
+- CLI validate の回帰テストを追加し、required identity fields の異常値 8 ケースで `Invalid .meta.json` と `meta_path` が stderr に出ることを固定した。
+- 既存の invalid-object validate ケースと、doctor の `broken_meta` 分類回帰も再実行して壊していないことを確認した。
+
+#### 実行コマンド / 結果
+```bash
+python -m unittest -v tests.cli_runtime.test_validate.TestCliValidate.test_validate_rejects_missing_or_invalid_required_meta_identity_fields
+ok
+
+python -m unittest -v tests.cli_runtime.test_validate.TestCliValidate.test_validate_reports_invalid_meta_json_shape
+ok
+
+python -m unittest -v tests.cli_runtime.test_runtime_doctor_s04.TestRuntimeDoctorS04.test_doctor_detects_broken_meta_when_reader_fails
+ok
+```
+
+#### 変更したファイル
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py` - required `type` / `id` を non-empty string contract として fail-fast 化
+- `spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py` - dogfooding mirror を parity 更新
+- `tests/cli_runtime/test_validate.py` - malformed identity field の targeted CLI regression を追加
+- `spec-dock/initiatives/init-00079-minor-bugfix-maintenance/epics/epic-00080-minor-bug-fixes/issues/iss-00082-fail-fast-on-malformed-node-metadata/report.md` - 実装と verification evidence を追記
+
+#### コミット
+- なし
+
+#### メモ
+- error wording は `Invalid .meta.json` を維持しつつ `field=<name>` と `meta_path` を含める形にした
+- doctor 側は `.meta.json` を含む RuntimeError を `broken_meta` として既存どおり分類できている

--- a/spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py
+++ b/spec-dock/scripts/spec_dock_runtime/infra/fs_repo.py
@@ -338,6 +338,20 @@ def ensure_no_legacy_meta_json(specdock_dir: Path) -> None:
     )
 
 
+def _require_non_empty_meta_string(meta: dict[str, Any], *, field: str, meta_path: Path) -> str:
+    raw_value = meta.get(field)
+    if not isinstance(raw_value, str):
+        raise RuntimeError(
+            f"Invalid .meta.json (required non-empty string field={field}): {meta_path}"
+        )
+    value = raw_value.strip()
+    if not value:
+        raise RuntimeError(
+            f"Invalid .meta.json (required non-empty string field={field}): {meta_path}"
+        )
+    return value
+
+
 def load_node_records(specdock_dir: Path) -> list[StoredMetaRecord]:
     ensure_no_legacy_meta_json(specdock_dir)
     initiatives_root = _initiatives_root(specdock_dir)
@@ -352,12 +366,10 @@ def load_node_records(specdock_dir: Path) -> list[StoredMetaRecord]:
         if not isinstance(meta, dict):
             raise RuntimeError(f"Invalid .meta.json (expected object): {meta_path}")
 
-        node_type = str(meta.get("type", "")).strip()
-        node_id = str(meta.get("id", "")).strip()
+        node_type = _require_non_empty_meta_string(meta, field="type", meta_path=meta_path)
+        node_id = _require_non_empty_meta_string(meta, field="id", meta_path=meta_path)
         title = str(meta.get("title", "")).strip()
         slug = str(meta.get("slug", "")).strip()
-        if not node_type or not node_id:
-            continue
         if node_id in seen_ids:
             raise RuntimeError(f"Duplicate id detected: {node_id} ({meta_path})")
         seen_ids.add(node_id)

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/fs_repo.py
@@ -338,6 +338,20 @@ def ensure_no_legacy_meta_json(specdock_dir: Path) -> None:
     )
 
 
+def _require_non_empty_meta_string(meta: dict[str, Any], *, field: str, meta_path: Path) -> str:
+    raw_value = meta.get(field)
+    if not isinstance(raw_value, str):
+        raise RuntimeError(
+            f"Invalid .meta.json (required non-empty string field={field}): {meta_path}"
+        )
+    value = raw_value.strip()
+    if not value:
+        raise RuntimeError(
+            f"Invalid .meta.json (required non-empty string field={field}): {meta_path}"
+        )
+    return value
+
+
 def load_node_records(specdock_dir: Path) -> list[StoredMetaRecord]:
     ensure_no_legacy_meta_json(specdock_dir)
     initiatives_root = _initiatives_root(specdock_dir)
@@ -352,12 +366,10 @@ def load_node_records(specdock_dir: Path) -> list[StoredMetaRecord]:
         if not isinstance(meta, dict):
             raise RuntimeError(f"Invalid .meta.json (expected object): {meta_path}")
 
-        node_type = str(meta.get("type", "")).strip()
-        node_id = str(meta.get("id", "")).strip()
+        node_type = _require_non_empty_meta_string(meta, field="type", meta_path=meta_path)
+        node_id = _require_non_empty_meta_string(meta, field="id", meta_path=meta_path)
         title = str(meta.get("title", "")).strip()
         slug = str(meta.get("slug", "")).strip()
-        if not node_type or not node_id:
-            continue
         if node_id in seen_ids:
             raise RuntimeError(f"Duplicate id detected: {node_id} ({meta_path})")
         seen_ids.add(node_id)

--- a/tests/cli_runtime/test_validate.py
+++ b/tests/cli_runtime/test_validate.py
@@ -17,6 +17,50 @@ from tests.cli_runtime.harness import (
 
 
 class TestCliValidate(CliRuntimeHarness):
+    def test_validate_rejects_missing_or_invalid_required_meta_identity_fields(self) -> None:
+        cases = (
+            ("type", None, "field=type"),
+            ("type", "", "field=type"),
+            ("type", "   ", "field=type"),
+            ("type", 123, "field=type"),
+            ("id", None, "field=id"),
+            ("id", "", "field=id"),
+            ("id", "   ", "field=id"),
+            ("id", 123, "field=id"),
+        )
+
+        for field, value, expected in cases:
+            with self.subTest(field=field, value=value):
+                with tempfile.TemporaryDirectory() as tmp:
+                    target = Path(tmp)
+                    self.assertEqual(main(["init", str(target)]), 0)
+
+                    self._create_same_repo_linked_hierarchy(target)
+
+                    issue_meta = (
+                        target
+                        / "spec-dock"
+                        / "initiatives"
+                        / "init-00001-auth-platform"
+                        / "epics"
+                        / "epic-00002-jwt-auth"
+                        / "issues"
+                        / "iss-00003-add-refresh-token"
+                        / ".meta.json"
+                    )
+                    meta = json.loads(issue_meta.read_text(encoding="utf-8"))
+                    if value is None:
+                        meta.pop(field, None)
+                    else:
+                        meta[field] = value
+                    self._write_json_force(issue_meta, meta)
+
+                    p = self._run_runtime_capture(target, ["validate"])
+                    self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
+                    self.assertIn("Invalid .meta.json", p.stderr)
+                    self.assertIn(expected, p.stderr)
+                    self.assertIn(str(issue_meta), p.stderr)
+
     def test_validate_detects_broken_parent_id(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)


### PR DESCRIPTION
## 概要

- malformed `.meta.json` の `type` / `id` を `load_node_records()` で fail-fast に変更
- provider-side source と checked-in dogfooding mirror の `fs_repo.py` 契約を同期
- `validate` 回帰テストを追加し、issue report に closure evidence を追記

## テスト

- `python -m unittest discover -v`
- `code-reviewer`: pass
- `qa-reviewer`: pass
- 手動テスト: `manual-tests/workspaces/2026-04-20-iss-00082-fail-fast-manual/trial-local/repo` で `validate` / `doctor` の baseline, fail-fast, restore を確認

## 補足

- manual test 中に一時作成された GitHub issue `#84` は close 済み

Closes #82
