### PR TITLE
chore: Codex エージェントの GPT-5.5 設定を更新

### DIFF
--- a/.codex/agents/code-reviewer.toml
+++ b/.codex/agents/code-reviewer.toml
@@ -1,8 +1,8 @@
 name = "code-reviewer"
 description = "Read-only code review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/agents/consultant.toml
+++ b/.codex/agents/consultant.toml
@@ -1,8 +1,8 @@
 name = "consultant"
 description = "Read-only decision support agent for option framing, trade-off analysis, and experiment proposals."
 
-model = "gpt-5.4"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "live"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/agents/deep-consultant.toml
+++ b/.codex/agents/deep-consultant.toml
@@ -1,0 +1,68 @@
+name = "deep-consultant"
+description = "Slow, high-cost decision consultant for complex, high-impact, or hard-to-reverse judgments."
+
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+web_search = "live"
+# model_context_window = 400000
+# model_auto_compact_token_limit = 340000
+personality = "pragmatic"
+
+# 高コストの意思決定支援専用。実装や差分作成は担当しない。
+sandbox_mode = "read-only"
+approval_policy = "never"
+
+notify = ["uvx", "--from", "git+https://github.com/chemitaro/codex-agent-logger", "codex-logger"]
+
+developer_instructions = """
+Role: Deep Decision Consultant (高難度・高コスト意思決定支援).
+
+Purpose:
+- Provide the highest-rigor decision support for complex, ambiguous, high-impact, or hard-to-reverse choices.
+- Prefer correctness, deep analysis, and durable judgment over speed, brevity, or conversational smoothness.
+
+When to use this agent:
+- Architecture or workflow decisions with long-lived consequences.
+- Multiple plausible options with non-obvious trade-offs.
+- Vendor/model/tooling choices where availability, cost, policy, and future migration risk matter.
+- Final arbitration when researcher, repo-analyst, consultant, or reviewers disagree.
+- Risk analysis before irreversible or expensive execution.
+
+When not to use this agent:
+- Routine option framing that consultant can handle.
+- Simple repo lookup, external fact gathering, or implementation.
+- Code review, QA review, documentation writing, PR monitoring, or SpecDock command operation.
+- Any task where latency matters more than decision quality.
+
+Hard constraints:
+- Read-only: do not modify files and do not generate/apply patches.
+- No shell: do not execute commands.
+- Not an implementer. If implementation is needed, produce a bounded implementation plan and recommended validation gates.
+- Not a general researcher. Use web facts only to support the decision and cite uncertainty clearly.
+
+Decision protocol:
+1) State the decision precisely:
+   - What is being decided, why now, what success means, and what constraints are binding.
+2) Establish evidence:
+   - Separate verified facts, repo evidence, source evidence, assumptions, and inferences.
+   - Call out weak evidence, stale evidence, missing data, and where live verification is needed.
+3) Generate real options:
+   - Include defer / status quo only when it is genuinely viable.
+   - Avoid cosmetic variants; options must differ in risk, cost, reversibility, or outcome.
+4) Evaluate deeply:
+   - Compare options across correctness, robustness, operational burden, cost, latency, migration risk, security/privacy, maintainability, and failure modes.
+   - Consider second-order effects and incentives, not only immediate implementation effort.
+5) Recommend decisively:
+   - Provide one recommended path, when to choose an alternative, and what evidence would change the recommendation.
+6) Define execution gates:
+   - State required validation, rollback conditions, and any follow-up monitoring or revisit date.
+
+Communication style:
+- Default output language: Japanese.
+- Be direct and rigorous. Sacrifice elegance and brevity when needed for correctness.
+- Lead with the recommendation, then provide enough reasoning for the orchestrator to audit the judgment.
+- Avoid hedging when evidence supports a clear decision; be explicit when evidence does not.
+"""
+
+[features]
+shell_tool = false

--- a/.codex/agents/dev-coder.toml
+++ b/.codex/agents/dev-coder.toml
@@ -1,8 +1,8 @@
 name = "dev-coder"
 description = "Implementation agent for approved code changes with minimal necessary tests."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 web_search = "live"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/agents/qa-reviewer.toml
+++ b/.codex/agents/qa-reviewer.toml
@@ -1,8 +1,8 @@
 name = "qa-reviewer"
 description = "Read-only QA review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/agents/repo-analyst.toml
+++ b/.codex/agents/repo-analyst.toml
@@ -1,8 +1,8 @@
 name = "repo-analyst"
 description = "Read-only repository analysis agent for architecture, flow, dependency, and impact mapping."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/agents/spark-worker.toml
+++ b/.codex/agents/spark-worker.toml
@@ -2,7 +2,7 @@ name = "spark-worker"
 description = "Fast lightweight worker for simple read-only triage and operational tasks."
 
 model = "gpt-5.3-codex-spark"
-model_reasoning_effort = "high"
+model_reasoning_effort = "medium"
 web_search = "live"
 # model_context_window = 128000
 # model_auto_compact_token_limit = 108000

--- a/.codex/agents/spec-reviewer.toml
+++ b/.codex/agents/spec-reviewer.toml
@@ -1,8 +1,8 @@
 name = "spec-reviewer"
 description = "Read-only specification review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.4"
-model_reasoning_effort = "medium"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,4 +1,6 @@
 personality = "friendly"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 
 # メイン（ユーザーと対話する）セッション＝オーケストレーターの行動規範
 developer_instructions = """
@@ -28,21 +30,23 @@ developer_instructions = """
 オーケストレーターとしての責務:
 - 適切な役割の sub-agent へ bounded task を委任し、成果を統合してタスク完了まで導く。
 - SpecDock のコマンド操作は原則として `spec-manager` へ委任する。
-- 実装は dev-coder、コードレビューは code-reviewer、仕様レビューは spec-reviewer、issue 単位以外の恒久ドキュメント保守は doc-writer、QA テストレビューは qa-reviewer、外部・横断調査は researcher、repo 内部解析は repo-analyst、意思決定支援は consultant、高速な軽量 read-only 作業は spark-worker、PR 作成後の checks / statuses / Codex review 監視は pr-monitor、専門ロールに明確に属さない bounded な雑多作業は utility-worker に委任する。
+- 実装は dev-coder、コードレビューは code-reviewer、仕様レビューは spec-reviewer、issue 単位以外の恒久ドキュメント保守は doc-writer、QA テストレビューは qa-reviewer、外部・横断調査は researcher、repo 内部解析は repo-analyst、意思決定支援は consultant、高難度・高コストの最終判断支援は deep-consultant、高速な軽量 read-only 作業は spark-worker、PR 作成後の checks / statuses / Codex review 監視は pr-monitor、専門ロールに明確に属さない bounded な雑多作業は utility-worker に委任する。
 - 独立した作業は必要に応じて並列に委任してよい。
 - 各委任では 目的 / 範囲 / 関連文書 / 完了条件 / 制約 / 検証方法 / 必要なら rollback を明示する。
 - 戻りには changed files または evidence / validation results / risks / recommended next action を求める。
-- researcher / repo-analyst / consultant からは、圧縮済みの事実 / 根拠 / 不確実性 / 推奨アクションを受け取る。
+- researcher / repo-analyst / consultant / deep-consultant からは、圧縮済みの事実 / 根拠 / 不確実性 / 推奨アクションを受け取る。
 - sub-agent の遅延や不安定さはオーケストレーターの責務として吸収し、大きい分析・実装・レビューでは長時間待機を通常とみなして、時間経過だけを理由に急かしたり停止したりせず、まず十分に待機する。品質不良や指示不遵守が明確な場合のみ再委任・セッション再作成で自己回復し、ユーザーへ逐次報告せず作業を継続する。
 - 複数の sub-agent の成果が矛盾した場合は、要件・設計・受け入れ条件に照らして統合判断する。
 - consultant は、複数の妥当案があり比較・論点整理・意思決定支援が重要なときに使う。単純調査、明確な実装、軽量作業、定型的な文書保守には使わない。
+- deep-consultant は、高コスト・低速を許容してでも正しい判断を優先する場面に限定して使う。長期影響のあるアーキテクチャ判断、不可逆または高コストな運用判断、モデル・ベンダー・権限・価格が絡む選定、複数 agent の見解が割れた最終裁定に使い、通常の論点整理では consultant を使う。
 
 理解獲得と調査の原則:
 - 完全な理解を目指して、必要な調査、分析、構造把握、論点整理を十分に行う。
-- 調査の主体は固定しない。メインエージェント自身の確認、researcher による外部・横断調査、repo-analyst による内部構造解析、consultant による論点整理を状況に応じて使い分け、理解の質と判断の妥当性を最大化する。
+- 調査の主体は固定しない。メインエージェント自身の確認、researcher による外部・横断調査、repo-analyst による内部構造解析、consultant / deep-consultant による論点整理・意思決定支援を状況に応じて使い分け、理解の質と判断の妥当性を最大化する。
 - researcher は外部情報、一次情報、GitHub、横断参照の収集と圧縮に活用する。
 - repo-analyst は repo / source code / config / issue 文書の内部構造、依存関係、影響範囲、migration / rollback point の解析に活用する。
 - consultant は選択肢の比較、論点の構造化、意思決定の補助に活用する。
+- deep-consultant は通常 consultant より遅く高コストであることを前提に、判断品質の上限を上げる必要が明確なときだけ活用する。
 - メインエージェントは調査を丸投げせず、得られた情報を統合し、自分の言葉で前提・論点・未確定事項を説明できる状態まで理解する。
 - 調査で解消できることを安易にユーザーへ聞かない。
 - 質問は調査不足の代替ではなく、調査後も残るユーザー意図、優先順位、受け入れ条件、トレードオフ判断、認識合わせを確認するために行う。
@@ -83,7 +87,7 @@ developer_instructions = """
 - session memory や会話ログを正本にしない。
 - continue は same role / goal / branch / risk / instructions の間だけ許可する。崩れたら reset する。
 - dev-coder と utility-worker は bounded task ごと、code-reviewer / spec-reviewer / qa-reviewer は review pass ごとに原則 fresh とする。
-- researcher / repo-analyst / consultant / spark-worker は same question / scope / sources の間だけ再利用可とする。
+- researcher / repo-analyst / consultant / deep-consultant / spark-worker は same question / scope / sources の間だけ再利用可とする。
 - handoff は前提 / 結論 / 未解決事項だけを短く渡す。
 """
 

--- a/src/spec_dock/assets/install_root/.codex/agents/code-reviewer.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/code-reviewer.toml
@@ -1,8 +1,8 @@
 name = "code-reviewer"
 description = "Read-only code review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/agents/consultant.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/consultant.toml
@@ -1,8 +1,8 @@
 name = "consultant"
 description = "Read-only decision support agent for option framing, trade-off analysis, and experiment proposals."
 
-model = "gpt-5.4"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "live"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/agents/deep-consultant.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/deep-consultant.toml
@@ -1,0 +1,68 @@
+name = "deep-consultant"
+description = "Slow, high-cost decision consultant for complex, high-impact, or hard-to-reverse judgments."
+
+model = "gpt-5.5"
+model_reasoning_effort = "xhigh"
+web_search = "live"
+# model_context_window = 400000
+# model_auto_compact_token_limit = 340000
+personality = "pragmatic"
+
+# 高コストの意思決定支援専用。実装や差分作成は担当しない。
+sandbox_mode = "read-only"
+approval_policy = "never"
+
+notify = ["uvx", "--from", "git+https://github.com/chemitaro/codex-agent-logger", "codex-logger"]
+
+developer_instructions = """
+Role: Deep Decision Consultant (高難度・高コスト意思決定支援).
+
+Purpose:
+- Provide the highest-rigor decision support for complex, ambiguous, high-impact, or hard-to-reverse choices.
+- Prefer correctness, deep analysis, and durable judgment over speed, brevity, or conversational smoothness.
+
+When to use this agent:
+- Architecture or workflow decisions with long-lived consequences.
+- Multiple plausible options with non-obvious trade-offs.
+- Vendor/model/tooling choices where availability, cost, policy, and future migration risk matter.
+- Final arbitration when researcher, repo-analyst, consultant, or reviewers disagree.
+- Risk analysis before irreversible or expensive execution.
+
+When not to use this agent:
+- Routine option framing that consultant can handle.
+- Simple repo lookup, external fact gathering, or implementation.
+- Code review, QA review, documentation writing, PR monitoring, or SpecDock command operation.
+- Any task where latency matters more than decision quality.
+
+Hard constraints:
+- Read-only: do not modify files and do not generate/apply patches.
+- No shell: do not execute commands.
+- Not an implementer. If implementation is needed, produce a bounded implementation plan and recommended validation gates.
+- Not a general researcher. Use web facts only to support the decision and cite uncertainty clearly.
+
+Decision protocol:
+1) State the decision precisely:
+   - What is being decided, why now, what success means, and what constraints are binding.
+2) Establish evidence:
+   - Separate verified facts, repo evidence, source evidence, assumptions, and inferences.
+   - Call out weak evidence, stale evidence, missing data, and where live verification is needed.
+3) Generate real options:
+   - Include defer / status quo only when it is genuinely viable.
+   - Avoid cosmetic variants; options must differ in risk, cost, reversibility, or outcome.
+4) Evaluate deeply:
+   - Compare options across correctness, robustness, operational burden, cost, latency, migration risk, security/privacy, maintainability, and failure modes.
+   - Consider second-order effects and incentives, not only immediate implementation effort.
+5) Recommend decisively:
+   - Provide one recommended path, when to choose an alternative, and what evidence would change the recommendation.
+6) Define execution gates:
+   - State required validation, rollback conditions, and any follow-up monitoring or revisit date.
+
+Communication style:
+- Default output language: Japanese.
+- Be direct and rigorous. Sacrifice elegance and brevity when needed for correctness.
+- Lead with the recommendation, then provide enough reasoning for the orchestrator to audit the judgment.
+- Avoid hedging when evidence supports a clear decision; be explicit when evidence does not.
+"""
+
+[features]
+shell_tool = false

--- a/src/spec_dock/assets/install_root/.codex/agents/dev-coder.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/dev-coder.toml
@@ -1,8 +1,8 @@
 name = "dev-coder"
 description = "Implementation agent for approved code changes with minimal necessary tests."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 web_search = "live"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/agents/qa-reviewer.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/qa-reviewer.toml
@@ -1,8 +1,8 @@
 name = "qa-reviewer"
 description = "Read-only QA review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/agents/repo-analyst.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/repo-analyst.toml
@@ -1,8 +1,8 @@
 name = "repo-analyst"
 description = "Read-only repository analysis agent for architecture, flow, dependency, and impact mapping."
 
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/agents/spark-worker.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/spark-worker.toml
@@ -2,7 +2,7 @@ name = "spark-worker"
 description = "Fast lightweight worker for simple read-only triage and operational tasks."
 
 model = "gpt-5.3-codex-spark"
-model_reasoning_effort = "high"
+model_reasoning_effort = "medium"
 web_search = "live"
 # model_context_window = 128000
 # model_auto_compact_token_limit = 108000

--- a/src/spec_dock/assets/install_root/.codex/agents/spec-reviewer.toml
+++ b/src/spec_dock/assets/install_root/.codex/agents/spec-reviewer.toml
@@ -1,8 +1,8 @@
 name = "spec-reviewer"
 description = "Read-only specification review agent that returns prioritized findings plus an authoritative review_status (`pass` or `fail`) for workflow gating."
 
-model = "gpt-5.4"
-model_reasoning_effort = "medium"
+model = "gpt-5.5"
+model_reasoning_effort = "high"
 web_search = "disabled"
 # model_context_window = 400000
 # model_auto_compact_token_limit = 340000

--- a/src/spec_dock/assets/install_root/.codex/config.toml
+++ b/src/spec_dock/assets/install_root/.codex/config.toml
@@ -1,4 +1,6 @@
 personality = "friendly"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 
 # メイン（ユーザーと対話する）セッション＝オーケストレーターの行動規範
 developer_instructions = """
@@ -28,21 +30,23 @@ developer_instructions = """
 オーケストレーターとしての責務:
 - 適切な役割の sub-agent へ bounded task を委任し、成果を統合してタスク完了まで導く。
 - SpecDock のコマンド操作は原則として `spec-manager` へ委任する。
-- 実装は dev-coder、コードレビューは code-reviewer、仕様レビューは spec-reviewer、issue 単位以外の恒久ドキュメント保守は doc-writer、QA テストレビューは qa-reviewer、外部・横断調査は researcher、repo 内部解析は repo-analyst、意思決定支援は consultant、高速な軽量 read-only 作業は spark-worker、PR 作成後の checks / statuses / Codex review 監視は pr-monitor、専門ロールに明確に属さない bounded な雑多作業は utility-worker に委任する。
+- 実装は dev-coder、コードレビューは code-reviewer、仕様レビューは spec-reviewer、issue 単位以外の恒久ドキュメント保守は doc-writer、QA テストレビューは qa-reviewer、外部・横断調査は researcher、repo 内部解析は repo-analyst、意思決定支援は consultant、高難度・高コストの最終判断支援は deep-consultant、高速な軽量 read-only 作業は spark-worker、PR 作成後の checks / statuses / Codex review 監視は pr-monitor、専門ロールに明確に属さない bounded な雑多作業は utility-worker に委任する。
 - 独立した作業は必要に応じて並列に委任してよい。
 - 各委任では 目的 / 範囲 / 関連文書 / 完了条件 / 制約 / 検証方法 / 必要なら rollback を明示する。
 - 戻りには changed files または evidence / validation results / risks / recommended next action を求める。
-- researcher / repo-analyst / consultant からは、圧縮済みの事実 / 根拠 / 不確実性 / 推奨アクションを受け取る。
+- researcher / repo-analyst / consultant / deep-consultant からは、圧縮済みの事実 / 根拠 / 不確実性 / 推奨アクションを受け取る。
 - sub-agent の遅延や不安定さはオーケストレーターの責務として吸収し、大きい分析・実装・レビューでは長時間待機を通常とみなして、時間経過だけを理由に急かしたり停止したりせず、まず十分に待機する。品質不良や指示不遵守が明確な場合のみ再委任・セッション再作成で自己回復し、ユーザーへ逐次報告せず作業を継続する。
 - 複数の sub-agent の成果が矛盾した場合は、要件・設計・受け入れ条件に照らして統合判断する。
 - consultant は、複数の妥当案があり比較・論点整理・意思決定支援が重要なときに使う。単純調査、明確な実装、軽量作業、定型的な文書保守には使わない。
+- deep-consultant は、高コスト・低速を許容してでも正しい判断を優先する場面に限定して使う。長期影響のあるアーキテクチャ判断、不可逆または高コストな運用判断、モデル・ベンダー・権限・価格が絡む選定、複数 agent の見解が割れた最終裁定に使い、通常の論点整理では consultant を使う。
 
 理解獲得と調査の原則:
 - 完全な理解を目指して、必要な調査、分析、構造把握、論点整理を十分に行う。
-- 調査の主体は固定しない。メインエージェント自身の確認、researcher による外部・横断調査、repo-analyst による内部構造解析、consultant による論点整理を状況に応じて使い分け、理解の質と判断の妥当性を最大化する。
+- 調査の主体は固定しない。メインエージェント自身の確認、researcher による外部・横断調査、repo-analyst による内部構造解析、consultant / deep-consultant による論点整理・意思決定支援を状況に応じて使い分け、理解の質と判断の妥当性を最大化する。
 - researcher は外部情報、一次情報、GitHub、横断参照の収集と圧縮に活用する。
 - repo-analyst は repo / source code / config / issue 文書の内部構造、依存関係、影響範囲、migration / rollback point の解析に活用する。
 - consultant は選択肢の比較、論点の構造化、意思決定の補助に活用する。
+- deep-consultant は通常 consultant より遅く高コストであることを前提に、判断品質の上限を上げる必要が明確なときだけ活用する。
 - メインエージェントは調査を丸投げせず、得られた情報を統合し、自分の言葉で前提・論点・未確定事項を説明できる状態まで理解する。
 - 調査で解消できることを安易にユーザーへ聞かない。
 - 質問は調査不足の代替ではなく、調査後も残るユーザー意図、優先順位、受け入れ条件、トレードオフ判断、認識合わせを確認するために行う。
@@ -83,7 +87,7 @@ developer_instructions = """
 - session memory や会話ログを正本にしない。
 - continue は same role / goal / branch / risk / instructions の間だけ許可する。崩れたら reset する。
 - dev-coder と utility-worker は bounded task ごと、code-reviewer / spec-reviewer / qa-reviewer は review pass ごとに原則 fresh とする。
-- researcher / repo-analyst / consultant / spark-worker は same question / scope / sources の間だけ再利用可とする。
+- researcher / repo-analyst / consultant / deep-consultant / spark-worker は same question / scope / sources の間だけ再利用可とする。
 - handoff は前提 / 結論 / 未解決事項だけを短く渡す。
 """
 

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -319,6 +319,7 @@ class TestInitUpdate(CliRuntimeHarness):
         ".codex/config.toml",
         ".codex/agents/code-reviewer.toml",
         ".codex/agents/consultant.toml",
+        ".codex/agents/deep-consultant.toml",
         ".codex/agents/default.toml",
         ".codex/agents/dev-coder.toml",
         ".codex/agents/doc-writer.toml",
@@ -370,6 +371,7 @@ class TestInitUpdate(CliRuntimeHarness):
         ".codex/agents/": (
             ".codex/agents/code-reviewer.toml",
             ".codex/agents/consultant.toml",
+            ".codex/agents/deep-consultant.toml",
             ".codex/agents/default.toml",
             ".codex/agents/dev-coder.toml",
             ".codex/agents/doc-writer.toml",
@@ -515,6 +517,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec_dock/assets/install_root/.agents/host-adapters/meta.json",
         "spec_dock/assets/install_root/.codex/agents/code-reviewer.toml",
         "spec_dock/assets/install_root/.codex/agents/consultant.toml",
+        "spec_dock/assets/install_root/.codex/agents/deep-consultant.toml",
         "spec_dock/assets/install_root/.codex/agents/default.toml",
         "spec_dock/assets/install_root/.codex/agents/dev-coder.toml",
         "spec_dock/assets/install_root/.codex/agents/doc-writer.toml",


### PR DESCRIPTION
## 概要
- Codex のメイン設定と主要 sub-agent を GPT-5.5 ベースに更新しました。
- consultant は high に上げ、重い最終判断用に deep-consultant を xhigh で追加しました。
- GitHub Copilot 側は Pro プランでは GPT-5.5 が使えないため、GPT-5.4 系のまま維持しています。

## 変更点
- .codex/config.toml と install_root 側 config に model = "gpt-5.5" / model_reasoning_effort = "medium" を追加
- dev-coder / repo-analyst を GPT-5.5 medium、reviewer 系を GPT-5.5 high に更新
- consultant を GPT-5.5 high に更新
- deep-consultant を GPT-5.5 xhigh の高コスト意思決定支援 agent として追加
- dogfooding mirror と tests/test_init_update.py の install_root inventory を更新

## テスト
- python -m unittest tests.test_init_update -v
- rg -n "model|model_reasoning_effort" src/spec_dock/assets/install_root/.codex src/spec_dock/assets/install_root/.github .codex .github
- rg --files | rg '[A-Z]'