### PR TITLE
Issue lifecycle start/finish commandsを追加

### DIFF
--- a/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -50,9 +50,10 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Normal issue execution lifecycle:
   - `./spec-dock/scripts/spec-dock issue start <target>`
   - `./spec-dock/scripts/spec-dock issue finish`
-- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
+- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch. It does not bypass dependency readiness, target validation, or checkout safety.
 - `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
 - Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
+- After `issue finish`, avoid running `sync --github` on the just-finished issue branch when you need active clear to remain clear. `sync --github` can restore active from branch-derived issue context; move to `main` or another non-issue branch before final sync, or skip post-finish sync.
 - Dependency mutation is command-first:
   - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
   - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`

--- a/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -50,7 +50,7 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Normal issue execution lifecycle:
   - `./spec-dock/scripts/spec-dock issue start <target>`
   - `./spec-dock/scripts/spec-dock issue finish`
-- `issue start -F` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
+- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
 - `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
 - Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
 - Dependency mutation is command-first:

--- a/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -9,6 +9,9 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Typical fit: implement the active issue through approved behavior-slice execution and update `report.md`.
 - Start from `spec-dock/active/context-pack.md`, then follow the issue workflow.
 - `spec-dock/docs/workflow_issue.md` is the source of truth for issue execution and completion.
+- Normal lifecycle path: start with `./spec-dock/scripts/spec-dock issue start <target>` and finish with `./spec-dock/scripts/spec-dock issue finish`.
+`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+- Treat direct `./spec-dock/scripts/spec-dock active set ...` as a manual / recovery command, not the primary issue execution path.
 - For shared phase authoring method, use:
   - `spec-dock/docs/phase_requirement.md`
   - `spec-dock/docs/phase_design.md`
@@ -18,15 +21,17 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
 - In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
 - Execution mode: follow the approved issue docs. If the docs are missing required detail or contradict the implementation path, update/review the docs before implementation continues.
+- Record delivery completion evidence in `spec-dock/active/issue/report.md` before running `./spec-dock/scripts/spec-dock issue finish`, because `issue finish` clears active state after lifecycle closure.
 - Treat `Spec-Locked Closure Index` as the issue-wide coverage ledger, not as a single test-case catalog. Execute and close work through each step's `step closure contract`.
 - Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
 - Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
 - Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
 - Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.
 - Do not skip the docs impact resolution step or the final diff review quality gate.
-- Issue execution is not complete unless the active issue is set and confirmed, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
+- Delivery completion must be confirmed before `issue finish` while the active issue is still set and confirmable, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
 - `spec-dock/active/issue/report.md` must record command evidence for required `sync`, `validate`, and review steps, including whether each required step succeeded, passed, or reached approval.
-- Complete status requires the active issue to remain set and confirmed, every required step to be executed, every required `sync` / `validate` step to succeed or pass, and every required review step to reach approval or pass.
+- Do not run `issue finish` until every required step has been executed, every required `sync` / `validate` step has succeeded or passed, every required review step has reached approval or pass, and the delivery completion evidence is recorded in `spec-dock/active/issue/report.md`.
+- After `issue finish`, do not require the active issue to remain set. Treat `issue finish` as lifecycle closure / GitHub close / active clear only.
 - If any required step is skipped, or executed without a successful, pass, or approved outcome, classify the issue as `blocked` or `incomplete`, record the reason and next action in `spec-dock/active/issue/report.md`, and do not report the issue as complete.
 - Treat the issue as `blocked` only when an external dependency, missing permission, unavailable service, or other environment condition prevents the next required action.
 - When blocked, record the reason and next action in `spec-dock/active/issue/report.md`. Include blocker type and impact when applicable.
@@ -42,6 +47,12 @@ description: Leaf skill for issue execution tasks in spec-dock.
 ## Runtime command reminders
 
 - Use runtime command path only: `./spec-dock/scripts/spec-dock ...`
+- Normal issue execution lifecycle:
+  - `./spec-dock/scripts/spec-dock issue start <target>`
+  - `./spec-dock/scripts/spec-dock issue finish`
+- `issue start -F` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
+- `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
+- Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
 - Dependency mutation is command-first:
   - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
   - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ After `init`, day-to-day operations are done via the runtime script installed in
 Notes:
 - For `new/import {initiative,epic,issue}`, `--title` is restricted to ASCII (alphanumerics + single spaces) and `--slug` is kebab-case.
 - Legacy sequential discussion docs are grandfathered only. New docs do not reuse legacy sequence names, and spec-dock does not auto-rename or auto-repair them to preserve forced backward compatibility.
-- Normal issue execution should use `issue start <target>` / `issue finish` as the primary path.
+- Normal issue execution should use `issue start <target>` / `issue finish` as the primary path. Use `issue start <target> -f` / `--force` only to bypass the unfinished active issue guard; dependency readiness still applies.
 - `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion. Record delivery completion evidence before running it.
 - Treat direct `active set` / `active set --checkout` as manual / recovery / low-level commands. `active set` updates active pointers from local nodes first. Branch operations are opt-in via `--checkout`.
 - With `active set --checkout`, the branch name is normalized to `<id>-<slug>` (fallback: `<id>`) to keep branch names ASCII.
@@ -171,5 +171,5 @@ v2 では `spec-dock/initiatives/` に Initiative → Epic → Issue の仕様�
 `spec-dock/active/` を “現在取り組んでいる対象” の固定入口（symlink）として使います。
 状態の集計は `spec-dock/.agent/index.json` と `spec-dock/.agent/tree.json` を `./spec-dock/scripts/spec-dock sync` で自動生成します（Git 管理しません）。
 
-補足: 通常の issue 実行開始/終了は `issue start <target>` / `issue finish` を primary path とし、`active set` / `active set --checkout` は manual / recovery 向けの low-level path として扱います。`new/import {initiative,epic,issue}` の `--title`/`--slug` には入力制約（ASCII / kebab-case）があり、`active set --checkout` を使う場合はブランチ名が `<id>-<slug>`（不適合なら `<id>`）へ正規化されます。
+補足: 通常の issue 実行開始/終了は `issue start <target>` / `issue finish` を primary path とし、unfinished active issue guard だけを bypass する場合は `issue start <target> -f` / `--force` を使います。`active set` / `active set --checkout` は manual / recovery 向けの low-level path として扱います。`new/import {initiative,epic,issue}` の `--title`/`--slug` には入力制約（ASCII / kebab-case）があり、`active set --checkout` を使う場合はブランチ名が `<id>-<slug>`（不適合なら `<id>`）へ正規化されます。
 また、`github.issue_number` は initiative/epic/issue をまたいで一意です（重複は検知されます）。詳細は導入先の `spec-dock/docs/reference_github.md`（このリポジトリでは `src/spec_dock/assets/spec_dock/docs/reference_github.md`）を参照してください。

--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ After `init`, day-to-day operations are done via the runtime script installed in
 # Note: canonical GitHub issue URLs are checked against the current repo; owner/repo mismatch is rejected.
 # Note: numeric initiative/epic/issue imports read from the resolved current repo (or explicit owner/repo when provided); if neither explicit repo scope nor a resolvable current repo scope from `origin` is available, import fails before local writes.
 
-# Set active issue pointers (symlinks) and generate context-pack
+# Normal issue execution lifecycle (primary path)
+./spec-dock/scripts/spec-dock issue start 123             # active + branch checkout/create
+./spec-dock/scripts/spec-dock issue start iss-local-00001 # local node id
+./spec-dock/scripts/spec-dock issue finish                # lifecycle closure: GitHub close + active clear
+
+# Manual / recovery active-set path (low-level)
 ./spec-dock/scripts/spec-dock active set 123             # default: active only (no checkout)
 ./spec-dock/scripts/spec-dock active set iss-local-00001 # local node id (no checkout)
 ./spec-dock/scripts/spec-dock active set 123 --checkout  # active + branch checkout/create
@@ -116,7 +121,9 @@ After `init`, day-to-day operations are done via the runtime script installed in
 Notes:
 - For `new/import {initiative,epic,issue}`, `--title` is restricted to ASCII (alphanumerics + single spaces) and `--slug` is kebab-case.
 - Legacy sequential discussion docs are grandfathered only. New docs do not reuse legacy sequence names, and spec-dock does not auto-rename or auto-repair them to preserve forced backward compatibility.
-- `active set` updates active pointers from local nodes first. Branch operations are opt-in via `--checkout`.
+- Normal issue execution should use `issue start <target>` / `issue finish` as the primary path.
+- `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion. Record delivery completion evidence before running it.
+- Treat direct `active set` / `active set --checkout` as manual / recovery / low-level commands. `active set` updates active pointers from local nodes first. Branch operations are opt-in via `--checkout`.
 - With `active set --checkout`, the branch name is normalized to `<id>-<slug>` (fallback: `<id>`) to keep branch names ASCII.
 - `github.issue_number` links (initiative/epic/issue) must be globally unique; duplicates are rejected/detected. See `src/spec_dock/assets/spec_dock/docs/reference_github.md` for details.
 - Generated initiative/epic/issue nodes include `discussions/` (`rules.md` included).
@@ -164,5 +171,5 @@ v2 では `spec-dock/initiatives/` に Initiative → Epic → Issue の仕様�
 `spec-dock/active/` を “現在取り組んでいる対象” の固定入口（symlink）として使います。
 状態の集計は `spec-dock/.agent/index.json` と `spec-dock/.agent/tree.json` を `./spec-dock/scripts/spec-dock sync` で自動生成します（Git 管理しません）。
 
-補足: `new/import {initiative,epic,issue}` の `--title`/`--slug` には入力制約（ASCII / kebab-case）があり、`active set --checkout` を使う場合はブランチ名が `<id>-<slug>`（不適合なら `<id>`）へ正規化されます。
+補足: 通常の issue 実行開始/終了は `issue start <target>` / `issue finish` を primary path とし、`active set` / `active set --checkout` は manual / recovery 向けの low-level path として扱います。`new/import {initiative,epic,issue}` の `--title`/`--slug` には入力制約（ASCII / kebab-case）があり、`active set --checkout` を使う場合はブランチ名が `<id>-<slug>`（不適合なら `<id>`）へ正規化されます。
 また、`github.issue_number` は initiative/epic/issue をまたいで一意です（重複は検知されます）。詳細は導入先の `spec-dock/docs/reference_github.md`（このリポジトリでは `src/spec_dock/assets/spec_dock/docs/reference_github.md`）を参照してください。

--- a/spec-dock/docs/README.md
+++ b/spec-dock/docs/README.md
@@ -48,6 +48,10 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 ./spec-dock/scripts/spec-dock import epic <num-or-canonical-url> --title "..." [--initiative <id>] [--allow-foreign-url]
 ./spec-dock/scripts/spec-dock import issue <num-or-canonical-url> --title "..." [--epic <id>] [--allow-foreign-url]
 
+./spec-dock/scripts/spec-dock issue start <github-issue-number>
+./spec-dock/scripts/spec-dock issue start --id <issue-id>
+./spec-dock/scripts/spec-dock issue finish
+
 ./spec-dock/scripts/spec-dock active set <id|#num|url>
 ./spec-dock/scripts/spec-dock active set --id <node-id>
 ./spec-dock/scripts/spec-dock active set --github-issue <n>
@@ -69,6 +73,7 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 - `new issue --create-github-issue` は default create の explicit alias
 - `--no-github` / `--allow-foreign-url` は compatibility flag として残るが、current contract mismatch を auto-migrate せず reject/fail-fast しうる
 - `import` は読み取り確認のみで、GitHub を更新しない。canonical URL は current repo と照合し、cross-repo node import は reject される
+- Issue 実行の通常入口は `issue start <target>`、終了導線は `issue finish`。`active set` / `active set --checkout` は manual / recovery 用の low-level command として使う
 - `active set` / `deps check` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える
 - 依存関係の追加/削除/確認は metadata の直編集ではなく `./spec-dock/scripts/spec-dock deps add/remove/check` を使い、変更後は `./spec-dock/scripts/spec-dock validate` と `./spec-dock/scripts/spec-dock sync --github` で整合を確認する
 - legacy sequential discussion docs は grandfathered only。新規作成で sequence reuse / auto-rename / auto-repair はしない

--- a/spec-dock/docs/github.md
+++ b/spec-dock/docs/github.md
@@ -36,32 +36,24 @@ gh issue create --title "<title>" --body "<body>"
 ./spec-dock/scripts/spec-dock new issue --epic 124 --title "..." --github-issue 123
 ```
 
-### 1.3 Issue ブランチ checkout（`active set <github_issue_number>`）
+### 1.3 Issue ブランチ checkout（`issue start <github_issue_number>`）
 
-GitHub Issue 番号から **ブランチ作成/checkout → active 設定 → sync** まで一括で行えます。
-
-```bash
-./spec-dock/scripts/spec-dock active set 123
-```
-
-内部的に実行されるコマンド（概要）:
+GitHub Issue 番号から **active issue 設定 → ブランチ作成/checkout** を一括で行えます。通常の Issue 実行では `issue start` を primary path として使います。
 
 ```bash
-gh issue develop 123 --name work/iss-00123 --checkout
+./spec-dock/scripts/spec-dock issue start 123
 ```
 
 注意:
 - 安全のため、**未コミット/未追跡の変更がある場合はエラーで中断**します（作業を保護するため）
 - 仕様ツリー内に `github.issue_number == 123` のノードが存在しない場合もエラーになります
+- `issue start` は issue node のみを対象にします。initiative / epic を checkout する manual / recovery 作業では `active set <target> --checkout` を明示してください
 
 補足:
-- `active set iss-00123` のようにノードIDで直接指定した場合でも、そのノードが GitHub Issue に紐づいていれば checkout します（initiative/epic/issue 共通）。
-- ブランチ名は日本語タイトルを使わず、`work/<node-id>` 形式を使います（例: `work/iss-00123`, `work/epic-00123`, `work/init-00123`）。
-- `work/<node-id>` が linked branch として既にある場合は、その既存 branch の checkout を優先します。
-- linked branch に `work/<node-id>` が無い場合は、`gh issue develop --name work/<node-id> --checkout` で作成します。
-- linked branch に legacy ブランチ（例: `gh-issue-123`）しか無い場合は、その legacy を一時 checkout してノードを解決し、最終的に `work/<node-id>` へ移行します（legacy が複数ある場合は非決定的なためエラー）。
-- `gh issue develop --name ...` が使えない環境では、互換のため `gh issue checkout` / `gh issue develop --checkout` にフォールバックします。
-- 互換フォールバックが使われた場合、最終的な branch 名は `gh` の挙動に依存するため `work/<node-id>` と一致しない可能性があります。
+- `issue start --id iss-00123` のように issue node ID で直接指定できます。
+- `active set iss-00123 --checkout` は同じ checkout 命名 contract を使いますが、unfinished issue guard を持たない manual / recovery 用の low-level command です。
+- ブランチ名は日本語タイトルを使わず、`<node-id>-<slug>` 形式を使います（例: `iss-00123-add-refresh-token`）。
+- desired branch が既にある場合は、その既存 branch の checkout を優先します。
 
 ## 2) 「どのリポジトリに作るか」はどう決まるか
 

--- a/spec-dock/docs/guide.md
+++ b/spec-dock/docs/guide.md
@@ -85,14 +85,17 @@ spec-dock/
 ## 最短 workflow
 
 1. 既存ノードに収まるか確認し、必要なら `new` / `import` する
-2. `active set` で作業対象を固定する
+2. Issue 実行では `issue start <target>` で作業対象を固定し、対象ブランチへ checkout する
 3. 対象 scope の `workflow_*.md` を正本にし、requirement / design は shared playbook、plan は `phase_plan.md` → `phase_plan_<scope>.md` の順で書く
 4. Initiative は Epic 分解、Epic は Issue 分割、Issue は agent-native / behavior-slice based execution contract を plan に落とす
-5. `validate` / `sync` で整合性と生成物を更新する
+5. `validate` / `sync` で整合性と生成物を更新し、Issue lifecycle を閉じる場合は `issue finish` を使う
 
 ## 代表コマンド（runtime script）
 
 ```bash
+./spec-dock/scripts/spec-dock issue start <github-issue-number>
+./spec-dock/scripts/spec-dock issue start --id <issue-id>
+./spec-dock/scripts/spec-dock issue finish
 ./spec-dock/scripts/spec-dock active set <id|#num|url>
 ./spec-dock/scripts/spec-dock deps check <target> --github
 ./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>
@@ -100,6 +103,8 @@ spec-dock/
 ./spec-dock/scripts/spec-dock validate
 ./spec-dock/scripts/spec-dock sync --github
 ```
+
+`active set` / `active set --checkout` は manual / recovery 用の low-level command です。通常の Issue 実行では `issue start` / `issue finish` を入口にします。
 
 
 ## 次に読む

--- a/spec-dock/docs/reference_github.md
+++ b/spec-dock/docs/reference_github.md
@@ -89,9 +89,9 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 
 - `issue start <target>` は issue node を解決して active set と checkout を一操作で行います
 - `issue start` は unfinished active issue branch 上で別 issue を start しようとした場合だけ default で block します
-- `issue start -F` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
+- `issue start -f` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
 - `main` / `master` / `develop` / `staging` や non-issue branch からの `issue start` は block しません
-- `issue start` の block message では `issue finish`、`issue start <target> -F`、manual `active set` の次アクションを案内します
+- `issue start` の block message では `issue finish`、`issue start <target> -f`、manual `active set` の次アクションを案内します
 
 `active set` は target を active として固定します。
 

--- a/spec-dock/docs/reference_github.md
+++ b/spec-dock/docs/reference_github.md
@@ -11,7 +11,7 @@
 ## 1. 前提（どのリポジトリが対象になるか）
 
 spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略するわけではありません。  
-`import` / `active set` / deps check / sync の `gh issue view` 系では repo slug が分かっている場合に `--repo owner/repo` を付け、same-repo URL import でも current repo を明示して読み取ります。  
+`import` / `issue start` / `issue finish` / `active set` / deps check / sync の `gh issue view` 系では repo slug が分かっている場合に `--repo owner/repo` を付け、same-repo URL import でも current repo を明示して読み取ります。
 一方で `gh issue create` / `gh issue list` は repo root を `cwd` にして実行し、対象リポジトリ解決は **`gh` の通常解釈**に委ねます。
 
 補足:
@@ -41,6 +41,11 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
   - remote mutation は close-only です。GitHub side delete は扱いません
   - close command 自体は local tree / docs / generated artifacts を直接更新しません
   - close 後の local `done` 観測は `./spec-dock/scripts/spec-dock sync --github` の既存経路に委ねます
+- `issue finish` は active issue lifecycle の通常終了 command です
+  - `./spec-dock/scripts/spec-dock issue finish` を受け付けます
+  - active issue の linked GitHub issue を close し、already-closed も success として扱います
+  - `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+  - active state は close / already-closed の確認成功後にだけ解除されます
 - `delete` は local spec node を削除し、linked GitHub Issue があれば close-only で扱います
   - top-level command として `./spec-dock/scripts/spec-dock delete <target> --yes` / `--id <node-id> --yes` / `--github-issue <n> --yes` を受け付けます
   - `issue` target は leaf delete を行い、linked GitHub issue は local delete 前に close します
@@ -78,7 +83,15 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - canonical でない URL-like target（例: `git@github.com:owner/repo/issues/123`）は reject します
 - current repo を検証できない場合（origin 未設定 / GitHub 以外の remote）は、canonical URL import を fail-closed で reject します
 
-## 4. `active set` と checkout（安全装置）
+## 4. `issue start` / `active set` と checkout（安全装置）
+
+通常の issue execution 開始は `issue start` を primary path とし、`active set` は manual / recovery path として残します。
+
+- `issue start <target>` は issue node を解決して active set と checkout を一操作で行います
+- `issue start` は unfinished active issue branch 上で別 issue を start しようとした場合だけ default で block します
+- `issue start -F` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
+- `main` / `master` / `develop` / `staging` や non-issue branch からの `issue start` は block しません
+- `issue start` の block message では `issue finish`、`issue start <target> -F`、manual `active set` の次アクションを案内します
 
 `active set` は target を active として固定します。
 
@@ -86,6 +99,7 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - 後方互換として `active set <target>` は維持されます
 - explicit form として `active set --id <node-id>` / `active set --github-issue <n>` も使えます
 - checkout は `active set <target> --checkout` を明示したときだけ実行します
+- `active set` は direct manual / recovery command であり、unfinished active issue guard の対象外です
 - target 解決はローカル node（`.meta.json`）を優先し、未解決なら checkout/active 変更なしで失敗します
 - `--checkout` 時に作業ツリーが dirty の場合は安全のため checkout を中断します
 - `--checkout` を伴う場合、ブランチ名は `<id>-<slug>`（不適合なら `<id>`）へ正規化されます（非ASCIIブランチ名を避ける）。詳細は [reference_naming.md](reference_naming.md) を参照してください。

--- a/spec-dock/docs/reference_naming.md
+++ b/spec-dock/docs/reference_naming.md
@@ -22,7 +22,7 @@
 ### 1.2 ブランチ命名（checkout 後の正規化）
 
 - `issue start <target>`
-- `issue start <target> -F`
+- `issue start <target> -f`
 - `active set <target> --checkout`
   - デフォルト（`active set <target>`）は no-checkout のため、ブランチ操作は行いません
   - `issue start` は issue node 専用です。initiative / epic / issue の target kind を問わないのは `active set <target> --checkout` のみです
@@ -171,7 +171,7 @@ validation / allocation の扱い:
 
 ### 5.2 対象
 
-- `issue start <target>` / `issue start <target> -F`
+- `issue start <target>` / `issue start <target> -f`
   - issue node のみを受け付けます
 - `active set <target> --checkout` を明示した場合
   - target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません

--- a/spec-dock/docs/reference_naming.md
+++ b/spec-dock/docs/reference_naming.md
@@ -21,8 +21,11 @@
 
 ### 1.2 ブランチ命名（checkout 後の正規化）
 
+- `issue start <target>`
+- `issue start <target> -F`
 - `active set <target> --checkout`
   - デフォルト（`active set <target>`）は no-checkout のため、ブランチ操作は行いません
+  - `issue start` は issue node 専用です。initiative / epic / issue の target kind を問わないのは `active set <target> --checkout` のみです
 
 ---
 
@@ -159,18 +162,20 @@ validation / allocation の扱い:
 
 ---
 
-## 5. `active set --checkout` のブランチ命名（日本語ブランチを避ける）
+## 5. `issue start` / `active set --checkout` のブランチ命名（日本語ブランチを避ける）
 
 ### 5.1 目的
 
-`active set --checkout` では、ブランチ名を **ASCII かつ git 的に妥当**な形式へ寄せます。  
+`issue start` と `active set --checkout` では、ブランチ名を **ASCII かつ git 的に妥当**な形式へ寄せます。
 これにより、非ASCII名や不正ref名による運用トラブルを避けます。
 
 ### 5.2 対象
 
-- `active set <target> --checkout` を明示した場合のみ
-- target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません
-- `--checkout` を付けない場合は **ブランチ操作しません**
+- `issue start <target>` / `issue start <target> -F`
+  - issue node のみを受け付けます
+- `active set <target> --checkout` を明示した場合
+  - target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません
+- `active set` で `--checkout` を付けない場合は **ブランチ操作しません**
 
 ### 5.3 望ましいブランチ名（desired）
 

--- a/spec-dock/docs/workflow-tree.md
+++ b/spec-dock/docs/workflow-tree.md
@@ -105,20 +105,28 @@ Issueは単独で「要件→設計→計画→実装→報告」まで完結す
 
 詳細: `reference_sync.md`
 
-### 5.2 いま作業する対象の固定（active）
+### 5.2 いま作業する対象の固定（issue start / issue finish / active）
 
 ```bash
+./spec-dock/scripts/spec-dock issue start 123          # primary path（checkout + active）
+./spec-dock/scripts/spec-dock issue start iss-00123
+./spec-dock/scripts/spec-dock issue finish
+
 ./spec-dock/scripts/spec-dock active show
-./spec-dock/scripts/spec-dock active set 123          # GitHub issue number（checkout + active + sync）
-./spec-dock/scripts/spec-dock active set iss-00123     # node id（issue）
-./spec-dock/scripts/spec-dock active set epic-00123    # node id（epic）
-./spec-dock/scripts/spec-dock active set init-00123    # node id（initiative）
+./spec-dock/scripts/spec-dock active set 123          # GitHub issue number（active only / no-checkout）
+./spec-dock/scripts/spec-dock active set 123 --checkout
+./spec-dock/scripts/spec-dock active set iss-00123    # node id（issue）
+./spec-dock/scripts/spec-dock active set epic-00123   # node id（epic）
+./spec-dock/scripts/spec-dock active set init-00123   # node id（initiative）
 ./spec-dock/scripts/spec-dock active clear
 ```
 
+- 通常の issue execution の開始/終了は `issue start <target>` / `issue finish` を primary lifecycle path とする。
+- `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。
+- `active set` は manual / recovery / low-level path として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う。
+- `active set <target>` のデフォルトは active only / no-checkout。ブランチ移動が必要な場合だけ `active set <target> --checkout` を使う。通常の issue 開始では `issue start` を使う。
 - `active` は生成物（gitignore）で、**「いま触る対象」の入口**だけを提供する。
 - エージェントは `spec-dock/active/context-pack.md` を入口にする。
-- GitHub Issue に紐づくノード（`github.issue_number` があるノード）を `active set` した場合、`active set` は checkout も行う。
 - active が未設定のレイヤーは placeholder（`spec-dock/system/active-none/**`）へ向く。
   - placeholder は編集対象外（best-effortで read-only）
 

--- a/spec-dock/docs/workflow_issue.md
+++ b/spec-dock/docs/workflow_issue.md
@@ -15,13 +15,17 @@ Issue は実装の最小単位です。
 - 共通 phase playbook: [phase_requirement.md](phase_requirement.md), [phase_design.md](phase_design.md), [phase_plan.md](phase_plan.md)
 - Issue plan playbook: [phase_plan_issue.md](phase_plan_issue.md)
 
-## 作成と active set
+## 作成と issue start
 
 ```bash
 ./spec-dock/scripts/spec-dock new issue --epic <epic-id> --title "..."
 ./spec-dock/scripts/spec-dock new issue --create-github-issue --epic <epic-id> --title "..."
 
 ./spec-dock/scripts/spec-dock import issue <num|#num|canonical-url> --title "..." [--epic <epic-id>]
+
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url>
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -F
+./spec-dock/scripts/spec-dock issue finish
 
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
 ./spec-dock/scripts/spec-dock active set --id <issue-id>
@@ -38,6 +42,14 @@ Issue は実装の最小単位です。
 - `import issue` の canonical URL は current repo と照合され、current repo を検証できない場合も含めて foreign GitHub issue URL は fail-closed で reject される
 - `--allow-foreign-url` は compatibility flag として残るが、cross-repo node identity import の成功経路にはならない
 - canonical でない URL-like target は受け付けない
+- 通常の issue execution 開始は `./spec-dock/scripts/spec-dock issue start <target>` を primary path とし、active set と checkout を一操作で完了する
+- `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。`main` / `master` / `develop` / `staging` や non-issue branch からの start は block しない
+- `./spec-dock/scripts/spec-dock issue start <target> -F` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
+- 通常の issue 完了は `./spec-dock/scripts/spec-dock issue finish` を primary path とする。active issue の linked GitHub issue を close し、already-closed も success として扱い、その確認後に active state を解除する
+`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+- delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う
+- `issue finish` 後は active issue が clear されていてよく、active issue が残っていること自体を `complete` condition にしてはならない
+- `active set` は manual / recovery command として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う
 - `active set` のデフォルトは no-checkout。ブランチ移動が必要な場合だけ `--checkout`
 - `active set` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える
 - 依存未解決なら `active set` は通常失敗する。確認は `./spec-dock/scripts/spec-dock deps check <target> --github`
@@ -78,8 +90,8 @@ Issue は実装の最小単位です。
 - 各 step は step result approval を得てから次へ進む
 - docs impact が `none` でない場合は、final quality gate の前に docs refresh / docs impact resolution step を置く
 - `git diff <base>...HEAD` を見る final diff review quality gate は独立 step にし、reviewer approval まで終える
-- route だけ、または `active set` だけでは Issue work は完了しない
-- `complete` と報告してよいのは、active issue が set され、その対象 issue を確認でき、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている証跡が記録されている場合のみである
+- route だけ、または manual `active set` だけでは Issue work は完了しない。通常の開始/終了は `issue start` / `issue finish` を使う
+- `complete` と報告してよいのは、`issue finish` 前に active issue が set されその対象 issue を確認できる状態で、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている証跡が記録され、その evidence を確認している場合のみである
 - 4 点の issue docs のいずれかが untouched、template、placeholder、または実質未記入の状態で残る場合は `未完了` であり、成功報告をしてはならない
 - required step（`sync` / `validate` / `required review`）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
 - `blocked` は、外部依存、権限不足、サービス停止、その他の環境条件によって次の required action を進められない状態を指す
@@ -95,7 +107,8 @@ Issue は実装の最小単位です。
 - `Test Contract Closure` に required closure id、step、evidence level、pre-implementation evidence、verification command、result を残す
 - `Closure Coverage` に各 required closure id と verification evidence の対応を残す
 - `Closure Delta` に追加・削除・変更・未実装 row と re-review 要否を残す
-- `complete` 判定に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡を残す
+- `complete` 判定に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡を、`issue finish` 前に active issue を確認できる状態の report に残す
+- `issue finish` 後は active issue が clear されていてよく、`complete` 判定は active state の残存ではなく `issue finish` 前に記録・確認した report evidence で行う
 - `complete` 判定に必要な required closure id は、report の `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている必要がある
 - required step（`sync` / `validate` / `required review`）を未実施にした場合、または実行しても成功、pass、approval に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
 - `blocked` / `未完了` の場合は reason と next action を残し、環境 blocker と product gap を混在させない
@@ -153,7 +166,7 @@ Issue は実装の最小単位です。
   - docs impact / docs refresh step が必要なら入っている
   - final diff review quality gate が独立している
 - report:
-  - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が残っている
+  - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が、`issue finish` 前に active issue を確認できる状態の report に残っている
   - required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で閉じている
   - required row の削除、locked expectation 変更、required 変更、spec link 意味変更がある場合は re-review 証跡が残っている
   - required step を未実施にした場合、または実行しても成功、pass、approval に到達しなかった場合は `blocked` / `未完了` の reason と next action が残っている

--- a/spec-dock/docs/workflow_issue.md
+++ b/spec-dock/docs/workflow_issue.md
@@ -24,7 +24,7 @@ Issue は実装の最小単位です。
 ./spec-dock/scripts/spec-dock import issue <num|#num|canonical-url> --title "..." [--epic <epic-id>]
 
 ./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url>
-./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -F
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -f
 ./spec-dock/scripts/spec-dock issue finish
 
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
@@ -44,7 +44,7 @@ Issue は実装の最小単位です。
 - canonical でない URL-like target は受け付けない
 - 通常の issue execution 開始は `./spec-dock/scripts/spec-dock issue start <target>` を primary path とし、active set と checkout を一操作で完了する
 - `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。`main` / `master` / `develop` / `staging` や non-issue branch からの start は block しない
-- `./spec-dock/scripts/spec-dock issue start <target> -F` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
+- `./spec-dock/scripts/spec-dock issue start <target> -f` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
 - 通常の issue 完了は `./spec-dock/scripts/spec-dock issue finish` を primary path とする。active issue の linked GitHub issue を close し、already-closed も success として扱い、その確認後に active state を解除する
 `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
 - delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う

--- a/spec-dock/docs/workflow_issue.md
+++ b/spec-dock/docs/workflow_issue.md
@@ -18,6 +18,7 @@ Issue は実装の最小単位です。
 ## 作成と issue start
 
 ```bash
+# primary lifecycle
 ./spec-dock/scripts/spec-dock new issue --epic <epic-id> --title "..."
 ./spec-dock/scripts/spec-dock new issue --create-github-issue --epic <epic-id> --title "..."
 
@@ -27,6 +28,7 @@ Issue は実装の最小単位です。
 ./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -f
 ./spec-dock/scripts/spec-dock issue finish
 
+# manual / recovery only
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
 ./spec-dock/scripts/spec-dock active set --id <issue-id>
 ./spec-dock/scripts/spec-dock active set --github-issue <n>
@@ -49,6 +51,7 @@ Issue は実装の最小単位です。
 `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
 - delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う
 - `issue finish` 後は active issue が clear されていてよく、active issue が残っていること自体を `complete` condition にしてはならない
+- `issue finish` 後に issue branch のまま `./spec-dock/scripts/spec-dock sync --github` を実行すると、branch-derived active restoration により active が復元され得る。active clear を保ちたい final sync は `main` などの non-issue branch に移動してから実行するか、finish 後 sync 自体を避ける
 - `active set` は manual / recovery command として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う
 - `active set` のデフォルトは no-checkout。ブランチ移動が必要な場合だけ `--checkout`
 - `active set` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00088",
+  "title": "Issue lifecycle start and finish commands",
+  "slug": "issue-lifecycle-start-and-finish-commands",
+  "created_at": "2026-05-05T01:08:32+09:00",
+  "updated_at": "2026-05-05T01:08:32+09:00",
+  "parent_id": "epic-00054",
+  "initiative_id": "init-local-00002",
+  "epic_id": "epic-00054",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 88,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
@@ -5,7 +5,7 @@ ID: "iss-00088"
 関連GitHub: ["#88"]
 状態: "approved"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-05"
+最終更新: "2026-05-06"
 依存: ["requirement.md"]
 親: ["epic-00054", "init-local-00002"]
 ---
@@ -34,7 +34,7 @@ ID: "iss-00088"
 - 非交渉制約:
   - provider runtime source と dogfooding docs / assets の整合を保つ。
   - GitHub state が確認できない active issue は unfinished とみなす。
-  - `-F` / `--force` は理由入力なしで使える。
+  - `-f` / `--force` は理由入力なしで使える。
 - 前提:
   - `close_node`、`set_active`、`clear_active` は既存 use case として存在する。
   - `infer_active_node_from_branch` は current branch から issue node を推定できる。
@@ -82,7 +82,7 @@ ID: "iss-00088"
   - ユーザーが「判定は issue がクローズであるかどうかを使用する」と指定したため。
   - local finished flag を追加しないことで Phase 1 の保存状態を増やさない。
 - trade-off:
-  - GitHub state が取得できない場合は安全側に倒して stop するため、offline / auth failure 時は `-F` が必要になる。
+  - GitHub state が取得できない場合は安全側に倒して stop するため、offline / auth failure 時は `-f` が必要になる。
 
 ## 依存関係分析
 - module dependency:
@@ -139,15 +139,15 @@ IssueCmd --> Text : render lifecycle result
 
 ## インターフェース契約
 - CLI:
-  - `./spec-dock/scripts/spec-dock issue start <target> [-F|--force] [--gh-limit N]`
-  - `./spec-dock/scripts/spec-dock issue start --id <issue-id> [-F|--force] [--gh-limit N]`
-  - `./spec-dock/scripts/spec-dock issue start --github-issue <n> [-F|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue start <target> [-f|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue start --id <issue-id> [-f|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue start --github-issue <n> [-f|--force] [--gh-limit N]`
   - `./spec-dock/scripts/spec-dock issue finish`
 - Defaults:
   - `issue start` always performs checkout.
   - `issue start` uses GitHub status for guard/readiness by default; there is no `--github` opt-in flag in Phase 1 because normal behavior must not require users to remember it.
-  - `-F` / `--force` bypasses only the unfinished active issue guard introduced by this command.
-  - `issue start` must not widen existing dependency/readiness bypass semantics. If the underlying active-set path has a broader `force` flag, lifecycle guard force and dependency force must be separated so `issue start -F` does not silently skip dependency readiness.
+  - `-f` / `--force` bypasses only the unfinished active issue guard introduced by this command.
+  - `issue start` must not widen existing dependency/readiness bypass semantics. If the underlying active-set path has a broader `force` flag, lifecycle guard force and dependency force must be separated so `issue start -f` does not silently skip dependency readiness.
 - Output:
   - start success:
     - `spec-dock: ok (issue start) target=<target> initiative=<id> epic=<id> issue=<id>`
@@ -297,7 +297,7 @@ tests/
   - finish closes then clears active.
   - finish failure does not clear active.
 - CLI:
-  - parser accepts `issue start`, `issue start -F`, `issue finish`.
+  - parser accepts `issue start`, `issue start -f`, `issue finish`.
   - non-issue target fails for start.
   - blocked message contains exact recovery commands.
 - Integration / runtime:
@@ -311,7 +311,7 @@ tests/
 ## 要件 / 例外 -> verification mapping
 - AC-001 -> CLI runtime test for issue start success and branch checkout.
 - AC-002 -> CLI/application test for blocked unfinished branch.
-- AC-003 -> CLI/application test for `-F`.
+- AC-003 -> CLI/application test for `-f`.
 - AC-004 -> CLI/application test for main/non-issue branch.
 - AC-005 -> CLI/application test for finish close and active clear.
 - AC-006 -> CLI/application tests for no active / no link / close failure.
@@ -321,7 +321,7 @@ tests/
 ## リスク / 移行 / ロールバック
 - risk:
   - GitHub state lookup can be expensive or unavailable.
-  - Mitigation: failure is actionable and `-F` remains available.
+  - Mitigation: failure is actionable and `-f` remains available.
 - risk:
   - `finish` may be mistaken for merge/PR completion.
   - Mitigation: output/docs explicitly say it closes GitHub issue and clears active only.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
@@ -1,0 +1,188 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00088"
+タイトル: "Issue lifecycle start and finish commands"
+関連GitHub: ["#88"]
+状態: "draft | approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-05"
+依存: ["requirement.md"]
+親: ["epic-00054", "init-local-00002"]
+---
+
+# iss-00088 Issue lifecycle start and finish commands — 設計（HOW）
+
+> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
+
+## Parent Diagram References
+- Epic diagrams:
+  - ...
+- Initiative diagrams:
+  - ...
+- reused decisions:
+  - ...
+
+## 目的・制約
+- 目的:
+  - ...
+- MUST / MUST NOT:
+  - ...
+- 非交渉制約:
+  - ...
+- 前提:
+  - ...
+
+## 既存実装 / 規約の理解
+- 参照した実装 / docs:
+  - ...
+- 現状理解:
+  - ...
+- 採用するパターン:
+  - ...
+- 採用しないもの:
+  - ...
+- 影響範囲:
+  - ...
+
+## 採用方針 / トレードオフ
+- 論点:
+  - ...
+- 選択肢:
+  - ...
+- 決定:
+  - ...
+
+## 依存関係分析
+- module dependency:
+  - ...
+- class dependency（必要時）:
+  - ...
+- function dependency（必要時）:
+  - ...
+- file dependency:
+  - ...
+- upstream / prerequisite:
+  - ...
+- downstream / dependent:
+  - ...
+- 実装起点:
+  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
+- sequencing implications:
+  - plan では upstream / prerequisite から順に step を組む
+
+## Module Dependency Diagram
+- Title:
+  - ...
+- Question answered:
+  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
+- Scope:
+  - ...
+- Excluded details:
+  - exhaustive call graph / 全 method / 全 import は描かない
+- Update trigger:
+  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
+- Diagram:
+  - 下の `plantuml` block を更新する
+
+### UML（原則: module dependency / package dependency delta）
+```plantuml
+@startuml
+top to bottom direction
+' show module / class / file / function dependencies that affect implementation order
+' do not copy Initiative/Epic diagrams
+
+rectangle "replace-with-module-a" as A
+rectangle "replace-with-module-b" as B
+A --> B : depends_on
+@enduml
+```
+
+## Local Diagram Delta（必要時）
+- changed boundary / responsibility / interaction:
+  - N/A: reason
+
+## インターフェース契約
+- API / function / protocol / data boundary:
+  - ...
+
+## Sequence Delta（必要時）
+- changed interaction:
+  - N/A: reason
+- retry / transaction / external API / queue:
+  - ...
+- UML:
+  - N/A: reason
+
+## Domain Model Delta（必要時）
+- parent model refs:
+  - ...
+- aggregate / entity / value object changes:
+  - N/A: reason
+- domain event / policy / specification changes:
+  - ...
+- invariant changes:
+  - ...
+- UML:
+  - N/A: reason
+
+## クラス / インターフェース詳細設計（必要時）
+- Class / Interface:
+  - ...
+- responsibility:
+  - ...
+- collaboration:
+  - ...
+- UML:
+  - N/A: reason
+
+## ディレクトリ / ファイル変更計画
+```text
+.
+|-- src/
+|   |-- package/
+|   |   |-- new_module.py        # Add: purpose; depends on: ...
+|   |   |-- existing_module.py   # Modify: purpose; depends on: ...
+|   |   `-- renamed_module.py    # Move/Rename from: src/package/old_module.py; purpose
+|   `-- tests/
+|       `-- test_new_module.py   # Add/Modify: purpose; depends on: src/package/new_module.py
+|-- docs/
+|   `-- reference.md             # Read only: purpose
+`-- legacy/
+    `-- obsolete_file.py         # Delete: purpose; depends on: replacement ready
+```
+
+## 要件 → 設計マッピング
+- AC-001 -> ...
+- EC-001 -> ...
+- constraint -> ...
+
+## テスト戦略
+- Unit:
+  - ...
+- Integration:
+  - ...
+- E2E / manual:
+  - ...
+- migration / rollback / feature flag if needed:
+  - ...
+
+## 要件 / 例外 -> verification mapping
+- AC-001 -> ...
+- EC-001 -> ...
+- constraint -> ...
+
+## リスク / 移行 / ロールバック（必要時）
+- ...
+
+## 未確定事項
+- Q-001:
+  - 質問:
+  - 選択肢:
+    - A:
+      - ...
+    - B:
+      - ...
+  - 推奨案:
+    - ...
+  - 影響範囲:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/design.md
@@ -3,7 +3,7 @@
 ID: "iss-00088"
 タイトル: "Issue lifecycle start and finish commands"
 関連GitHub: ["#88"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-05"
 依存: ["requirement.md"]
@@ -12,177 +12,322 @@ ID: "iss-00088"
 
 # iss-00088 Issue lifecycle start and finish commands — 設計（HOW）
 
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
 ## Parent Diagram References
-- Epic diagrams:
-  - ...
-- Initiative diagrams:
-  - ...
+- Epic:
+  - `epic-00054` は GitHub lifecycle command expansion として、command-side close と local delete の lifecycle gap を扱う。
+  - 本 issue は既存 `close` capability を通常 issue execution の `finish` 導線へ結び、`active set --checkout` を通常 `start` 導線へ包む追加 slice である。
 - reused decisions:
-  - ...
+  - remote GitHub issue delete は扱わない。
+  - close は linked GitHub issue の close-only operation とする。
+  - branch naming は既存 `active set --checkout` の `<id>-<slug>` decision を再利用する。
 
 ## 目的・制約
 - 目的:
-  - ...
+  - 通常 issue execution の primary path を `issue start` / `issue finish` として表現する。
+  - `active set` は manual / recovery path として維持する。
+  - 未完了 active issue branch から別 issue へ移る事故だけを `issue start` 側で止める。
 - MUST / MUST NOT:
-  - ...
+  - MUST: `issue start` は issue target のみ受け付け、active set + checkout を実行する。
+  - MUST: `issue finish` は active issue の linked GitHub issue を close / already-closed 確認し、成功後に active を解除する。
+  - MUST NOT: `active set` / `active set --checkout` の既存 contract を変更しない。
+  - MUST NOT: `finish` で commit / push / merge / PR / report 自動編集を行わない。
 - 非交渉制約:
-  - ...
+  - provider runtime source と dogfooding docs / assets の整合を保つ。
+  - GitHub state が確認できない active issue は unfinished とみなす。
+  - `-F` / `--force` は理由入力なしで使える。
 - 前提:
-  - ...
+  - `close_node`、`set_active`、`clear_active` は既存 use case として存在する。
+  - `infer_active_node_from_branch` は current branch から issue node を推定できる。
 
 ## 既存実装 / 規約の理解
 - 参照した実装 / docs:
-  - ...
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/active.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/close.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/set_active.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/close_node.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/domain/active.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/reference_github.md`
 - 現状理解:
-  - ...
+  - parser は top-level `active` / `close` / `delete` などを登録しているが、top-level `issue` command group はない。
+  - command wrappers は `CommandSpec` と typed `CommandArgs` で use case を呼ぶ薄い構造である。
+  - `set_active` は target resolution、deps readiness、optional GitHub status、optional checkout、active manifest commit を一括で扱う。
+  - `close_node` は target node の linked GitHub issue を close / already-closed success として扱い、local active state は変更しない。
+  - `clear_active` は active manifest / symlink / agent state を active-none へ戻す。
 - 採用するパターン:
-  - ...
+  - 新規 `commands/issue.py` は existing command wrapper style に従う。
+  - 新規 application use case は既存 `set_active` / `close_node` / `clear_active` を合成する orchestration layer とする。
+  - branch guard は domain helper `infer_active_node_from_branch` と current active manifest を使う。
 - 採用しないもの:
-  - ...
+  - `active set` 内への guard 混入。
+  - active manifest schema への finished flag 追加。
+  - GitHub close 以外の completion state。
+  - force reason / audit schema の導入。
 - 影響範囲:
-  - ...
+  - CLI parser / registry
+  - commands layer
+  - application contracts / use cases
+  - presentation text
+  - docs / skill guidance
+  - runtime CLI tests
 
 ## 採用方針 / トレードオフ
 - 論点:
-  - ...
-- 選択肢:
-  - ...
+  - `finish` 済み判定を local lifecycle state として持つか、GitHub closed state を正本にするか。
 - 決定:
-  - ...
+  - GitHub `CLOSED` state を正本にする。
+- 理由:
+  - ユーザーが「判定は issue がクローズであるかどうかを使用する」と指定したため。
+  - local finished flag を追加しないことで Phase 1 の保存状態を増やさない。
+- trade-off:
+  - GitHub state が取得できない場合は安全側に倒して stop するため、offline / auth failure 時は `-F` が必要になる。
 
 ## 依存関係分析
 - module dependency:
-  - ...
-- class dependency（必要時）:
-  - ...
-- function dependency（必要時）:
-  - ...
+  - `cli/parser.py` -> `commands/issue.py` -> `UseCases.issue_start` / `UseCases.issue_finish`
+  - `application/issue_lifecycle.py` -> `set_active`, `close_node`, `clear_active`, `infer_active_node_from_branch`
+  - `presentation/cli_text.py` -> new lifecycle result dataclasses
+- function dependency:
+  - `issue_start` は target resolution / active chain update / checkout を `set_active` へ委譲する。
+  - `issue_finish` は active issue target を `close_node` へ渡し、成功後に `clear_active` を呼ぶ。
+  - unfinished guard は `set_active` 呼び出し前に評価し、block 時は active state / checkout を一切変更しない。
 - file dependency:
-  - ...
+  - new command registration は parser / registry 変更に依存する。
+  - docs / skill 更新は runtime behavior 決定後に行う。
 - upstream / prerequisite:
-  - ...
+  - application contract dataclasses と use case wiring を先に追加する。
+  - command parser は use case contract が決まってから接続する。
 - downstream / dependent:
-  - ...
+  - docs / skills / tests は command surface と output wording に依存する。
 - 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
+  - red tests for parser / application guard / finish behavior を先に固定し、use case と command wrapper を後から実装する。
 - sequencing implications:
-  - plan では upstream / prerequisite から順に step を組む
+  - plan では S01 application contract / guard、S02 command surface、S03 finish / clear active、S90 docs / skill の順に進める。
 
 ## Module Dependency Diagram
-- Title:
-  - ...
-- Question answered:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
-- Scope:
-  - ...
-- Excluded details:
-  - exhaustive call graph / 全 method / 全 import は描かない
-- Update trigger:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- Diagram:
-  - 下の `plantuml` block を更新する
-
-### UML（原則: module dependency / package dependency delta）
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
 
-rectangle "replace-with-module-a" as A
-rectangle "replace-with-module-b" as B
-A --> B : depends_on
+rectangle "cli/parser.py" as Parser
+rectangle "commands/issue.py" as IssueCmd
+rectangle "application/contracts.py\nUseCases" as Contracts
+rectangle "application/issue_lifecycle.py" as Lifecycle
+rectangle "application/set_active.py" as SetActive
+rectangle "application/close_node.py" as CloseNode
+rectangle "application/set_active.py\nclear_active" as ClearActive
+rectangle "domain/active.py\ninfer_active_node_from_branch" as BranchInfer
+rectangle "presentation/cli_text.py" as Text
+
+Parser --> IssueCmd : bind issue start/finish
+IssueCmd --> Contracts : call issue lifecycle use cases
+Lifecycle --> SetActive : start success path
+Lifecycle --> CloseNode : finish close
+Lifecycle --> ClearActive : finish cleanup
+Lifecycle --> BranchInfer : unfinished issue branch guard
+IssueCmd --> Text : render lifecycle result
 @enduml
 ```
 
-## Local Diagram Delta（必要時）
+## Local Diagram Delta
 - changed boundary / responsibility / interaction:
-  - N/A: reason
+  - `issue start` is the new primary workflow entry.
+  - `active set` remains low-level and unconstrained by unfinished issue guard.
+  - `issue finish` closes the active issue and clears active state, but does not validate deliverables.
 
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
+- CLI:
+  - `./spec-dock/scripts/spec-dock issue start <target> [-F|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue start --id <issue-id> [-F|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue start --github-issue <n> [-F|--force] [--gh-limit N]`
+  - `./spec-dock/scripts/spec-dock issue finish`
+- Defaults:
+  - `issue start` always performs checkout.
+  - `issue start` uses GitHub status for guard/readiness by default; there is no `--github` opt-in flag in Phase 1 because normal behavior must not require users to remember it.
+  - `-F` / `--force` bypasses only the unfinished active issue guard introduced by this command.
+  - `issue start` must not widen existing dependency/readiness bypass semantics. If the underlying active-set path has a broader `force` flag, lifecycle guard force and dependency force must be separated so `issue start -F` does not silently skip dependency readiness.
+- Output:
+  - start success:
+    - `spec-dock: ok (issue start) target=<target> initiative=<id> epic=<id> issue=<id>`
+    - `spec-dock: ok (issue checkout) branch=<branch>`
+    - forced path includes `spec-dock: warning (issue start) forced=true ...` or warning payload.
+  - start blocked:
+    - stderr includes current active issue, current branch, requested issue, GitHub state, and commands for finish / force / active set recovery.
+  - finish success:
+    - `spec-dock: ok (issue finish) issue=<id> github=#<n> state=CLOSED active_cleared=true already_closed=<true|false>`
+- Data boundary:
+  - No new persisted lifecycle file in Phase 1.
+  - Active state continues to live in `.agent/active.json` / `spec-dock/active/*`.
 
-## Sequence Delta（必要時）
-- changed interaction:
-  - N/A: reason
-- retry / transaction / external API / queue:
-  - ...
-- UML:
-  - N/A: reason
+## Sequence Delta
+### `issue start`
+```plantuml
+@startuml
+skinparam monochrome true
+hide footbox
 
-## Domain Model Delta（必要時）
-- parent model refs:
-  - ...
+actor User
+participant "issue start" as Cmd
+participant "active store" as Active
+participant "git branch" as Git
+participant "GitHub issue state" as GH
+participant "set_active --checkout" as SetActive
+
+User -> Cmd: issue start <target>
+Cmd -> Active: load current active issue
+Cmd -> Git: current branch
+Cmd -> GH: confirm active issue state
+alt active issue branch + different target + not CLOSED + no force
+  Cmd -> User: block with next commands
+else allowed
+  Cmd -> SetActive: set target + checkout
+  SetActive -> User: active and branch ready
+end
+@enduml
+```
+
+### `issue finish`
+```plantuml
+@startuml
+skinparam monochrome true
+hide footbox
+
+actor User
+participant "issue finish" as Cmd
+participant "active store" as Active
+participant "close_node" as Close
+participant "clear_active" as Clear
+
+User -> Cmd: issue finish
+Cmd -> Active: load active issue
+Cmd -> Close: close linked GitHub issue
+alt close/already-closed success
+  Cmd -> Clear: clear active
+  Cmd -> User: finish success
+else failure
+  Cmd -> User: fail, active unchanged
+end
+@enduml
+```
+
+## Domain Model Delta
 - aggregate / entity / value object changes:
-  - N/A: reason
-- domain event / policy / specification changes:
-  - ...
+  - No new domain aggregate.
+- policy changes:
+  - New `unfinished active issue guard` policy in application layer:
+    - active issue exists
+    - requested issue differs
+    - current branch resolves to the active issue
+    - active issue GitHub state is not `CLOSED` or cannot be confirmed
+    - no force flag
 - invariant changes:
-  - ...
-- UML:
-  - N/A: reason
+  - `active set` remains unconstrained.
+  - `issue start` protects normal guided path only.
 
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- responsibility:
-  - ...
-- collaboration:
-  - ...
-- UML:
-  - N/A: reason
+## クラス / インターフェース詳細設計
+- `IssueStartRequest`:
+  - target: `TargetRef`
+  - force: bool
+  - issue_limit: int
+- `IssueStartResult`:
+  - target_display / requested issue id
+  - delegated `ActiveSetResult`
+  - forced: bool
+  - warnings: list[str]
+- `IssueFinishRequest`:
+  - no target; uses current active issue
+- `IssueFinishResult`:
+  - issue id
+  - GitHub issue number
+  - already_closed
+  - active_cleared
+  - warnings
+- `IssueStartBlocked` or RuntimeError:
+  - message carries current active issue, current branch, requested issue, GitHub state, exact next commands.
 
 ## ディレクトリ / ファイル変更計画
 ```text
-.
-|-- src/
-|   |-- package/
-|   |   |-- new_module.py        # Add: purpose; depends on: ...
-|   |   |-- existing_module.py   # Modify: purpose; depends on: ...
-|   |   `-- renamed_module.py    # Move/Rename from: src/package/old_module.py; purpose
-|   `-- tests/
-|       `-- test_new_module.py   # Add/Modify: purpose; depends on: src/package/new_module.py
+src/spec_dock/assets/spec_dock/
+|-- scripts/spec_dock_runtime/
+|   |-- cli/parser.py                    # Modify: add top-level issue subcommands
+|   |-- commands/issue.py                # Add: command args/wrappers for issue start/finish
+|   |-- application/contracts.py         # Modify: lifecycle request/result and UseCases entries
+|   |-- application/issue_lifecycle.py   # Add: start/finish orchestration and guard
+|   |-- application/__init__.py or wiring # Modify: register use cases if needed
+|   `-- presentation/cli_text.py         # Modify: lifecycle output rendering
 |-- docs/
-|   `-- reference.md             # Read only: purpose
-`-- legacy/
-    `-- obsolete_file.py         # Delete: purpose; depends on: replacement ready
+|   |-- workflow_issue.md                # Modify: primary path and guard wording
+|   |-- reference_github.md              # Modify: issue lifecycle command reference
+|   `-- reference_naming.md              # Modify: issue start checkout uses existing branch naming
+`-- install_root/.agents/skills/
+    `-- spec-dock-issue-execution/SKILL.md # Modify: agent primary path
+
+spec-dock/
+|-- docs/                               # Mirror provider docs changes
+|-- scripts/spec_dock_runtime/           # Mirror runtime changes only if dogfooding mirror is checked-in
+`-- active/issue/report.md               # Update: implementation evidence
+
+tests/
+|-- cli_runtime/test_issue_lifecycle.py  # Add: CLI/application behavior coverage
+|-- cli_runtime/test_active.py           # Modify only for regression if needed
+`-- test_init_update.py                  # Modify if shipped asset mirror assertions require update
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001 -> `issue start` command wrapper + `issue_lifecycle.issue_start` + `set_active(checkout=True)`
+- AC-002 -> unfinished active issue guard before delegated `set_active`
+- AC-003 -> force path in `issue_start`
+- AC-004 -> branch inference guard only when current branch maps to active issue
+- AC-005 -> `issue_finish` close + clear active orchestration
+- AC-006 -> failure-before-clear behavior in `issue_finish`
+- AC-007 -> docs / skill / CLI help updates
+- EC-001 -> target kind validation
+- EC-002 -> GitHub state failure treated as unfinished
+- EC-003 -> same target idempotent start
+- EC-004 -> existing checkout failure propagation with no partial active update
+- EC-005 -> regression: active set unchanged
 
 ## テスト戦略
-- Unit:
-  - ...
-- Integration:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
+- Unit / application:
+  - start blocks before `set_active` when unfinished active issue branch is detected.
+  - start force delegates to `set_active`.
+  - start from main/non-issue branch delegates to `set_active`.
+  - finish closes then clears active.
+  - finish failure does not clear active.
+- CLI:
+  - parser accepts `issue start`, `issue start -F`, `issue finish`.
+  - non-issue target fails for start.
+  - blocked message contains exact recovery commands.
+- Integration / runtime:
+  - temp repo with stub `gh` verifies start checkout and active state.
+  - temp repo verifies finish close/already-closed and active clear.
+- Docs / assets:
+  - provider and dogfooding docs include `issue start` / `issue finish` primary path.
+  - installed skill includes command guidance.
+  - mirror / scaffold assertions updated if tests expect exact shipped assets.
 
 ## 要件 / 例外 -> verification mapping
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001 -> CLI runtime test for issue start success and branch checkout.
+- AC-002 -> CLI/application test for blocked unfinished branch.
+- AC-003 -> CLI/application test for `-F`.
+- AC-004 -> CLI/application test for main/non-issue branch.
+- AC-005 -> CLI/application test for finish close and active clear.
+- AC-006 -> CLI/application tests for no active / no link / close failure.
+- AC-007 -> docs assertion or targeted grep plus reviewer inspection.
+- EC-005 -> existing active set tests remain green.
 
-## リスク / 移行 / ロールバック（必要時）
-- ...
+## リスク / 移行 / ロールバック
+- risk:
+  - GitHub state lookup can be expensive or unavailable.
+  - Mitigation: failure is actionable and `-F` remains available.
+- risk:
+  - `finish` may be mistaken for merge/PR completion.
+  - Mitigation: output/docs explicitly say it closes GitHub issue and clears active only.
+- rollback:
+  - Remove `issue` command group and docs additions; existing `active` / `close` commands remain intact.
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - Phase 1 behavior and exclusions are fixed by requirement.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
@@ -1,0 +1,211 @@
+---
+種別: 実装計画書（Issue）
+ID: "iss-00088"
+タイトル: "Issue lifecycle start and finish commands"
+関連GitHub: ["#88"]
+状態: "draft | approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-05"
+依存: ["requirement.md", "design.md"]
+親: ["epic-00054", "init-local-00002"]
+---
+
+# iss-00088 Issue lifecycle start and finish commands — 実装計画（Execution Contract）
+
+> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。実行 policy は `workflow_issue.md`、Issue plan の書き方は `phase_plan_issue.md` を正本にする。
+
+## この計画で満たす要件ID
+- AC:
+  - ...
+- EC:
+  - ...
+- 制約:
+  - ...
+
+## マイルストーン一覧
+- M1:
+  - 対象:
+  - exit:
+- M2:
+  - ...
+
+## 依存関係から導く実装順序
+- 依存関係の正本:
+  - `design.md` の `依存関係分析`
+  - `design.md` の `Module Dependency Diagram`
+  - `design.md` の `ディレクトリ / ファイル変更計画`
+- sequencing rule:
+  - upstream / prerequisite / lower-dependency slice から先に step を組む
+  - downstream / dependent slice は前提が固まってから置く
+- step ordering notes:
+  - どの step が何に依存するかを短く書く
+- step dependency summary:
+  - S01:
+    - depends on:
+    - unblocks:
+    - target files:
+
+## ステップ一覧
+- S01:
+  - 観測可能な振る舞い:
+  - depends on:
+  - unblocks:
+  - target files:
+  - closes:
+  - review gate:
+- S02:
+  - ...
+
+## 要件 ↔ ステップ対応
+- AC-001 -> S01
+- EC-001 -> S02
+
+## Spec-Locked Closure Index（仕様固定クロージャ索引）
+
+> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+
+| id | phase / step | slice | type | spec link | locked expectation | observable input/state | bug class guarded | required | evidence level | closure evidence |
+|---|---|---|---|---|---|---|---|---|---|---|
+| tc-001 | S01 | <behavior> | acceptance | AC-001 | ... | ... | spec drift | yes | red-required | report step closure |
+| tc-002 | S01 | <behavior> | negative | EC-001 | ... | ... | silent failure | yes | covered-existing | report step closure |
+
+- optional detail columns when needed:
+  - fixture notes:
+  - golden output:
+  - manual verification:
+  - property domain:
+  - non-goals:
+- evidence level values:
+  - red-required:
+  - covered-existing:
+  - inspect-only:
+  - manual-required:
+- detail policy:
+  - 通常 Issue は step / behavior slice ごとに 1〜3 件程度の検証契約を書く。
+  - 中央 index は重複するテストケース表にせず、仕様ロック、担当 step、required、evidence level、closure evidence だけを追う。
+  - public CLI behavior、shipped scaffold / runtime contract、template / system docs の互換性、installer / update / migration、filesystem / GitHub / active store、negative path、既存 regression、複数 Agent 並列実装の領域では詳細化する。
+
+## レビュー / QA ゲート方針
+- RG1 implementation review:
+  - timing:
+  - scope:
+- QG1 QA review:
+  - timing:
+  - scope:
+- SG1 spec review:
+  - timing:
+  - scope:
+
+## 実行ルール（全ステップ共通）
+- 実行 policy、approval cadence、completion contract は `workflow_issue.md` を正本にする。
+- step / block / behavior slice の書き方は `phase_plan_issue.md` を正本にする。
+- plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
+
+## 実装ステップ
+
+### S01 — <observable behavior>
+- observable behavior:
+  - ...
+- design refs:
+  - ...
+- depends on:
+  - ...
+- unblocks:
+  - ...
+- target files:
+  - ...
+- test bundle:
+  - closure ids:
+    - tc-001
+  - test ids:
+    - same as closure ids unless a project explicitly documents separate aliases
+  - evidence level:
+    - red-required / covered-existing / inspect-only / manual-required
+  - acceptance:
+  - characterization:
+  - property / invariant:
+  - regression:
+  - negative:
+- pre-implementation evidence:
+  - expected red / characterization pass / test sensitivity evidence:
+- report update:
+  - ...
+- notes:
+  - ...
+
+#### step closure contract
+- closure ids:
+  - tc-001
+- close when:
+  - ...
+- verification evidence:
+  - targeted command / manual evidence / inspection evidence:
+- report evidence:
+  - Step Contract Closure:
+  - Test Contract Closure:
+  - Closure Coverage:
+- residual risk:
+  - ...
+
+#### behavior slice execution
+- implementation batch:
+  - allowed scope:
+  - forbidden scope:
+- verification:
+  - targeted command:
+  - related / full command:
+- refactor / tidy:
+  - purpose:
+  - guardrail:
+
+#### step gate
+- review:
+  - ...
+- expected verification:
+  - ...
+- report update:
+  - ...
+
+### Sxx — <next observable behavior>
+- ...
+
+### S90 — docs impact resolution / docs refresh
+- 対象:
+  - docs / assets / workflow / skill / none
+- 対応:
+  - ...
+
+### S99 — final diff review quality gate
+- branch diff scope:
+  - ...
+- required validation:
+  - ...
+- reviewer approvals:
+  - ...
+- report update:
+  - ...
+
+## 未確定事項
+- Q-001:
+  - 質問:
+  - 選択肢:
+    - A:
+      - ...
+    - B:
+      - ...
+  - 推奨案:
+    - ...
+  - 影響範囲:
+    - ...
+
+## final exit contract
+- AC/EC 達成:
+  - ...
+- docs impact resolved:
+  - ...
+- final diff approved:
+  - ...
+- required closure ids closed:
+  - Step Contract Closure:
+  - Test Contract Closure:
+  - Closure Coverage:

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
@@ -3,7 +3,7 @@
 ID: "iss-00088"
 タイトル: "Issue lifecycle start and finish commands"
 関連GitHub: ["#88"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-05"
 依存: ["requirement.md", "design.md"]
@@ -12,22 +12,48 @@ ID: "iss-00088"
 
 # iss-00088 Issue lifecycle start and finish commands — 実装計画（Execution Contract）
 
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。実行 policy は `workflow_issue.md`、Issue plan の書き方は `phase_plan_issue.md` を正本にする。
-
 ## この計画で満たす要件ID
 - AC:
-  - ...
+  - AC-001
+  - AC-002
+  - AC-003
+  - AC-004
+  - AC-005
+  - AC-006
+  - AC-007
 - EC:
-  - ...
+  - EC-001
+  - EC-002
+  - EC-003
+  - EC-004
+  - EC-005
 - 制約:
-  - ...
+  - `active set` / `active set --checkout` の既存挙動を変更しない
+  - `issue finish` は commit / push / merge / PR / stash / report 自動編集を行わない
+  - dirty worktree hard block や protected branch hard block は Phase 1 に含めない
+  - provider runtime / docs / skills と dogfooding mirror の整合を保つ
 
 ## マイルストーン一覧
 - M1:
   - 対象:
+    - spec readiness and red behavior lock
   - exit:
+    - design / plan が issue 固有で、SG1 spec review が pass する
 - M2:
-  - ...
+  - 対象:
+    - `issue start` command and unfinished guard
+  - exit:
+    - start success / block / force / non-issue target behavior が tests で閉じる
+- M3:
+  - 対象:
+    - `issue finish` command
+  - exit:
+    - close + active clear / failure active unchanged が tests で閉じる
+- M4:
+  - 対象:
+    - docs / skill / mirror parity and final validation
+  - exit:
+    - provider + dogfooding docs / skill / runtime tests / final review が pass する
 
 ## 依存関係から導く実装順序
 - 依存関係の正本:
@@ -35,177 +61,387 @@ ID: "iss-00088"
   - `design.md` の `Module Dependency Diagram`
   - `design.md` の `ディレクトリ / ファイル変更計画`
 - sequencing rule:
-  - upstream / prerequisite / lower-dependency slice から先に step を組む
-  - downstream / dependent slice は前提が固まってから置く
-- step ordering notes:
-  - どの step が何に依存するかを短く書く
+  - use case contracts -> command wrapper -> finish orchestration -> docs / skill -> final validation の順で進める
 - step dependency summary:
+  - S00:
+    - depends on:
+      - requirement/design/plan
+    - unblocks:
+      - implementation
+    - target files:
+      - issue docs only
   - S01:
     - depends on:
+      - current command/use case patterns
     - unblocks:
+      - `issue start` parser / CLI wrapper
     - target files:
+      - `application/contracts.py`, new lifecycle use case, tests
+  - S02:
+    - depends on:
+      - S01 lifecycle contract
+    - unblocks:
+      - user-facing `issue start`
+    - target files:
+      - `commands/issue.py`, `cli/parser.py`, `presentation/cli_text.py`, tests
+  - S03:
+    - depends on:
+      - active issue target handling and close capability
+    - unblocks:
+      - user-facing `issue finish`
+    - target files:
+      - lifecycle use case, command wrapper, tests
+  - S90:
+    - depends on:
+      - runtime behavior
+    - unblocks:
+      - final quality gate
+    - target files:
+      - provider docs, dogfooding docs, installed skill
+  - S99:
+    - depends on:
+      - S01-S90
+    - unblocks:
+      - issue completion
+    - target files:
+      - report and final validation evidence
 
 ## ステップ一覧
+- S00:
+  - 観測可能な振る舞い:
+    - issue docs だけで implementation-ready と判断できる
+  - closes:
+    - SG1 baseline only
+  - review gate:
+    - SG1 spec review pass
 - S01:
   - 観測可能な振る舞い:
-  - depends on:
-  - unblocks:
-  - target files:
+    - application layer が `issue start` の success / block / force policy を表現できる
   - closes:
+    - AC-001
+    - AC-002
+    - AC-003
+    - AC-004
+    - EC-001
+    - EC-002
+    - EC-003
+    - EC-004
+    - EC-005
   - review gate:
+    - targeted tests pass
 - S02:
-  - ...
+  - 観測可能な振る舞い:
+    - CLI から `issue start` を実行でき、messages が action-oriented である
+  - closes:
+    - AC-001
+    - AC-002
+    - AC-003
+    - AC-004
+  - review gate:
+    - CLI tests pass
+- S03:
+  - 観測可能な振る舞い:
+    - CLI から `issue finish` を実行でき、close success 後だけ active clear される
+  - closes:
+    - AC-005
+    - AC-006
+  - review gate:
+    - CLI/application tests pass
+- S90:
+  - 観測可能な振る舞い:
+    - docs / skills が `issue start` / `issue finish` を primary path として案内する
+  - closes:
+    - AC-007
+  - review gate:
+    - docs/spec review pass
+- S99:
+  - 観測可能な振る舞い:
+    - final diff / tests / validation / review evidence が report に揃う
+  - closes:
+    - final exit contract
+  - review gate:
+    - implementation review pass
+    - QA review pass
+    - final spec review pass
 
 ## 要件 ↔ ステップ対応
-- AC-001 -> S01
-- EC-001 -> S02
+- AC-001 -> S01, S02
+- AC-002 -> S01, S02
+- AC-003 -> S01, S02
+- AC-004 -> S01, S02
+- AC-005 -> S03
+- AC-006 -> S03
+- AC-007 -> S90, S99
+- EC-001 -> S01, S02
+- EC-002 -> S01, S02
+- EC-003 -> S01, S02
+- EC-004 -> S01, S02
+- EC-005 -> S01, S02, S99
 
 ## Spec-Locked Closure Index（仕様固定クロージャ索引）
 
-> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
-
 | id | phase / step | slice | type | spec link | locked expectation | observable input/state | bug class guarded | required | evidence level | closure evidence |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | acceptance | AC-001 | ... | ... | spec drift | yes | red-required | report step closure |
-| tc-002 | S01 | <behavior> | negative | EC-001 | ... | ... | silent failure | yes | covered-existing | report step closure |
-
-- optional detail columns when needed:
-  - fixture notes:
-  - golden output:
-  - manual verification:
-  - property domain:
-  - non-goals:
-- evidence level values:
-  - red-required:
-  - covered-existing:
-  - inspect-only:
-  - manual-required:
-- detail policy:
-  - 通常 Issue は step / behavior slice ごとに 1〜3 件程度の検証契約を書く。
-  - 中央 index は重複するテストケース表にせず、仕様ロック、担当 step、required、evidence level、closure evidence だけを追う。
-  - public CLI behavior、shipped scaffold / runtime contract、template / system docs の互換性、installer / update / migration、filesystem / GitHub / active store、negative path、既存 regression、複数 Agent 並列実装の領域では詳細化する。
+| lc-001 | S01/S02 | issue start success | acceptance | AC-001 | `issue start <issue>` sets active issue and checks out the issue branch; non-issue targets fail-fast | CLI target issue node; active state; branch | missing guided start / wrong node kind accepted | yes | red-required | CLI/runtime test + report closure |
+| lc-002 | S01/S02 | unfinished guard | negative | AC-002, EC-002 | different issue start from unfinished active issue branch blocks before active/checkout mutation and prints next commands | active issue open/unknown; current branch maps to active issue; target differs; no force | accidental context switch / partial active mutation | yes | red-required | CLI/runtime test + report closure |
+| lc-003 | S01/S02 | force start | acceptance | AC-003 | `-F`/`--force` bypasses only the unfinished issue guard, does not bypass dependency/readiness checks, and shows forced start evidence | same as lc-002 plus force plus dependency-not-ready fixture | force ignored / silent force / dependency bypass leak | yes | red-required | CLI/runtime test + report closure |
+| lc-004 | S01/S02 | safe branch start | regression | AC-004, EC-003 | main/non-issue branch and same issue restart do not trigger unfinished guard | current branch main/non-issue or requested==active issue | overblocking normal/emergency workflows | yes | red-required | CLI/runtime test + report closure |
+| lc-005 | S03 | issue finish success | acceptance | AC-005 | finish closes/already-closed active linked GitHub issue and clears active only after close success | active issue with GitHub link; issue state open/closed | finish does not clear / finish clears before close | yes | red-required | CLI/runtime test + report closure |
+| lc-006 | S03 | issue finish failure | negative | AC-006 | no active, no link, or close/status failure leaves active unchanged and gives recovery guidance | missing active / missing link / gateway error | silent failure / active lost on failure | yes | red-required | CLI/runtime test + report closure |
+| lc-007 | S90 | docs and skill guidance | acceptance | AC-007 | provider docs, dogfooding docs, CLI help, and issue execution skill describe `issue start`/`issue finish` as primary path and keep `active set` as manual/recovery | docs/skill files | agent continues old ambiguous workflow | yes | inspect-only | docs diff + spec review closure |
+| lc-008 | S99 | existing active contract unchanged | regression | EC-005, constraints | direct `active set` behavior remains unchanged and existing tests stay green | existing active tests and targeted active set use | guard leaks into manual recovery path | yes | covered-existing | regression command + report closure |
 
 ## レビュー / QA ゲート方針
-- RG1 implementation review:
-  - timing:
-  - scope:
-- QG1 QA review:
-  - timing:
-  - scope:
 - SG1 spec review:
   - timing:
+    - S00 後
+    - S90 後
+    - S99 前
   - scope:
+    - requirement / design / plan readiness
+    - docs / skill contract consistency
+- RG1 implementation review:
+  - timing:
+    - S02/S03 実装後
+    - S99 final diff 前
+  - scope:
+    - layer boundaries
+    - active set / close reuse
+    - failure active unchanged guarantees
+- QG1 QA review:
+  - timing:
+    - targeted tests pass 後
+    - final validation 後
+  - scope:
+    - acceptance coverage
+    - negative path coverage
+    - docs mirror coverage
 
 ## 実行ルール（全ステップ共通）
 - 実行 policy、approval cadence、completion contract は `workflow_issue.md` を正本にする。
 - step / block / behavior slice の書き方は `phase_plan_issue.md` を正本にする。
-- plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
+- required closure row、locked expectation、required、spec link を変更する場合は plan amendment と re-review を先に通す。
+- 各 step の pass 後は `report.md` に evidence を残す。
 
 ## 実装ステップ
 
-### S01 — <observable behavior>
+### S00 — spec readiness
 - observable behavior:
-  - ...
-- design refs:
-  - ...
-- depends on:
-  - ...
-- unblocks:
-  - ...
+  - docs are ready for implementation handoff.
 - target files:
-  - ...
+  - `spec-dock/active/issue/requirement.md`
+  - `spec-dock/active/issue/design.md`
+  - `spec-dock/active/issue/plan.md`
+  - `spec-dock/active/issue/report.md`
 - test bundle:
   - closure ids:
-    - tc-001
-  - test ids:
-    - same as closure ids unless a project explicitly documents separate aliases
+    - SG1 baseline
   - evidence level:
-    - red-required / covered-existing / inspect-only / manual-required
-  - acceptance:
-  - characterization:
-  - property / invariant:
-  - regression:
-  - negative:
-- pre-implementation evidence:
-  - expected red / characterization pass / test sensitivity evidence:
-- report update:
-  - ...
-- notes:
-  - ...
-
-#### step closure contract
-- closure ids:
-  - tc-001
-- close when:
-  - ...
-- verification evidence:
-  - targeted command / manual evidence / inspection evidence:
+    - inspect-only
+- bounded implementation batch:
+  - issue docs only; no provider runtime/docs/skill files.
+- verification command:
+  - `./spec-dock/scripts/spec-dock validate`
 - report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-- residual risk:
-  - ...
+  - spec-review verdict, required fixes, and validate result.
+- close when:
+  - spec-reviewer reports pass or required fixes are applied and re-reviewed.
 
-#### behavior slice execution
-- implementation batch:
-  - allowed scope:
-  - forbidden scope:
-- verification:
-  - targeted command:
-  - related / full command:
-- refactor / tidy:
-  - purpose:
-  - guardrail:
+### S01 — application lifecycle contract and guard
+- observable behavior:
+  - application layer can decide whether `issue start` should proceed, block, or force.
+- design refs:
+  - `design.md` dependency analysis
+  - `design.md` interface contract
+- depends on:
+  - S00
+- unblocks:
+  - S02
+- target files:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py`
+  - wiring file(s) that assemble `UseCases`
+  - targeted tests
+- test bundle:
+  - closure ids:
+    - lc-001
+    - lc-002
+    - lc-003
+    - lc-004
+    - lc-008
+  - evidence level:
+    - red-required
+  - acceptance:
+    - success path delegates to set active with checkout
+    - force path delegates despite unfinished guard
+    - force path does not bypass dependency/readiness checks
+  - negative:
+    - unfinished guard blocks before mutation
+    - non-issue target fails
+  - regression:
+    - active set existing behavior unchanged
+- pre-implementation evidence:
+  - expected red tests for missing lifecycle use case / command path
+- bounded implementation batch:
+  - application contracts and lifecycle orchestration only.
+  - no CLI parser/command registration except wiring needed for callable construction.
+  - no docs/skill wording changes.
+- refactor/tidy guardrails:
+  - reuse existing active, close, GitHub, and branch inference helpers where practical.
+  - do not add persisted lifecycle state.
+  - keep direct `active set` semantics outside this guard.
+- step closure contract:
+  - close when:
+    - targeted lifecycle tests pass and prove no active/checkout mutation on blocked path.
+  - verification evidence:
+    - `python -m unittest tests.cli_runtime.test_issue_lifecycle`
+  - report evidence:
+    - red/green lifecycle test results, mutation-order proof, and force-scope proof.
+  - residual risk:
+    - GitHub unavailable behavior remains stubbed; final runtime tests cover CLI-level behavior.
 
-#### step gate
-- review:
-  - ...
-- expected verification:
-  - ...
-- report update:
-  - ...
+### S02 — CLI `issue start`
+- observable behavior:
+  - `./spec-dock/scripts/spec-dock issue start <target>` is available and action-oriented.
+- depends on:
+  - S01
+- unblocks:
+  - S03
+- target files:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - dogfooding mirror runtime files if checked in
+  - CLI tests
+- test bundle:
+  - closure ids:
+    - lc-001
+    - lc-002
+    - lc-003
+    - lc-004
+  - evidence level:
+    - red-required
+  - acceptance:
+    - parser accepts target forms and `-F` / `--force`
+    - success output includes active and checkout evidence
+  - negative:
+    - blocked output includes next commands
+- pre-implementation evidence:
+  - expected red parser / CLI test before command registration
+- bounded implementation batch:
+  - parser, command wrapper, presentation text, registry/bootstrap wiring, and CLI tests for `issue start`.
+  - no docs/skill wording changes.
+- refactor/tidy guardrails:
+  - do not duplicate target parsing rules if existing command helpers can be reused.
+  - blocked output must stay actionable without committing to destructive recovery.
+- step closure contract:
+  - close when:
+    - CLI tests for start success/block/force/main branch/same issue/non-issue target pass.
+  - verification evidence:
+    - targeted `python -m unittest ...test_issue_lifecycle...`
+  - report evidence:
+    - command parse/output test results and examples of blocked and forced messages.
 
-### Sxx — <next observable behavior>
-- ...
+### S03 — CLI `issue finish`
+- observable behavior:
+  - `./spec-dock/scripts/spec-dock issue finish` closes active linked GitHub issue and clears active after success.
+- depends on:
+  - S01
+- unblocks:
+  - S90
+- target files:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - CLI/application tests
+- test bundle:
+  - closure ids:
+    - lc-005
+    - lc-006
+  - evidence level:
+    - red-required
+  - acceptance:
+    - open issue closes and clears active
+    - already closed clears active
+  - negative:
+    - no active / no GitHub linkage / close failure leaves active unchanged
+- pre-implementation evidence:
+  - expected red tests for missing `issue finish`
+- bounded implementation batch:
+  - finish lifecycle orchestration, command wrapper, presentation text, and finish tests.
+  - no close-node behavior rewrite beyond minimal reusable call integration.
+- refactor/tidy guardrails:
+  - clear active only after close/already-closed success.
+  - if close/status fails, preserve active state and surface recovery guidance.
+- step closure contract:
+  - close when:
+    - finish tests pass and demonstrate clear-active ordering.
+  - verification evidence:
+    - `python -m unittest tests.cli_runtime.test_issue_lifecycle`
+  - report evidence:
+    - finish success/already-closed/failure test results and active-clear ordering proof.
 
 ### S90 — docs impact resolution / docs refresh
 - 対象:
-  - docs / assets / workflow / skill / none
+  - docs / assets / workflow / skill
 - 対応:
-  - ...
+  - update provider docs and dogfooding docs:
+    - `workflow_issue.md`
+    - `reference_github.md`
+    - `reference_naming.md` if checkout wording is touched
+  - update issue execution skill:
+    - `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md`
+  - update checked-in mirror where applicable:
+    - `spec-dock/docs/...`
+    - `spec-dock/scripts/...`
+    - `.agents/skills/...` mirror if present
+- test bundle:
+  - closure ids:
+    - lc-007
+  - evidence level:
+    - inspect-only
+- bounded implementation batch:
+  - provider docs, dogfooding docs, and issue execution skill wording only.
+  - no runtime code/test changes.
+- verification command:
+  - targeted docs grep/inspection plus `./spec-dock/scripts/spec-dock validate`
+- report evidence:
+  - changed docs/skill list and summary of primary-path / manual-recovery wording.
+- step closure contract:
+  - close when:
+    - docs/skill wording states primary path and exclusions clearly.
 
 ### S99 — final diff review quality gate
 - branch diff scope:
-  - ...
+  - all changes from `main...HEAD`
 - required validation:
-  - ...
+  - targeted lifecycle tests
+  - existing active/close regression tests
+  - docs/scaffold tests if assets changed
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync --github`
 - reviewer approvals:
-  - ...
+  - code-reviewer pass
+  - qa-reviewer pass
+  - spec-reviewer final pass
 - report update:
-  - ...
+  - record command evidence, `sync --github` evidence, review verdicts, closure coverage, changed files, residual risks.
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - Implementation may choose helper names and test fixture internals, but must not change closure expectations.
 
 ## final exit contract
 - AC/EC 達成:
-  - ...
+  - lc-001 through lc-008 closed in report.
 - docs impact resolved:
-  - ...
+  - provider + dogfooding docs and skill guidance updated or explicit no-op recorded.
 - final diff approved:
-  - ...
+  - reviewer pass evidence recorded.
 - required closure ids closed:
   - Step Contract Closure:
+    - all required rows pass or approved no-op.
   - Test Contract Closure:
+    - required red/acceptance/negative/regression evidence recorded.
   - Closure Coverage:
+    - every required closure id maps to verification evidence.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/plan.md
@@ -5,7 +5,7 @@ ID: "iss-00088"
 関連GitHub: ["#88"]
 状態: "approved"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-05"
+最終更新: "2026-05-06"
 依存: ["requirement.md", "design.md"]
 親: ["epic-00054", "init-local-00002"]
 ---
@@ -184,7 +184,7 @@ ID: "iss-00088"
 |---|---|---|---|---|---|---|---|---|---|---|
 | lc-001 | S01/S02 | issue start success | acceptance | AC-001 | `issue start <issue>` sets active issue and checks out the issue branch; non-issue targets fail-fast | CLI target issue node; active state; branch | missing guided start / wrong node kind accepted | yes | red-required | CLI/runtime test + report closure |
 | lc-002 | S01/S02 | unfinished guard | negative | AC-002, EC-002 | different issue start from unfinished active issue branch blocks before active/checkout mutation and prints next commands | active issue open/unknown; current branch maps to active issue; target differs; no force | accidental context switch / partial active mutation | yes | red-required | CLI/runtime test + report closure |
-| lc-003 | S01/S02 | force start | acceptance | AC-003 | `-F`/`--force` bypasses only the unfinished issue guard, does not bypass dependency/readiness checks, and shows forced start evidence | same as lc-002 plus force plus dependency-not-ready fixture | force ignored / silent force / dependency bypass leak | yes | red-required | CLI/runtime test + report closure |
+| lc-003 | S01/S02 | force start | acceptance | AC-003 | `-f`/`--force` bypasses only the unfinished issue guard, does not bypass dependency/readiness checks, and shows forced start evidence | same as lc-002 plus force plus dependency-not-ready fixture | force ignored / silent force / dependency bypass leak | yes | red-required | CLI/runtime test + report closure |
 | lc-004 | S01/S02 | safe branch start | regression | AC-004, EC-003 | main/non-issue branch and same issue restart do not trigger unfinished guard | current branch main/non-issue or requested==active issue | overblocking normal/emergency workflows | yes | red-required | CLI/runtime test + report closure |
 | lc-005 | S03 | issue finish success | acceptance | AC-005 | finish closes/already-closed active linked GitHub issue and clears active only after close success | active issue with GitHub link; issue state open/closed | finish does not clear / finish clears before close | yes | red-required | CLI/runtime test + report closure |
 | lc-006 | S03 | issue finish failure | negative | AC-006 | no active, no link, or close/status failure leaves active unchanged and gives recovery guidance | missing active / missing link / gateway error | silent failure / active lost on failure | yes | red-required | CLI/runtime test + report closure |
@@ -322,7 +322,7 @@ ID: "iss-00088"
   - evidence level:
     - red-required
   - acceptance:
-    - parser accepts target forms and `-F` / `--force`
+    - parser accepts target forms and `-f` / `--force`
     - success output includes active and checkout evidence
   - negative:
     - blocked output includes next commands

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
@@ -1,0 +1,94 @@
+---
+種別: 実装報告書（Issue）
+ID: "iss-00088"
+タイトル: "Issue lifecycle start and finish commands"
+関連GitHub: ["#88"]
+状態: "draft | approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-05"
+依存: ["requirement.md", "design.md", "plan.md"]
+親: ["epic-00054", "init-local-00002"]
+---
+
+# iss-00088 Issue lifecycle start and finish commands — 実装報告（LOG）
+
+## 実装サマリー (任意)
+- [実装した内容の概要を2-3文で記載]
+
+## 実装記録（セッションログ） (必須)
+
+### 2026-05-05 HH:MM - HH:MM
+
+#### 対象
+- Step: S01, S02, ...
+- AC/EC: AC-___, EC-___
+
+#### 実施内容
+- ...
+
+#### 実行コマンド / 結果
+```bash
+<command>
+
+<result>
+```
+
+#### Step Contract Closure
+| step | closure ids | close condition | evidence | result | notes |
+|---|---|---|---|---|---|
+| S01 | tc-001 | ... | ... | pass / approved no-op / fail / blocked | ... |
+
+#### Test Contract Closure
+| closure id / test id | step | required | evidence level | pre-implementation evidence | verification command | result | notes |
+|---|---|---|---|---|---|---|---|
+| tc-001 | S01 | yes | red-required | ... | ... | pass / approved no-op / fail / blocked | ... |
+
+- `closure id / test id` は Central index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
+
+#### Closure Coverage
+| closure id | step | verification evidence | result | notes |
+|---|---|---|---|---|
+| tc-001 | S01 | ... | pass / approved no-op / fail / blocked | ... |
+
+#### Closure Delta
+| change | closure id | test id alias | resolves to closure id | reason | re-review required |
+|---|---|---|---|---|---|
+| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no |
+
+#### 変更したファイル
+- `path/to/file1` - ...
+- `path/to/file2` - ...
+
+#### コミット
+- <hash> <message>
+
+#### メモ
+- ...
+
+---
+
+### 2026-05-05 HH:MM - HH:MM
+
+#### 対象
+- Step: ...
+- AC/EC: ...
+
+#### 実施内容
+- ...
+
+---
+
+## 遭遇した問題と解決 (任意)
+- 問題: ...
+  - 解決: ...
+
+## 学んだこと (任意)
+- ...
+- ...
+
+## 今後の推奨事項 (任意)
+- ...
+- ...
+
+## 省略/例外メモ (必須)
+- 該当なし

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
@@ -5,7 +5,7 @@ ID: "iss-00088"
 関連GitHub: ["#88"]
 状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-05"
+最終更新: "2026-05-06"
 依存: ["requirement.md", "design.md", "plan.md"]
 親: ["epic-00054", "init-local-00002"]
 ---
@@ -14,7 +14,7 @@ ID: "iss-00088"
 
 ## 実装サマリー
 - 実装完了。`issue start` / `issue finish` の guided lifecycle command、provider/docs/skill/mirror 更新、targeted tests、full regression、`validate`、`sync --github` を完了した。
-- `issue start -F` は unfinished active issue guard のみを bypass し、dependency/readiness checks は bypass しない契約として実装・テストした。
+- `issue start -f` は unfinished active issue guard のみを bypass し、dependency/readiness checks は bypass しない契約として実装・テストした。
 - `active set` / `active set --checkout` は manual / recovery command として既存 contract を維持した。
 
 ## 実装記録（セッションログ）
@@ -100,8 +100,8 @@ issue: iss-00088 (spec-dock/initiatives/init-local-00002-prototype-feature-expan
 #### 実施内容
 - `spec-dock issue start` / `spec-dock issue finish` command group を追加した。
 - `issue start` は issue node のみを対象にし、active set と checkout を一操作で行う。
-- unfinished active issue branch から別 issue を start する場合、GitHub state が `CLOSED` でない、または確認不能で、`-F` がないときは active mutation / checkout の前に block する。
-- `-F` / `--force` は lifecycle guard だけを bypass し、dependency/readiness check は `set_active(force=False)` として維持した。
+- unfinished active issue branch から別 issue を start する場合、GitHub state が `CLOSED` でない、または確認不能で、`-f` がないときは active mutation / checkout の前に block する。
+- `-f` / `--force` は lifecycle guard だけを bypass し、dependency/readiness check は `set_active(force=False)` として維持した。
 - `main` / `master` / `develop` / `staging` / non-issue branch からの start と same issue restart は block しない。
 - `issue finish` は active issue の linked GitHub issue を close し、already-closed を success として扱い、その成功後だけ active state を clear する。
 - `issue finish` の no active / no GitHub linkage / stale active node / GitHub state or close failure は active state を保持し、recovery guidance と raw reason を表示する。
@@ -142,8 +142,8 @@ python -m unittest discover -v
 # exposes issue start / issue finish
 
 ./spec-dock/scripts/spec-dock issue start --help
-# exposes --id, --github-issue, -F/--force, --gh-limit
-# -F help states dependency readiness checks still apply
+# exposes --id, --github-issue, -f/--force, --gh-limit
+# -f help states dependency readiness checks still apply
 
 ./spec-dock/scripts/spec-dock validate
 # spec-dock: ok (validate) nodes=37
@@ -169,7 +169,7 @@ diff -u src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-executi
 #### Step Contract Closure
 | step | closure ids | close condition | evidence | result | notes |
 |---|---|---|---|---|---|
-| S01 | lc-001, lc-002, lc-003, lc-004, lc-008 | application lifecycle guard and force scope implemented | `tests.cli_runtime.test_issue_lifecycle` pass | pass | `-F` does not bypass dependency guard |
+| S01 | lc-001, lc-002, lc-003, lc-004, lc-008 | application lifecycle guard and force scope implemented | `tests.cli_runtime.test_issue_lifecycle` pass | pass | `-f` does not bypass dependency guard |
 | S02 | lc-001, lc-002, lc-003, lc-004 | CLI `issue start` parser/output/action paths implemented | CLI help + lifecycle tests pass | pass | block message includes recovery commands |
 | S03 | lc-005, lc-006 | CLI `issue finish` close/clear ordering implemented | finish tests pass | pass | failure paths leave active unchanged |
 | S90 | lc-007 | docs/skill primary path updated and mirrored | docs/skill grep + mirror diffs clean | pass | `active set` documented as manual/recovery |
@@ -262,21 +262,42 @@ diff -u src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-executi
   - QA-reviewer pass: no P0/P1; P2 stale `workflow-tree.md` guidance was addressed after review.
   - final spec re-review pass: S99 `pending-review` contradiction resolved; no P0/P1 blockers remain.
   - spec-review P1 docs findings were resolved by documenting `issue start` / `issue finish` in root `README.md`, removing the skill contradiction that required active state after finish, and aligning `workflow_issue.md` completion wording with active clear.
+- Manual test:
+  - report directory: `manual-tests/reports/2026-05-05-iss-00088-issue-lifecycle/`
+  - workspace: `manual-tests/workspaces/2026-05-05-iss-00088-issue-lifecycle/repo`
+  - GitHub repo: `chemitaro/spec-dock-manual-iss-00088-lifecycle`
+  - verdict: pass
+  - covered real GitHub-backed `issue start`, unfinished branch guard, `-f` dependency readiness preservation, direct `active set --checkout` manual/recovery boundary, non-issue branch start, `issue finish` close+active clear, already-closed finish, and recovery guidance with active preservation.
+  - final health: `validate` ok (`nodes=7`), `sync --github` ok, `doctor` ok (`findings=0`), and all temporary GitHub issues were closed.
+  - operational observation: after `issue finish`, the current Git branch remains on the issue branch; running `sync --github` there can restore active from the branch name, so final cleanup should switch to `main` or another non-issue branch before sync when active should remain clear.
 
 ## 遭遇した問題と解決
+- 2026-05-06 force short option correction:
+  - user feedback により、`issue start` の unfinished active issue guard bypass short option を uppercase `-F` ではなく lowercase `-f` に修正した。
+  - long option `--force` は維持した。
+  - `active set --force` / `sync --force` など他 command の force contract は変更していない。
+  - block/recovery message、provider runtime、dogfooding runtime mirror、provider/dogfooding docs、root README、issue execution skill、tests、issue docs を `-f` に揃えた。
+  - verification:
+    - `./spec-dock/scripts/spec-dock issue start --help`: `-f, --force` を表示。
+    - `python -m unittest tests.cli_runtime.test_issue_lifecycle -v`: pass (`Ran 15 tests ... OK`)。
+    - `./spec-dock/scripts/spec-dock validate`: pass (`nodes=37`)。
+    - provider/dogfooding runtime mirror for `commands/issue.py` and `application/issue_lifecycle.py`: `cmp -s` pass。
+    - `git diff --check`: pass。
+  - old short options `-F` and accidental `-t` are rejected by lifecycle CLI regression test.
 - 2026-05-05 SG1 spec review は fail:
-  - `-F` の scope が dependency/readiness bypass と読める設計記述になっていた。
+  - `-f` の scope が dependency/readiness bypass と読める設計記述になっていた。
   - S99 final gate に `sync --github` evidence が不足していた。
   - S01-S03 に step-local の bounded implementation batch / verification / report evidence が不足していた。
   - S00 が lc-007 docs closure を先取りしており、S90 の docs closure と混同しやすかった。
 - 解決:
-  - `-F` を unfinished active issue guard 専用とし、dependency/readiness check は bypass しない契約へ修正した。
+  - `-f` を unfinished active issue guard 専用とし、dependency/readiness check は bypass しない契約へ修正した。
   - S99 に `./spec-dock/scripts/spec-dock sync --github` と report evidence を追加した。
   - S00-S03/S90 に bounded implementation batch、verification command、report evidence、refactor guardrails を補足した。
   - S00 は SG1 baseline として扱い、lc-007 は S90/S99 の docs/skill closure に限定した。
 
 ## 学んだこと
 - `issue finish` の completion source は local lifecycle flag ではなく GitHub `CLOSED` state として固定した。
+- 実運用では `issue finish` 後も Git branch 自体は issue branch のままなので、その状態で `sync --github` を走らせると branch 名から active が復元されうる。active clear を保ちたい終了手順では、`main` など non-issue branch へ移動してから final sync するのが安全。
 
 ## 今後の推奨事項
 - 追加の Phase 2 として force reason / audit schema、finish 前の delivery gate 連携、PR/merge automation を検討する場合は、別 issue で要件化してから実装する。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
@@ -3,7 +3,7 @@
 ID: "iss-00088"
 タイトル: "Issue lifecycle start and finish commands"
 関連GitHub: ["#88"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-05"
 依存: ["requirement.md", "design.md", "plan.md"]
@@ -12,83 +12,275 @@ ID: "iss-00088"
 
 # iss-00088 Issue lifecycle start and finish commands — 実装報告（LOG）
 
-## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+## 実装サマリー
+- 実装完了。`issue start` / `issue finish` の guided lifecycle command、provider/docs/skill/mirror 更新、targeted tests、full regression、`validate`、`sync --github` を完了した。
+- `issue start -F` は unfinished active issue guard のみを bypass し、dependency/readiness checks は bypass しない契約として実装・テストした。
+- `active set` / `active set --checkout` は manual / recovery command として既存 contract を維持した。
 
-## 実装記録（セッションログ） (必須)
+## 実装記録（セッションログ）
 
-### 2026-05-05 HH:MM - HH:MM
+### 2026-05-05 spec authoring
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
+- Step: S00
+- AC/EC:
+  - SG1 baseline
 
 #### 実施内容
-- ...
+- `spec-dock/active/issue/requirement.md` を確認し、`issue start` / `issue finish` Phase 1 の目的、scope、acceptance criteria、edge cases を確認した。
+- `spec-dock/active/issue/design.md` を scaffold から issue 固有の設計へ更新した。
+- `spec-dock/active/issue/plan.md` を scaffold から Spec-Locked Closure Index 付きの execution contract へ更新した。
+- `spec-dock/active/issue/report.md` を本 issue 固有の execution log として初期化した。
 
 #### 実行コマンド / 結果
 ```bash
-<command>
+pwd && git branch --show-current && git status --short && ./spec-dock/scripts/spec-dock active show
 
-<result>
+/Users/iwasawayuuta/workspace/tools/spec-dock
+iss-00088-issue-lifecycle-start-and-finish-commands
+initiative: init-local-00002 (spec-dock/initiatives/init-local-00002-prototype-feature-expansion)
+epic: epic-00054 (spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion)
+issue: iss-00088 (spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands)
 ```
 
 #### Step Contract Closure
 | step | closure ids | close condition | evidence | result | notes |
 |---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved no-op / fail / blocked | ... |
+| S00 | SG1 baseline | issue docs are implementation-ready after spec review | spec-reviewer pass after P1 fixes | pass | ready for implementation |
 
 #### Test Contract Closure
 | closure id / test id | step | required | evidence level | pre-implementation evidence | verification command | result | notes |
 |---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required | ... | ... | pass / approved no-op / fail / blocked | ... |
-
-- `closure id / test id` は Central index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
+| SG1 baseline | S00 | yes | inspect-only | N/A | spec-reviewer pass | pass | docs/skill implementation still pending |
 
 #### Closure Coverage
 | closure id | step | verification evidence | result | notes |
 |---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved no-op / fail / blocked | ... |
+| SG1 baseline | S00 | design/plan/report authored and re-reviewed | pass | implementation handoff approved |
 
 #### Closure Delta
 | change | closure id | test id alias | resolves to closure id | reason | re-review required |
 |---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no |
+| none | lc-007 | lc-007 | lc-007 | initial contract | yes |
 
 #### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
+- `spec-dock/active/issue/design.md` - issue-specific design
+- `spec-dock/active/issue/plan.md` - issue-specific execution contract
+- `spec-dock/active/issue/report.md` - initial report evidence
 
 #### コミット
-- <hash> <message>
+- 未実施
 
 #### メモ
-- ...
+- Implementation must not begin until SG1 spec review passes.
 
----
-
-### 2026-05-05 HH:MM - HH:MM
+### 2026-05-05 implementation and verification
 
 #### 対象
-- Step: ...
-- AC/EC: ...
+- Steps:
+  - S01 application lifecycle contract and guard
+  - S02 CLI `issue start`
+  - S03 CLI `issue finish`
+  - S90 docs impact resolution / docs refresh
+  - S99 final diff review quality gate
+- AC/EC:
+  - AC-001
+  - AC-002
+  - AC-003
+  - AC-004
+  - AC-005
+  - AC-006
+  - AC-007
+  - EC-001
+  - EC-002
+  - EC-003
+  - EC-004
+  - EC-005
 
 #### 実施内容
-- ...
+- `spec-dock issue start` / `spec-dock issue finish` command group を追加した。
+- `issue start` は issue node のみを対象にし、active set と checkout を一操作で行う。
+- unfinished active issue branch から別 issue を start する場合、GitHub state が `CLOSED` でない、または確認不能で、`-F` がないときは active mutation / checkout の前に block する。
+- `-F` / `--force` は lifecycle guard だけを bypass し、dependency/readiness check は `set_active(force=False)` として維持した。
+- `main` / `master` / `develop` / `staging` / non-issue branch からの start と same issue restart は block しない。
+- `issue finish` は active issue の linked GitHub issue を close し、already-closed を success として扱い、その成功後だけ active state を clear する。
+- `issue finish` の no active / no GitHub linkage / stale active node / GitHub state or close failure は active state を保持し、recovery guidance と raw reason を表示する。
+- `issue finish` は lifecycle closure のみであり、commit / push / PR / merge / validate / test / review completion を保証しないことを docs/skill に明記した。
+- provider runtime と dogfooding runtime mirror、provider docs と dogfooding docs、provider skill と checked-in skill mirror を同期した。
+- checked-in dogfooding `iss-00088` の `.meta.json` 追加に合わせ、cutover snapshot test constants を更新した。
 
----
+#### 実行コマンド / 結果
+```bash
+python -m unittest tests.cli_runtime.test_issue_lifecycle
+# Ran 14 tests in 15.322s
+# OK
 
-## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
+python -m unittest tests.cli_runtime.test_close tests.cli_runtime.test_active
+# Ran 40 tests in 24.645s
+# OK
 
-## 学んだこと (任意)
-- ...
-- ...
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_subprocess_validate_and_sync_on_cutover_snapshot tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_subprocess_deps_mutation_on_cutover_snapshot
+# Ran 3 tests in 1.043s
+# OK
 
-## 今後の推奨事項 (任意)
-- ...
-- ...
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_surface_includes_doctor_and_explicit_target_hint
+# Ran 2 tests in 0.158s
+# OK
 
-## 省略/例外メモ (必須)
-- 該当なし
+python -m unittest tests.test_init_update.TestInitUpdate.test_workflow_issue_doc_matches_bundled_asset tests.test_init_update.TestInitUpdate.test_current_guidance_documents_match_discussion_numbering_contract tests.cli_runtime.test_wrappers.TestCliRulesContract.test_scaffold_docs_point_to_runtime_commands_and_rules_docs
+# Ran 3 tests in 0.090s
+# OK
+
+python -m compileall -q src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime tests/cli_runtime/test_issue_lifecycle.py
+# exit 0
+
+python -m unittest discover -v
+# Ran 762 tests in 222.915s
+# OK
+
+./spec-dock/scripts/spec-dock issue --help
+# exposes issue start / issue finish
+
+./spec-dock/scripts/spec-dock issue start --help
+# exposes --id, --github-issue, -F/--force, --gh-limit
+# -F help states dependency readiness checks still apply
+
+./spec-dock/scripts/spec-dock validate
+# spec-dock: ok (validate) nodes=37
+
+./spec-dock/scripts/spec-dock sync --github
+# spec-dock: sync: active unchanged (matched id in branch: iss-00088)
+# spec-dock: ok (sync) wrote=spec-dock/.agent/index-all.json,...
+
+git diff --check
+# no output
+
+diff -ru -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime
+# no output
+
+diff -u src/spec_dock/assets/spec_dock/docs/workflow_issue.md spec-dock/docs/workflow_issue.md
+diff -u src/spec_dock/assets/spec_dock/docs/workflow-tree.md spec-dock/docs/workflow-tree.md
+diff -u src/spec_dock/assets/spec_dock/docs/reference_github.md spec-dock/docs/reference_github.md
+diff -u src/spec_dock/assets/spec_dock/docs/reference_naming.md spec-dock/docs/reference_naming.md
+diff -u src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md .agents/skills/spec-dock-issue-execution/SKILL.md
+# no output
+```
+
+#### Step Contract Closure
+| step | closure ids | close condition | evidence | result | notes |
+|---|---|---|---|---|---|
+| S01 | lc-001, lc-002, lc-003, lc-004, lc-008 | application lifecycle guard and force scope implemented | `tests.cli_runtime.test_issue_lifecycle` pass | pass | `-F` does not bypass dependency guard |
+| S02 | lc-001, lc-002, lc-003, lc-004 | CLI `issue start` parser/output/action paths implemented | CLI help + lifecycle tests pass | pass | block message includes recovery commands |
+| S03 | lc-005, lc-006 | CLI `issue finish` close/clear ordering implemented | finish tests pass | pass | failure paths leave active unchanged |
+| S90 | lc-007 | docs/skill primary path updated and mirrored | docs/skill grep + mirror diffs clean | pass | `active set` documented as manual/recovery |
+| S99 | lc-001..lc-008 | final validation, sync, parity, and regression pass | full suite, validate, sync, parity checks, spec/code/QA review pass | pass | final review gate closed; QA P2 workflow-tree follow-up resolved |
+
+#### Test Contract Closure
+| closure id / test id | step | required | evidence level | pre-implementation evidence | verification command | result | notes |
+|---|---|---|---|---|---|---|---|
+| lc-001 | S01/S02 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | start sets active and checks out issue branch |
+| lc-002 | S01/S02 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | open/unknown unfinished guard blocks before mutation |
+| lc-003 | S01/S02 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | force bypasses lifecycle guard only, dependency guard still blocks |
+| lc-004 | S01/S02 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | main branch and same issue restart do not block |
+| lc-005 | S03 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | close/already-closed success clears active |
+| lc-006 | S03 | yes | red-required | command/use case absent before implementation | `python -m unittest tests.cli_runtime.test_issue_lifecycle` | pass | no active/no link/close failure leave active unchanged |
+| lc-007 | S90 | yes | inspect-only | docs/skill did not name lifecycle commands as primary path | docs grep + provider/mirror diffs | pass | workflow/reference/skill updated |
+| lc-008 | S99 | yes | covered-existing | active set regression suite existed | `python -m unittest tests.cli_runtime.test_close tests.cli_runtime.test_active` and full suite | pass | direct active set contract unchanged |
+
+#### Closure Coverage
+| closure id | step | verification evidence | result | notes |
+|---|---|---|---|---|
+| lc-001 | S01/S02 | lifecycle tests, CLI help, full suite | pass | issue-only target and checkout covered |
+| lc-002 | S01/S02 | lifecycle block test | pass | no active file / branch mutation on block |
+| lc-003 | S01/S02 | force + dependency-not-ready test | pass | force scope constrained |
+| lc-004 | S01/S02 | main branch / same issue restart test | pass | emergency/non-issue branch work remains possible |
+| lc-005 | S03 | finish open/already-closed tests | pass | active clear after success |
+| lc-006 | S03 | finish failure tests | pass | active unchanged on failures; recovery guidance asserted for missing link, stale node, state failure, and close failure |
+| lc-007 | S90 | docs/skill/README/workflow update and mirror diff | pass | primary path wording and delivery non-guarantee present; delivery completion is before `issue finish` |
+| lc-008 | S99 | active/close/lifecycle regression and full suite | pass | direct active set bypass test confirms guard did not leak into `active set` |
+
+#### 変更したファイル
+- `.agents/skills/spec-dock-issue-execution/SKILL.md`
+- `README.md`
+- `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md`
+- `src/spec_dock/assets/spec_dock/docs/README.md`
+- `src/spec_dock/assets/spec_dock/docs/guide.md`
+- `src/spec_dock/assets/spec_dock/docs/github.md`
+- `src/spec_dock/assets/spec_dock/docs/workflow_issue.md`
+- `src/spec_dock/assets/spec_dock/docs/workflow-tree.md`
+- `src/spec_dock/assets/spec_dock/docs/reference_github.md`
+- `src/spec_dock/assets/spec_dock/docs/reference_naming.md`
+- `spec-dock/docs/README.md`
+- `spec-dock/docs/guide.md`
+- `spec-dock/docs/github.md`
+- `spec-dock/docs/workflow_issue.md`
+- `spec-dock/docs/workflow-tree.md`
+- `spec-dock/docs/reference_github.md`
+- `spec-dock/docs/reference_naming.md`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+- `spec-dock/scripts/spec_dock_runtime/application/contracts.py`
+- `spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py`
+- `spec-dock/scripts/spec_dock_runtime/commands/issue.py`
+- `spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+- `spec-dock/scripts/spec_dock_runtime/cli/parser.py`
+- `spec-dock/scripts/spec_dock_runtime/cli/registry.py`
+- `spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+- `tests/cli_runtime/test_issue_lifecycle.py`
+- `tests/test_init_update.py`
+- `spec-dock/active/issue/design.md`
+- `spec-dock/active/issue/plan.md`
+- `spec-dock/active/issue/report.md`
+
+#### コミット
+- 未実施
+
+#### メモ
+- `compileall` 実行により `__pycache__` が生成されたが、git status には出ない ignored artifact である。runtime mirror parity は `-x __pycache__` を付けて source file 同士で確認した。
+- `sync --github` は generated state を更新したが、tracked diff は発生しなかった。
+- QA/spec/code review findings after implementation passes were resolved:
+  - report final closure evidence was added.
+  - finish failure recovery guidance was added and tested.
+  - UNKNOWN GitHub state blocking and arbitrary non-issue branch start were added to lifecycle tests.
+  - docs/skill now state that `issue finish` does not guarantee delivery completion.
+  - entry docs (`README.md`, `guide.md`, `github.md`) now point normal issue execution at `issue start` / `issue finish`.
+  - `issue start` allows switching from a completed active issue branch when GitHub state is `CLOSED`.
+  - `issue finish` clear-active failure now includes recovery guidance after remote close success.
+  - design/report/reference naming ambiguity around `issue start --github` was removed; `issue start` remains issue-only and has no Phase 1 `--github` opt-in.
+  - QA P2/P3 coverage findings were resolved by adding `test_direct_active_set_checkout_bypasses_issue_lifecycle_guard` and asserting no-active finish recovery guidance.
+  - code-review P2 mirror-parity finding was resolved by adding lifecycle runtime files to the checked-in provider/mirror parity test map.
+  - spec-review P1 docs findings were resolved by documenting `issue start` / `issue finish` in root `README.md`, removing the skill contradiction that required active state after finish, and aligning `workflow_issue.md` completion wording with active clear.
+  - final QA P2 stale `workflow-tree.md` guidance was resolved by making `issue start` / `issue finish` the primary lifecycle path and demoting `active set` to manual/recovery/no-checkout guidance in provider and dogfooding docs.
+- Final review gate:
+  - spec-reviewer pass: no P0/P1 specification blockers or material cross-artifact contradictions.
+  - code-reviewer pass: no findings; guarded start, direct active set separation, force scope, unknown-state fail-closed handling, finish recovery paths, and mirror parity coverage reviewed.
+  - QA-reviewer pass: no P0/P1; P2 stale `workflow-tree.md` guidance was addressed after review.
+  - final spec re-review pass: S99 `pending-review` contradiction resolved; no P0/P1 blockers remain.
+  - spec-review P1 docs findings were resolved by documenting `issue start` / `issue finish` in root `README.md`, removing the skill contradiction that required active state after finish, and aligning `workflow_issue.md` completion wording with active clear.
+
+## 遭遇した問題と解決
+- 2026-05-05 SG1 spec review は fail:
+  - `-F` の scope が dependency/readiness bypass と読める設計記述になっていた。
+  - S99 final gate に `sync --github` evidence が不足していた。
+  - S01-S03 に step-local の bounded implementation batch / verification / report evidence が不足していた。
+  - S00 が lc-007 docs closure を先取りしており、S90 の docs closure と混同しやすかった。
+- 解決:
+  - `-F` を unfinished active issue guard 専用とし、dependency/readiness check は bypass しない契約へ修正した。
+  - S99 に `./spec-dock/scripts/spec-dock sync --github` と report evidence を追加した。
+  - S00-S03/S90 に bounded implementation batch、verification command、report evidence、refactor guardrails を補足した。
+  - S00 は SG1 baseline として扱い、lc-007 は S90/S99 の docs/skill closure に限定した。
+
+## 学んだこと
+- `issue finish` の completion source は local lifecycle flag ではなく GitHub `CLOSED` state として固定した。
+
+## 今後の推奨事項
+- 追加の Phase 2 として force reason / audit schema、finish 前の delivery gate 連携、PR/merge automation を検討する場合は、別 issue で要件化してから実装する。
+
+## 省略/例外メモ
+- commit / push / PR / merge / GitHub issue close は本実装作業では未実施。`issue finish` は lifecycle closure command として実装済みだが、この issue 自体の完了処理としては実行していない。
+- `issue finish` は delivery completion を保証しないため、delivery completion は本 report の tests / reviews / validate / sync evidence で閉じる。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/report.md
@@ -272,6 +272,27 @@ diff -u src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-executi
   - operational observation: after `issue finish`, the current Git branch remains on the issue branch; running `sync --github` there can restore active from the branch name, so final cleanup should switch to `main` or another non-issue branch before sync when active should remain clear.
 
 ## 遭遇した問題と解決
+- 2026-05-07 skill external review and remediation:
+  - consultant verdict: conditional_pass.
+    - finding: skill reminder should state that `issue start -f` / `--force` does not bypass dependency readiness, target validation, or checkout safety.
+    - finding: workflow command block should visually separate primary lifecycle and manual / recovery commands.
+    - finding: `issue finish` naming can be misread as delivery completion; skill already mitigates this but should keep the warning prominent.
+  - QA-reviewer verdict: pass with P2 findings.
+    - finding: skill did not yet warn that `sync --github` on a just-finished issue branch can restore active from branch-derived context.
+    - finding: automated regression did not yet cover the primary CLI path `issue start` -> `issue finish` in one scenario.
+  - spec-reviewer verdict: fail with P1.
+    - finding: shipped provider skill at `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md` still documented old `issue start -F` while dogfooding mirror used `-f`.
+  - remediation:
+    - provider skill and dogfooding mirror skill now both document `issue start -f` / `--force`.
+    - skill now states that `-f` / `--force` bypasses only the unfinished active issue guard and does not bypass dependency readiness, target validation, or checkout safety.
+    - skill and workflow now warn that post-finish `sync --github` on the issue branch can restore active; final sync should move to `main` or another non-issue branch first, or be skipped after finish.
+    - workflow command block now separates `# primary lifecycle` from `# manual / recovery only`.
+    - added `test_issue_start_then_finish_closes_open_issue_and_clears_active` to cover the skill's primary lifecycle path.
+  - verification:
+    - provider skill / dogfooding mirror skill: `cmp -s` pass.
+    - provider workflow / dogfooding workflow: `cmp -s` pass.
+    - targeted grep found no stale `issue start -F` or accidental `issue start -t` guidance outside historical/report context.
+    - `python -m unittest tests.cli_runtime.test_issue_lifecycle -v`: pass (`Ran 16 tests ... OK`).
 - 2026-05-06 force short option correction:
   - user feedback により、`issue start` の unfinished active issue guard bypass short option を uppercase `-F` ではなく lowercase `-f` に修正した。
   - long option `--force` は維持した。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/requirement.md
@@ -1,0 +1,291 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00088"
+タイトル: "Issue lifecycle start and finish commands"
+関連GitHub: ["#88"]
+状態: "draft"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-05"
+親: ["epic-00054", "init-local-00002"]
+---
+
+# iss-00088 Issue lifecycle start and finish commands — 要件定義（WHAT / WHY）
+
+## 目的
+- 通常の issue 実行入口として `spec-dock issue start` / `spec-dock issue finish` を追加し、agent と maintainer が active issue と checkout を明確な lifecycle 操作として扱えるようにする。
+- 手動・復旧用の `active set` は維持しつつ、未完了 issue branch から別 issue を開始する accident path だけを guided command 側で止める。
+- Phase 1 として main / protected branch の hard block ではなく、作業性を保つ soft guardrail と明確な次アクション提示を導入する。
+
+## 背景・現状
+- 現状の挙動:
+  - `active set` は active pointer を設定でき、`--checkout` を明示した場合だけ branch 作成または checkout を行う。
+  - `close` は linked GitHub issue を close できるが、active issue lifecycle の終了導線とは結びついていない。
+  - `active set` / `close` は低レベル操作として存在する一方、通常の issue 実行を「開始」と「終了」で表す command surface はない。
+- 現状の課題:
+  - 複数 issue にまたがる agent 作業で、active issue を固定せず、checkout せず、issue close もしないまま長大な変更に進む余地がある。
+  - `active set --checkout` を通常開始手順として毎回思い出す必要があり、agent 向けの primary path と手動復旧 path が混ざっている。
+  - 強い main branch 制限を先に入れると、非常時対応や手動復旧の作業性を落とす。
+  - 未完了 issue branch から別 issue へ移る場合に、何が危険で、どう続行または中断すべきかを CLI が説明しない。
+- 再現手順:
+  1. issue branch 上で active issue の作業を進める。
+  2. GitHub issue を close していない状態で、別 issue の作業へ移ろうとする。
+  3. 現状は通常開始 command がないため、agent は `active set` を省略したり、別 branch へ移る判断を曖昧にしたまま作業を続けられる。
+- 観測点:
+  - CLI:
+    - `./spec-dock/scripts/spec-dock active set <target> --checkout`
+    - `./spec-dock/scripts/spec-dock close <target>`
+    - 新規 `./spec-dock/scripts/spec-dock issue start <target>`
+    - 新規 `./spec-dock/scripts/spec-dock issue finish`
+  - Git:
+    - current branch が registered issue branch として認識されるか
+  - GitHub:
+    - active issue の linked GitHub issue state が `CLOSED` かどうか
+  - Docs / skills:
+    - issue execution workflow と agent skill が `issue start` / `issue finish` を primary path として案内するか
+- 情報源:
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/reference_github.md`
+  - `spec-dock/docs/reference_naming.md`
+  - `spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/requirement.md`
+  - 2026-05-05 lifecycle command planning discussion
+
+## 対象ユーザー / 利用シナリオ
+- 主な利用者:
+  - issue 単位で spec-dock 作業を進める maintainer
+  - active issue docs を入口に実装する coding agent / orchestrator
+  - 非常時や復旧時に低レベル `active set` も使いたい maintainer
+- 代表シナリオ:
+  - maintainer が `issue start iss-00088` を実行し、active issue 設定と branch checkout を一操作で完了する。
+  - agent が未完了 active issue branch 上で別 issue を start しようとして止められ、`issue finish` または `issue start <target> -F` のどちらを実行すべきか理解できる。
+  - maintainer が `issue finish` を実行し、active issue の GitHub issue を close したうえで active state を解除する。
+  - 手動復旧時は従来通り `active set` / `active set --checkout` を制限なく使える。
+
+## スコープ
+- MUST:
+  - `spec-dock issue start <target>` を追加し、issue node のみを対象に active set と checkout を実行できること
+  - `spec-dock issue start <target> -F` / `--force` を追加し、unfinished active issue guard を明示的に bypass できること
+  - `spec-dock issue finish` を追加し、current active issue の linked GitHub issue を close または already-closed success として扱い、その後 active state を解除できること
+  - `issue start` は active issue branch 上で別 issue を開始しようとする場合、active issue の GitHub state が `CLOSED` でない限り default stop すること
+  - `issue start` の default stop message は current active issue、current branch、requested issue、GitHub state、次に実行できる command を表示すること
+  - `active set` / `active set --checkout` の既存挙動を変えず、manual / recovery path として残すこと
+  - provider docs / dogfooding docs / issue execution skill / CLI help を `issue start` / `issue finish` の primary path に揃えること
+- MUST NOT:
+  - Phase 1 で main / master / develop / staging などの branch からの `issue start` を禁止しない
+  - Phase 1 で dirty worktree を spec-dock 独自の hard block 条件にしない
+  - `issue finish` で commit、push、merge、PR 作成、stash、report 自動編集を行わない
+  - `active set` / `active set --checkout` に unfinished active issue guard を追加しない
+  - `-F` / `--force` に理由入力を必須化しない
+- OUT OF SCOPE:
+  - PR 作成、PR monitoring、merge automation
+  - protected branch policy enforcement
+  - issue completion criteria の完全自動判定
+  - incident mode / reason-required audit schema
+  - local delete command の追加または変更
+
+## 境界
+- Always:
+  - `issue start` は通常 issue execution の guided path として扱う
+  - `active set` は低レベルの手動・復旧・migration・explicit user instruction path として扱う
+  - unfinished 判定の正本は linked GitHub issue の `CLOSED` state とする
+  - GitHub state を確認できない場合は安全側に倒し、unfinished として扱う
+  - `issue finish` は GitHub issue close / already-closed 確認が成功した場合だけ active state を解除する
+- Ask:
+  - Phase 2 以降で `--reason` を任意または必須にするか
+  - Phase 2 以降で `issue finish` に validate / sync / report evidence check を追加するか
+- Never:
+  - `issue finish` を merge / deploy / review complete と同義にしない
+  - force bypass を silent success にしない
+  - manual recovery path を塞がない
+
+## 非交渉制約
+- additive command change とし、既存 `active set`、`close`、`sync`、`validate`、`deps` の contract を壊さないこと
+- command runtime の source of truth は provider-side `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/` とすること
+- shipped docs/templates/system を変更する場合は provider-side assets と dogfooding mirror の整合を取ること
+- branch checkout naming は既存 `active set --checkout` の `<id>-<slug>` 正規化 contract に従うこと
+- GitHub issue state の取得と close は既存 GitHub CLI integration の repo scope / current repo linkage contract に従うこと
+
+## 前提
+- 本 issue は `epic-00054` の GitHub lifecycle command expansion の追加 slice として扱う。
+- `close` command は既に linked GitHub issue close の低レベル capability を提供している。
+- `issue finish` は `close` capability を active issue lifecycle の終了導線として再利用する。
+- `issue start` の checkout は既存 active set checkout behavior を再利用し、独自 branch naming を導入しない。
+- `-F` / `--force` の理由入力は Phase 1 では要求しない。
+
+## 受け入れ条件
+- AC-001:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - linked GitHub issue を持つ issue node が存在する
+  - When:
+    - `./spec-dock/scripts/spec-dock issue start <target>` を実行する
+  - Then:
+    - 対象 issue が active issue になる
+    - 対象 issue の branch が checkout される
+    - 対象が issue node でない場合は fail-fast する
+  - 観測点:
+    - CLI / runtime tests
+    - `spec-dock/.agent/active.json`
+    - current branch
+- AC-002:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - current branch が active issue branch として認識される
+    - active issue の linked GitHub issue state が `CLOSED` ではない
+    - requested issue が active issue と異なる
+  - When:
+    - `./spec-dock/scripts/spec-dock issue start <requested>` を `-F` なしで実行する
+  - Then:
+    - command は停止する
+    - active state は変更されない
+    - checkout は行われない
+    - message に current active issue、current branch、requested issue、GitHub state、`issue finish`、`issue start <requested> -F`、manual `active set` の導線が表示される
+  - 観測点:
+    - CLI / runtime tests
+    - active state unchanged assertion
+    - git checkout not called assertion
+- AC-003:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - AC-002 と同じ unfinished active issue branch 状態
+  - When:
+    - `./spec-dock/scripts/spec-dock issue start <requested> -F` を実行する
+  - Then:
+    - guard は bypass される
+    - requested issue が active issue になる
+    - requested issue branch が checkout される
+    - output に forced start であることが表示される
+  - 観測点:
+    - CLI / runtime tests
+    - active state
+    - current branch
+- AC-004:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - current branch が `main` / `master` / `develop` / `staging` または registered issue branch と認識されない branch である
+  - When:
+    - `./spec-dock/scripts/spec-dock issue start <target>` を実行する
+  - Then:
+    - unfinished active issue guard は発火しない
+    - 通常の target resolution / deps / checkout の結果に従って start が進む
+  - 観測点:
+    - CLI / runtime tests
+- AC-005:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - active issue が linked GitHub issue を持つ
+  - When:
+    - `./spec-dock/scripts/spec-dock issue finish` を実行する
+  - Then:
+    - linked GitHub issue が open の場合は close される
+    - linked GitHub issue が already closed の場合は success として扱われる
+    - close / already-closed 確認後に active state が解除される
+  - 観測点:
+    - CLI / runtime tests
+    - GitHub issue state
+    - `spec-dock/.agent/active.json` または active show
+- AC-006:
+  - Actor:
+    - maintainer / coding agent
+  - Given:
+    - active issue が存在しない、または active issue が GitHub issue に linked されていない、または GitHub close / state 確認が失敗する
+  - When:
+    - `./spec-dock/scripts/spec-dock issue finish` を実行する
+  - Then:
+    - command は fail-fast する
+    - active state は変更されない
+    - 次に取るべき復旧 action が表示される
+  - 観測点:
+    - CLI / runtime tests
+    - active state unchanged assertion
+- AC-007:
+  - Actor:
+    - reviewer
+  - Given:
+    - provider docs、dogfooding docs、agent skill、CLI help を確認する
+  - When:
+    - issue execution の通常導線を読む
+  - Then:
+    - `issue start` -> 実装 -> 検証 / report -> `issue finish` が primary path として説明されている
+    - `active set` は manual / recovery path として説明されている
+    - `issue finish` が merge / PR / commit / validate success を保証しないことが明記されている
+  - 観測点:
+    - docs / skill diff
+    - tests where applicable
+
+## 例外・エッジケース
+- EC-001:
+  - 条件:
+    - requested target が initiative / epic node である
+  - 期待:
+    - `issue start` は issue node のみを許可し、対象種別不一致で fail-fast する
+  - 観測点:
+    - CLI / runtime tests
+- EC-002:
+  - 条件:
+    - active issue の GitHub state を取得できない
+  - 期待:
+    - `issue start` は unfinished として default stop し、`-F` による続行導線を表示する
+  - 観測点:
+    - CLI / runtime tests
+- EC-003:
+  - 条件:
+    - active issue と requested issue が同じである
+  - 期待:
+    - `issue start` は idempotent に進む、または already active として success を返す
+  - 観測点:
+    - CLI / runtime tests
+- EC-004:
+  - 条件:
+    - checkout 時に git worktree dirty など既存 `active set --checkout` の safety guard が失敗する
+  - 期待:
+    - `issue start` は既存 checkout failure を伝え、active state と checkout を中途半端に進めない
+  - 観測点:
+    - CLI / runtime tests
+- EC-005:
+  - 条件:
+    - `active set` / `active set --checkout` を直接実行する
+  - 期待:
+    - unfinished active issue guard は適用されず、既存 command contract が維持される
+  - 観測点:
+    - regression tests
+
+## 入力→出力例
+- EX-001:
+  - Input:
+    - `./spec-dock/scripts/spec-dock issue start iss-00088`
+  - Output:
+    - active issue が `iss-00088` になり、branch `iss-00088-issue-lifecycle-start-and-finish-commands` が checkout される
+- EX-002:
+  - Input:
+    - `./spec-dock/scripts/spec-dock issue start iss-00089`
+  - Output:
+    - `Cannot start iss-00089 because active issue iss-00088 is not closed.`
+    - `Run ./spec-dock/scripts/spec-dock issue finish or ./spec-dock/scripts/spec-dock issue start iss-00089 -F.`
+- EX-003:
+  - Input:
+    - `./spec-dock/scripts/spec-dock issue finish`
+  - Output:
+    - active issue の linked GitHub issue が close され、active state が解除される
+
+## 用語（ドメイン語彙）
+- TERM-001:
+  - issue start:
+    - issue node を active にし、対応 branch を checkout する通常開始 command
+- TERM-002:
+  - issue finish:
+    - current active issue の linked GitHub issue を close / already-closed 確認し、active state を解除する通常終了 command
+- TERM-003:
+  - unfinished active issue:
+    - current active issue の linked GitHub issue state が `CLOSED` と確認できない状態
+- TERM-004:
+  - registered issue branch:
+    - spec-dock graph 内の issue id または GitHub issue number から current branch が特定 issue に対応すると推定できる branch
+
+## 未確定事項
+- なし:
+  - Phase 1 は `issue start` / `issue finish` guided lifecycle command と docs / skill alignment に限定する。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/requirement.md
@@ -3,13 +3,30 @@
 ID: "iss-00088"
 タイトル: "Issue lifecycle start and finish commands"
 関連GitHub: ["#88"]
-状態: "draft"
+状態: "defined"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-05"
+最終更新: "2026-05-06"
 親: ["epic-00054", "init-local-00002"]
 ---
 
 # iss-00088 Issue lifecycle start and finish commands — 要件定義（WHAT / WHY）
+
+## この issue で実施すること
+- `spec-dock issue start <target>` と `spec-dock issue finish` を、issue 実行の通常開始・通常終了 command として追加する。
+- `issue start` は対象 issue を active にし、対応 branch を checkout する。対象は issue node のみに限定する。
+- `issue start` は、未完了の active issue branch 上で別 issue を開始しようとした場合に default で停止し、誤って複数 issue にまたがる作業へ流れることを防ぐ。
+- `issue start -f` / `--force` は、この unfinished active issue guard だけを明示的に bypass する。依存未解決や readiness check は bypass しない。
+- `issue finish` は current active issue の linked GitHub issue を close し、すでに closed の場合も success として扱い、その成功確認後に active state を解除する。
+- `active set` / `active set --checkout` は既存の低レベル manual / recovery path として残し、今回の unfinished guard を適用しない。
+- provider runtime、dogfooding runtime mirror、CLI help、provider docs、dogfooding docs、issue execution skill、root README を一貫した lifecycle contract に更新する。
+- 自動テストに加えて、real GitHub repo を使う manual test を実施し、実運用に近い start / guard / force / finish / failure recovery / cleanup を確認する。
+
+## 完了後にユーザーが得る状態
+- agent や maintainer は、issue 作業の入口として `issue start` を使えば active 設定と branch checkout を一操作で完了できる。
+- 未完了 issue の branch 上で別 issue を始めようとしたとき、CLI が危険を説明し、`issue finish`、`issue start -f`、manual `active set --checkout` の選択肢を提示する。
+- `issue finish` により、GitHub issue close と active clear が明示的な終了操作として結びつく。
+- 非常時・復旧時には、従来どおり direct `active set` を使える。
+- docs / skill / README を読んだ agent が、通常 lifecycle と manual recovery path を混同しにくくなる。
 
 ## 目的
 - 通常の issue 実行入口として `spec-dock issue start` / `spec-dock issue finish` を追加し、agent と maintainer が active issue と checkout を明確な lifecycle 操作として扱えるようにする。
@@ -56,31 +73,40 @@ ID: "iss-00088"
   - 非常時や復旧時に低レベル `active set` も使いたい maintainer
 - 代表シナリオ:
   - maintainer が `issue start iss-00088` を実行し、active issue 設定と branch checkout を一操作で完了する。
-  - agent が未完了 active issue branch 上で別 issue を start しようとして止められ、`issue finish` または `issue start <target> -F` のどちらを実行すべきか理解できる。
+  - agent が未完了 active issue branch 上で別 issue を start しようとして止められ、`issue finish` または `issue start <target> -f` のどちらを実行すべきか理解できる。
   - maintainer が `issue finish` を実行し、active issue の GitHub issue を close したうえで active state を解除する。
   - 手動復旧時は従来通り `active set` / `active set --checkout` を制限なく使える。
 
 ## スコープ
 - MUST:
   - `spec-dock issue start <target>` を追加し、issue node のみを対象に active set と checkout を実行できること
-  - `spec-dock issue start <target> -F` / `--force` を追加し、unfinished active issue guard を明示的に bypass できること
+  - `spec-dock issue start <target> -f` / `--force` を追加し、unfinished active issue guard を明示的に bypass できること
   - `spec-dock issue finish` を追加し、current active issue の linked GitHub issue を close または already-closed success として扱い、その後 active state を解除できること
   - `issue start` は active issue branch 上で別 issue を開始しようとする場合、active issue の GitHub state が `CLOSED` でない限り default stop すること
   - `issue start` の default stop message は current active issue、current branch、requested issue、GitHub state、次に実行できる command を表示すること
+  - `issue start` は active issue の GitHub state を取得できない場合、unfinished として安全側に停止すること
+  - `issue start -f` は unfinished active issue guard だけを bypass し、dependency readiness / target validation / checkout safety は bypass しないこと
   - `active set` / `active set --checkout` の既存挙動を変えず、manual / recovery path として残すこと
   - provider docs / dogfooding docs / issue execution skill / CLI help を `issue start` / `issue finish` の primary path に揃えること
+  - root `README.md` と `workflow-tree.md` など利用者が最初に触る docs でも、`issue start` / `issue finish` を primary path として案内すること
+  - `issue finish` は delivery completion、commit、push、PR、merge、validate、test、review の完了を保証しないことを docs / skill に明記すること
+  - `issue finish` 前に delivery completion evidence を report に記録し、`issue finish` 後に active issue が残ることを complete condition にしないこと
+  - provider asset と dogfooding mirror の差分 drift を、テストまたは明示的な diff 検証で確認できること
+  - manual test 用の計画・チェックリスト・実行ログ・サマリを `manual-tests/reports/2026-05-05-iss-00088-issue-lifecycle/` に残すこと
 - MUST NOT:
   - Phase 1 で main / master / develop / staging などの branch からの `issue start` を禁止しない
   - Phase 1 で dirty worktree を spec-dock 独自の hard block 条件にしない
   - `issue finish` で commit、push、merge、PR 作成、stash、report 自動編集を行わない
   - `active set` / `active set --checkout` に unfinished active issue guard を追加しない
-  - `-F` / `--force` に理由入力を必須化しない
+  - `-f` / `--force` に理由入力を必須化しない
 - OUT OF SCOPE:
   - PR 作成、PR monitoring、merge automation
   - protected branch policy enforcement
   - issue completion criteria の完全自動判定
   - incident mode / reason-required audit schema
   - local delete command の追加または変更
+  - `issue finish` 後に自動で `main` へ checkout する挙動
+  - `sync --github` の branch-derived active restoration contract の変更
 
 ## 境界
 - Always:
@@ -89,6 +115,8 @@ ID: "iss-00088"
   - unfinished 判定の正本は linked GitHub issue の `CLOSED` state とする
   - GitHub state を確認できない場合は安全側に倒し、unfinished として扱う
   - `issue finish` は GitHub issue close / already-closed 確認が成功した場合だけ active state を解除する
+  - `issue finish` 後も current Git branch は自動では変えない
+  - final sync で active clear を保ちたい場合は、`main` など non-issue branch へ移動してから `sync --github` する運用を docs / report に残す
 - Ask:
   - Phase 2 以降で `--reason` を任意または必須にするか
   - Phase 2 以降で `issue finish` に validate / sync / report evidence check を追加するか
@@ -109,7 +137,7 @@ ID: "iss-00088"
 - `close` command は既に linked GitHub issue close の低レベル capability を提供している。
 - `issue finish` は `close` capability を active issue lifecycle の終了導線として再利用する。
 - `issue start` の checkout は既存 active set checkout behavior を再利用し、独自 branch naming を導入しない。
-- `-F` / `--force` の理由入力は Phase 1 では要求しない。
+- `-f` / `--force` の理由入力は Phase 1 では要求しない。
 
 ## 受け入れ条件
 - AC-001:
@@ -135,12 +163,12 @@ ID: "iss-00088"
     - active issue の linked GitHub issue state が `CLOSED` ではない
     - requested issue が active issue と異なる
   - When:
-    - `./spec-dock/scripts/spec-dock issue start <requested>` を `-F` なしで実行する
+    - `./spec-dock/scripts/spec-dock issue start <requested>` を `-f` なしで実行する
   - Then:
     - command は停止する
     - active state は変更されない
     - checkout は行われない
-    - message に current active issue、current branch、requested issue、GitHub state、`issue finish`、`issue start <requested> -F`、manual `active set` の導線が表示される
+    - message に current active issue、current branch、requested issue、GitHub state、`issue finish`、`issue start <requested> -f`、manual `active set` の導線が表示される
   - 観測点:
     - CLI / runtime tests
     - active state unchanged assertion
@@ -151,9 +179,10 @@ ID: "iss-00088"
   - Given:
     - AC-002 と同じ unfinished active issue branch 状態
   - When:
-    - `./spec-dock/scripts/spec-dock issue start <requested> -F` を実行する
+    - `./spec-dock/scripts/spec-dock issue start <requested> -f` を実行する
   - Then:
     - guard は bypass される
+    - dependency readiness が未充足の場合は `-f` 付きでも停止する
     - requested issue が active issue になる
     - requested issue branch が checkout される
     - output に forced start であることが表示される
@@ -216,6 +245,20 @@ ID: "iss-00088"
   - 観測点:
     - docs / skill diff
     - tests where applicable
+- AC-008:
+  - Actor:
+    - maintainer / reviewer
+  - Given:
+    - manual test 用 GitHub repo と manual workspace が用意されている
+  - When:
+    - manual test plan に従って real GitHub issue を使った lifecycle 操作を実行する
+  - Then:
+    - normal start、unfinished guard、force + dependency readiness、manual active set boundary、non-issue branch start、finish success、already-closed finish、failure recovery guidance、final health check が確認される
+    - temporary GitHub issues は close される
+    - plan / checklist / execution-log / summary が残る
+  - 観測点:
+    - `manual-tests/reports/2026-05-05-iss-00088-issue-lifecycle/`
+    - manual GitHub repo issue state
 
 ## 例外・エッジケース
 - EC-001:
@@ -229,7 +272,7 @@ ID: "iss-00088"
   - 条件:
     - active issue の GitHub state を取得できない
   - 期待:
-    - `issue start` は unfinished として default stop し、`-F` による続行導線を表示する
+    - `issue start` は unfinished として default stop し、`-f` による続行導線を表示する
   - 観測点:
     - CLI / runtime tests
 - EC-003:
@@ -253,6 +296,14 @@ ID: "iss-00088"
     - unfinished active issue guard は適用されず、既存 command contract が維持される
   - 観測点:
     - regression tests
+- EC-006:
+  - 条件:
+    - `issue finish` 後、current branch が issue branch のまま `sync --github` を実行する
+  - 期待:
+    - 既存 sync contract により branch 名から active が復元されうる
+    - この issue では sync contract を変更せず、運用上の注意として manual test / report に記録する
+  - 観測点:
+    - manual test execution log
 
 ## 入力→出力例
 - EX-001:
@@ -265,7 +316,7 @@ ID: "iss-00088"
     - `./spec-dock/scripts/spec-dock issue start iss-00089`
   - Output:
     - `Cannot start iss-00089 because active issue iss-00088 is not closed.`
-    - `Run ./spec-dock/scripts/spec-dock issue finish or ./spec-dock/scripts/spec-dock issue start iss-00089 -F.`
+    - `Run ./spec-dock/scripts/spec-dock issue finish or ./spec-dock/scripts/spec-dock issue start iss-00089 -f.`
 - EX-003:
   - Input:
     - `./spec-dock/scripts/spec-dock issue finish`
@@ -288,4 +339,18 @@ ID: "iss-00088"
 
 ## 未確定事項
 - なし:
-  - Phase 1 は `issue start` / `issue finish` guided lifecycle command と docs / skill alignment に限定する。
+  - Phase 1 は `issue start` / `issue finish` guided lifecycle command、docs / skill alignment、automated regression、manual GitHub-backed validation に限定する。
+
+## 成功条件
+- runtime:
+  - `issue start` / `issue finish` が CLI command として利用できる
+  - existing `active set` / `close` / `deps` contract が壊れていない
+- safety:
+  - 未完了 issue branch からの accidental switch は default block される
+  - emergency / recovery path は塞がれない
+- documentation:
+  - provider docs、dogfooding docs、root README、issue execution skill が同じ lifecycle model を説明している
+- verification:
+  - targeted lifecycle tests、active/close regression、full unittest、validate、sync、provider/mirror parity、manual GitHub-backed test が pass している
+- evidence:
+  - `spec-dock/active/issue/report.md` に自動テスト、review、manual test の証跡が記録されている

--- a/spec-dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/contracts.py
@@ -199,6 +199,36 @@ class CloseNodeResult:
     warnings: list[str]
 
 
+@dataclass(frozen=True)
+class IssueStartRequest:
+    target: TargetRef
+    force: bool
+    issue_limit: int
+
+
+@dataclass(frozen=True)
+class IssueStartResult:
+    target_display: str
+    requested_issue_id: str
+    active_set: ActiveSetResult
+    forced: bool
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class IssueFinishRequest:
+    pass
+
+
+@dataclass(frozen=True)
+class IssueFinishResult:
+    issue_id: str
+    github_issue_number: int
+    already_closed: bool
+    active_cleared: bool
+    warnings: list[str]
+
+
 DeleteTerminalStatus = Literal[
     "ok",
     "invalid_selector_combination",
@@ -396,6 +426,12 @@ class UseCases:
     )
     close_node: Callable[[CloseNodeRequest], CloseNodeResult] = lambda _req: (_ for _ in ()).throw(
         RuntimeError("close_node is not configured")
+    )
+    issue_start: Callable[[IssueStartRequest], IssueStartResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("issue_start is not configured")
+    )
+    issue_finish: Callable[[IssueFinishRequest], IssueFinishResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("issue_finish is not configured")
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
         lambda _req: DoctorResult(ok=True, findings=[], warnings=[])

--- a/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from ..domain.active import infer_active_node_from_branch
+from ..domain.ids import format_id, parse_id
+from ..domain.models import SpecGraph, SpecNode, SpecNodeKind, SpecNodeSeed
+from ..domain.tree import build_graph
+from ..infra.contracts import ActiveManifest, StoredMetaRecord
+from .close_node import close_node
+from .contracts import (
+    ClearActiveRequest,
+    CloseNodeRequest,
+    IssueFinishRequest,
+    IssueFinishResult,
+    IssueStartRequest,
+    IssueStartResult,
+    SetActiveRequest,
+    TargetRef,
+)
+from .github_issue_targets import normalize_repo_slug
+from .ports import Ports
+from .repo_context import resolve_current_repo_slug
+from .set_active import clear_active, set_active
+
+
+def _to_spec_node_seed(record: StoredMetaRecord) -> SpecNodeSeed:
+    return SpecNodeSeed(
+        kind=cast(SpecNodeKind, record.kind),
+        id=record.id,
+        title=record.title,
+        slug=record.slug,
+        path=Path(record.path),
+        meta_path=Path(record.meta_path),
+        parent_id=record.parent_id,
+        initiative_id=record.initiative_id,
+        epic_id=record.epic_id,
+        github_issue_number=record.github_issue_number,
+        github_repo_owner=record.github_repo_owner,
+        github_repo_name=record.github_repo_name,
+    )
+
+
+def _resolve_repo_root(ports: Ports) -> Path:
+    if ports.repo_root is None:
+        raise RuntimeError("repo_root is required")
+    return ports.repo_root
+
+
+def _resolve_specdock_dir(ports: Ports) -> Path:
+    if ports.specdock_dir is not None:
+        return ports.specdock_dir
+    if ports.repo_root is not None:
+        return ports.repo_root / "spec-dock"
+    raise RuntimeError("specdock_dir is required")
+
+
+def _build_graph(ports: Ports) -> SpecGraph:
+    records = ports.node_reader.load_node_records()
+    if not records:
+        raise RuntimeError("No nodes found. Create at least one initiative/epic/issue.")
+    return build_graph([_to_spec_node_seed(record) for record in records])
+
+
+def _find_existing_id_by_num(graph: SpecGraph, *, prefix: str, num: int, local: bool) -> str | None:
+    for node_id in graph.nodes_by_id.keys():
+        try:
+            parsed_prefix, is_local, parsed_num = parse_id(str(node_id))
+        except RuntimeError:
+            continue
+        if parsed_prefix == prefix and parsed_num == num and is_local == local:
+            return str(node_id)
+    return None
+
+
+def _resolve_target_node(graph: SpecGraph, target: TargetRef, *, current_repo_slug: str | None) -> SpecNode:
+    if target.kind == "github_issue":
+        if target.github_issue_number is None:
+            raise RuntimeError("TargetRef.github_issue_number is required")
+        matches = [
+            node
+            for node in graph.nodes_by_id.values()
+            if node.github_issue_number == int(target.github_issue_number) and node.kind in ("initiative", "epic", "issue")
+        ]
+        target_repo_slug = normalize_repo_slug(target.github_repo_owner, target.github_repo_name)
+        if target_repo_slug is not None:
+            allow_current_unscoped = current_repo_slug is not None and target_repo_slug == current_repo_slug
+            matches = [
+                node
+                for node in matches
+                if (
+                    normalize_repo_slug(node.github_repo_owner, node.github_repo_name) == target_repo_slug
+                    or (
+                        allow_current_unscoped
+                        and normalize_repo_slug(node.github_repo_owner, node.github_repo_name) is None
+                    )
+                )
+            ]
+            scope = f" in repo scope ({target_repo_slug})"
+        else:
+            scope = ""
+        if not matches:
+            raise RuntimeError(
+                f"No node found for github.issue_number={int(target.github_issue_number)}{scope}. Create/link the node first."
+            )
+        if len(matches) > 1:
+            ids = ", ".join(sorted(f"{node.kind}:{node.id}" for node in matches))
+            raise RuntimeError(f"Ambiguous github.issue_number={int(target.github_issue_number)}{scope}: {ids}")
+        return matches[0]
+
+    if target.kind != "node_id":
+        raise RuntimeError(f"Unsupported target kind: {target.kind}")
+    if target.node_id is None:
+        raise RuntimeError("TargetRef.node_id is required")
+
+    raw_id = str(target.node_id).strip().lower()
+    prefix, is_local, num = parse_id(raw_id)
+    resolved = _find_existing_id_by_num(graph, prefix=prefix, num=num, local=is_local) or format_id(
+        prefix,
+        num,
+        local=is_local,
+    )
+    node = graph.nodes_by_id.get(resolved)
+    if node is None or node.kind not in ("initiative", "epic", "issue"):
+        raise RuntimeError(f"Node not found: {resolved}")
+    return node
+
+
+def _active_issue_id(manifest: ActiveManifest | None) -> str | None:
+    if manifest is None or manifest.issue is None:
+        return None
+    return manifest.issue.id
+
+
+def _github_state_for_node(node: SpecNode, ports: Ports, *, current_repo_slug: str | None) -> str:
+    if node.github_issue_number is None:
+        return "UNKNOWN"
+    if ports.issue_gateway is None:
+        return "UNKNOWN"
+    repo_slug = normalize_repo_slug(node.github_repo_owner, node.github_repo_name) or current_repo_slug
+    try:
+        snapshot = ports.issue_gateway.issue_view_snapshot(
+            _resolve_repo_root(ports),
+            int(node.github_issue_number),
+            repo_slug=repo_slug,
+        )
+    except RuntimeError:
+        return "UNKNOWN"
+    state = str(snapshot.state).strip().upper()
+    return state or "UNKNOWN"
+
+
+def _format_issue_target(node: SpecNode) -> str:
+    return node.id
+
+
+def _finish_failure_guidance(*, active_issue_id: str, error: RuntimeError) -> str:
+    return "\n".join(
+        [
+            f"issue finish failed while closing GitHub issue for active issue {active_issue_id}.",
+            "Active selection was not cleared.",
+            "Recovery:",
+            "  spec-dock/scripts/spec-dock active show",
+            "  spec-dock/scripts/spec-dock issue finish",
+            "  gh issue view <github-issue-number>",
+            str(error),
+        ]
+    )
+
+
+def _finish_active_clear_failure_guidance(
+    *,
+    active_issue_id: str,
+    github_issue_number: int,
+    error: RuntimeError,
+) -> str:
+    return "\n".join(
+        [
+            f"issue finish failed after GitHub close/already-closed step for active issue {active_issue_id}.",
+            f"GitHub issue #{github_issue_number} may have been closed successfully or may already have been closed.",
+            "Active selection was not cleared.",
+            "Recovery:",
+            "  spec-dock/scripts/spec-dock active show",
+            "  spec-dock/scripts/spec-dock issue finish",
+            "  spec-dock/scripts/spec-dock active set <issue-id> --checkout",
+            "Use manual active recovery if active metadata is stale or points at the wrong issue.",
+            str(error),
+        ]
+    )
+
+
+def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
+    if ports.active_state_store is None:
+        raise RuntimeError("active_state_store is required")
+    if ports.git_gateway is None:
+        raise RuntimeError("git_gateway is required")
+
+    graph = _build_graph(ports)
+    current_repo_slug = resolve_current_repo_slug(ports)
+    requested = _resolve_target_node(graph, req.target, current_repo_slug=current_repo_slug)
+    if requested.kind != "issue":
+        raise RuntimeError(f"issue start only accepts issue nodes: target={requested.id} kind={requested.kind}")
+
+    specdock_dir = _resolve_specdock_dir(ports)
+    active_load = ports.active_state_store.load_active_manifest(specdock_dir)
+    active_issue_id = _active_issue_id(active_load.manifest)
+    current_branch = ports.git_gateway.current_branch_or_none(_resolve_repo_root(ports)) or "(detached)"
+
+    if active_issue_id is not None and active_issue_id != requested.id and not req.force:
+        active_node = graph.nodes_by_id.get(active_issue_id)
+        branch_node, _reason = infer_active_node_from_branch(
+            graph,
+            branch=current_branch,
+            current_repo_slug=current_repo_slug,
+        )
+        if active_node is not None and branch_node is not None and branch_node.id == active_issue_id:
+            github_state = _github_state_for_node(active_node, ports, current_repo_slug=current_repo_slug)
+            if github_state != "CLOSED":
+                requested_target = _format_issue_target(requested)
+                raise RuntimeError(
+                    "\n".join(
+                        [
+                            "issue start blocked: unfinished active issue branch",
+                            f"- current active issue: {active_issue_id}",
+                            f"- current branch: {current_branch}",
+                            f"- requested issue: {requested.id}",
+                            f"- github state: {github_state}",
+                            "Next commands:",
+                            "  spec-dock/scripts/spec-dock issue finish",
+                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -F",
+                            f"  spec-dock/scripts/spec-dock active set {requested_target} --checkout",
+                        ]
+                    )
+                )
+
+    active_set_result = set_active(
+        SetActiveRequest(
+            target=req.target,
+            force=False,
+            checkout=True,
+            use_github=True,
+            issue_limit=req.issue_limit,
+        ),
+        ports,
+    )
+    warnings = list(active_set_result.warnings)
+    if req.force:
+        warnings.insert(0, f"issue start forced=true guard=unfinished_active_issue requested={requested.id}")
+    return IssueStartResult(
+        target_display=_format_issue_target(requested),
+        requested_issue_id=requested.id,
+        active_set=active_set_result,
+        forced=bool(req.force),
+        warnings=warnings,
+    )
+
+
+def issue_finish(req: IssueFinishRequest, ports: Ports) -> IssueFinishResult:
+    del req
+    if ports.active_state_store is None:
+        raise RuntimeError("active_state_store is required")
+
+    specdock_dir = _resolve_specdock_dir(ports)
+    active_load = ports.active_state_store.load_active_manifest(specdock_dir)
+    active_issue_id = _active_issue_id(active_load.manifest)
+    if active_issue_id is None:
+        raise RuntimeError(
+            "issue finish requires an active issue. Recovery: run issue start <issue> or active set <issue> --checkout."
+        )
+
+    try:
+        close_result = close_node(
+            CloseNodeRequest(
+                target=TargetRef(kind="node_id", node_id=active_issue_id, github_issue_number=None),
+            ),
+            ports,
+        )
+    except RuntimeError as error:
+        raise RuntimeError(_finish_failure_guidance(active_issue_id=active_issue_id, error=error)) from error
+    try:
+        clear_result = clear_active(ClearActiveRequest(), ports)
+    except RuntimeError as error:
+        raise RuntimeError(
+            _finish_active_clear_failure_guidance(
+                active_issue_id=active_issue_id,
+                github_issue_number=close_result.github_issue_number,
+                error=error,
+            )
+        ) from error
+    warnings = [*active_load.warnings, *close_result.warnings, *clear_result.warnings]
+    return IssueFinishResult(
+        issue_id=close_result.node_id,
+        github_issue_number=close_result.github_issue_number,
+        already_closed=close_result.already_closed,
+        active_cleared=clear_result.cleared,
+        warnings=warnings,
+    )

--- a/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -228,7 +228,7 @@ def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
                             f"- github state: {github_state}",
                             "Next commands:",
                             "  spec-dock/scripts/spec-dock issue finish",
-                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -F",
+                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -f",
                             f"  spec-dock/scripts/spec-dock active set {requested_target} --checkout",
                         ]
                     )

--- a/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -234,11 +234,12 @@ def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
                     )
                 )
 
+    checkout = active_issue_id != requested.id
     active_set_result = set_active(
         SetActiveRequest(
             target=req.target,
             force=False,
-            checkout=True,
+            checkout=checkout,
             use_github=True,
             issue_limit=req.issue_limit,
         ),

--- a/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -15,6 +15,8 @@ from ..application.contracts import UseCases
 from ..application.import_node import import_epic as application_import_epic
 from ..application.import_node import import_initiative as application_import_initiative
 from ..application.import_node import import_issue as application_import_issue
+from ..application.issue_lifecycle import issue_finish as application_issue_finish
+from ..application.issue_lifecycle import issue_start as application_issue_start
 from ..application.mutate_deps import mutate_deps as application_mutate_deps
 from ..application.ports import Ports
 from ..application.set_active import clear_active as application_clear_active
@@ -242,6 +244,8 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         mutate_deps=lambda req: application_mutate_deps(req, ports),
         delete_node=lambda req: application_delete_node(req, ports),
         close_node=lambda req: application_close_node(req, ports),
+        issue_start=lambda req: application_issue_start(req, ports),
+        issue_finish=lambda req: application_issue_finish(req, ports),
         validate_tree=lambda req: application_validate_tree(req, ports),
         doctor=lambda req: application_doctor(req, ports),
     )

--- a/spec-dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/parser.py
@@ -51,6 +51,11 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     _bind_leaf(sub.add_parser("delete", help="Delete local spec nodes with safeguards"), registry, "delete")
     _bind_leaf(sub.add_parser("close", help="Close the linked GitHub issue for a node target"), registry, "close")
 
+    p_issue = sub.add_parser("issue", help="Run guided issue lifecycle commands")
+    issue_sub = p_issue.add_subparsers(dest="issue_cmd", required=True)
+    _bind_leaf(issue_sub.add_parser("start", help="Set active issue and checkout its branch"), registry, "issue_start")
+    _bind_leaf(issue_sub.add_parser("finish", help="Close active issue and clear active pointers"), registry, "issue_finish")
+
     _bind_leaf(
         sub.add_parser("sync", help="Generate index.json/tree.json (optionally enrich from GitHub)"),
         registry,

--- a/spec-dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/registry.py
@@ -6,6 +6,7 @@ from ..commands import delete as delete_commands
 from ..commands import deps as deps_commands
 from ..commands import doctor as doctor_commands
 from ..commands import import_cmd as import_commands
+from ..commands import issue as issue_commands
 from ..commands import new as new_commands
 from ..commands import sync as sync_commands
 from ..commands import validate as validate_commands
@@ -19,6 +20,7 @@ def build_registry() -> CommandRegistry:
     items.update(active_commands.command_specs())
     items.update(delete_commands.command_specs())
     items.update(close_commands.command_specs())
+    items.update(issue_commands.command_specs())
     items.update(sync_commands.command_specs())
     items.update(deps_commands.command_specs())
     items.update(validate_commands.command_specs())

--- a/spec-dock/scripts/spec_dock_runtime/commands/issue.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/issue.py
@@ -45,7 +45,7 @@ def _add_issue_start_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--id", help="Explicit issue node id target (e.g. iss-00123)")
     parser.add_argument("--github-issue", type=int, help="Explicit GitHub issue number target (e.g. 123)")
     parser.add_argument(
-        "-F",
+        "-f",
         "--force",
         action="store_true",
         help="Bypass only the unfinished active issue guard; dependency readiness checks still apply.",

--- a/spec-dock/scripts/spec_dock_runtime/commands/issue.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/issue.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from ..application.contracts import IssueFinishRequest, IssueStartRequest, TargetRef, UseCases
+from ..presentation.cli_text import render_issue_finish_text, render_issue_start_text
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+from .targets import parse_explicit_target_flags
+
+
+@dataclass(frozen=True)
+class IssueStartArgs(CommandArgs):
+    target_ref: TargetRef
+    force: bool
+    gh_limit: int
+
+
+@dataclass(frozen=True)
+class IssueFinishArgs(CommandArgs):
+    pass
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "issue_start": CommandSpec(
+            add_arguments=_add_issue_start_arguments,
+            args_factory=_issue_start_args,
+            run=_run_issue_start,
+        ),
+        "issue_finish": CommandSpec(
+            add_arguments=_add_issue_finish_arguments,
+            args_factory=_issue_finish_args,
+            run=_run_issue_finish,
+        ),
+    }
+
+
+def _add_issue_start_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "target",
+        nargs="?",
+        help="GitHub issue number (digits only: 123 / #123 / URL) or issue node id (e.g. iss-00123)",
+    )
+    parser.add_argument("--id", help="Explicit issue node id target (e.g. iss-00123)")
+    parser.add_argument("--github-issue", type=int, help="Explicit GitHub issue number target (e.g. 123)")
+    parser.add_argument(
+        "-F",
+        "--force",
+        action="store_true",
+        help="Bypass only the unfinished active issue guard; dependency readiness checks still apply.",
+    )
+    parser.add_argument("--gh-limit", type=int, default=10000, help="gh issue list limit (default: 10000)")
+
+
+def _add_issue_finish_arguments(parser: argparse.ArgumentParser) -> None:
+    del parser
+
+
+def _issue_start_args(ns: argparse.Namespace) -> CommandArgs:
+    target_ref, _target_display = parse_explicit_target_flags(
+        positional_target=getattr(ns, "target", None),
+        node_id=getattr(ns, "id", None),
+        github_issue=getattr(ns, "github_issue", None),
+        command_label="issue start",
+    )
+    return IssueStartArgs(
+        target_ref=target_ref,
+        force=bool(getattr(ns, "force", False)),
+        gh_limit=int(getattr(ns, "gh_limit", 10000)),
+    )
+
+
+def _issue_finish_args(ns: argparse.Namespace) -> CommandArgs:
+    del ns
+    return IssueFinishArgs()
+
+
+def _run_issue_start(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    typed = _expect_issue_start_args(args)
+    result = use_cases.issue_start(
+        IssueStartRequest(
+            target=typed.target_ref,
+            force=typed.force,
+            issue_limit=typed.gh_limit,
+        )
+    )
+    return CommandOutcome(exit_code=0, text=render_issue_start_text(result))
+
+
+def _run_issue_finish(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    _expect_issue_finish_args(args)
+    result = use_cases.issue_finish(IssueFinishRequest())
+    return CommandOutcome(exit_code=0, text=render_issue_finish_text(result))
+
+
+def _expect_issue_start_args(args: CommandArgs) -> IssueStartArgs:
+    if not isinstance(args, IssueStartArgs):
+        raise RuntimeError("Invalid command args for issue start")
+    return args
+
+
+def _expect_issue_finish_args(args: CommandArgs) -> IssueFinishArgs:
+    if not isinstance(args, IssueFinishArgs):
+        raise RuntimeError("Invalid command args for issue finish")
+    return args

--- a/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -13,6 +13,8 @@ from ..application.contracts import (
     DepsCheckResult,
     DoctorResult,
     ImportNodeResult,
+    IssueFinishResult,
+    IssueStartResult,
     MutateDepsError,
     MutateDepsResult,
     SyncCommandResult,
@@ -253,6 +255,37 @@ def render_close_text(result: CloseNodeResult, *, target_display: str) -> CliTex
                 "spec-dock: ok (close) "
                 f"target={target_display} node={result.node_id} kind={result.node_kind} "
                 f"github=#{result.github_issue_number} state={state} already_closed={'true' if result.already_closed else 'false'}"
+            )
+        ],
+        stderr_lines=[],
+        warnings=list(result.warnings),
+    )
+
+
+def render_issue_start_text(result: IssueStartResult) -> CliText:
+    selection = result.active_set.selection
+    ini = selection.initiative_id or "(none)"
+    epic = selection.epic_id or "(none)"
+    issue = selection.issue_id or "(none)"
+    stdout_lines = [
+        (
+            "spec-dock: ok (issue start) "
+            f"target={result.target_display} initiative={ini} epic={epic} issue={issue}"
+        )
+    ]
+    if result.active_set.branch is not None:
+        stdout_lines.append(f"spec-dock: ok (issue checkout) branch={result.active_set.branch.desired}")
+    return CliText(stdout_lines=stdout_lines, stderr_lines=[], warnings=list(result.warnings))
+
+
+def render_issue_finish_text(result: IssueFinishResult) -> CliText:
+    return CliText(
+        stdout_lines=[
+            (
+                "spec-dock: ok (issue finish) "
+                f"issue={result.issue_id} github=#{result.github_issue_number} state=CLOSED "
+                f"active_cleared={'true' if result.active_cleared else 'false'} "
+                f"already_closed={'true' if result.already_closed else 'false'}"
             )
         ],
         stderr_lines=[],

--- a/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -50,9 +50,10 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Normal issue execution lifecycle:
   - `./spec-dock/scripts/spec-dock issue start <target>`
   - `./spec-dock/scripts/spec-dock issue finish`
-- `issue start -F` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
+- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch. It does not bypass dependency readiness, target validation, or checkout safety.
 - `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
 - Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
+- After `issue finish`, avoid running `sync --github` on the just-finished issue branch when you need active clear to remain clear. `sync --github` can restore active from branch-derived issue context; move to `main` or another non-issue branch before final sync, or skip post-finish sync.
 - Dependency mutation is command-first:
   - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
   - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`

--- a/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -9,6 +9,9 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Typical fit: implement the active issue through approved behavior-slice execution and update `report.md`.
 - Start from `spec-dock/active/context-pack.md`, then follow the issue workflow.
 - `spec-dock/docs/workflow_issue.md` is the source of truth for issue execution and completion.
+- Normal lifecycle path: start with `./spec-dock/scripts/spec-dock issue start <target>` and finish with `./spec-dock/scripts/spec-dock issue finish`.
+`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+- Treat direct `./spec-dock/scripts/spec-dock active set ...` as a manual / recovery command, not the primary issue execution path.
 - For shared phase authoring method, use:
   - `spec-dock/docs/phase_requirement.md`
   - `spec-dock/docs/phase_design.md`
@@ -18,15 +21,17 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
 - In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
 - Execution mode: follow the approved issue docs. If the docs are missing required detail or contradict the implementation path, update/review the docs before implementation continues.
+- Record delivery completion evidence in `spec-dock/active/issue/report.md` before running `./spec-dock/scripts/spec-dock issue finish`, because `issue finish` clears active state after lifecycle closure.
 - Treat `Spec-Locked Closure Index` as the issue-wide coverage ledger, not as a single test-case catalog. Execute and close work through each step's `step closure contract`.
 - Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
 - Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
 - Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
 - Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.
 - Do not skip the docs impact resolution step or the final diff review quality gate.
-- Issue execution is not complete unless the active issue is set and confirmed, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
+- Delivery completion must be confirmed before `issue finish` while the active issue is still set and confirmable, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
 - `spec-dock/active/issue/report.md` must record command evidence for required `sync`, `validate`, and review steps, including whether each required step succeeded, passed, or reached approval.
-- Complete status requires the active issue to remain set and confirmed, every required step to be executed, every required `sync` / `validate` step to succeed or pass, and every required review step to reach approval or pass.
+- Do not run `issue finish` until every required step has been executed, every required `sync` / `validate` step has succeeded or passed, every required review step has reached approval or pass, and the delivery completion evidence is recorded in `spec-dock/active/issue/report.md`.
+- After `issue finish`, do not require the active issue to remain set. Treat `issue finish` as lifecycle closure / GitHub close / active clear only.
 - If any required step is skipped, or executed without a successful, pass, or approved outcome, classify the issue as `blocked` or `incomplete`, record the reason and next action in `spec-dock/active/issue/report.md`, and do not report the issue as complete.
 - Treat the issue as `blocked` only when an external dependency, missing permission, unavailable service, or other environment condition prevents the next required action.
 - When blocked, record the reason and next action in `spec-dock/active/issue/report.md`. Include blocker type and impact when applicable.
@@ -42,6 +47,12 @@ description: Leaf skill for issue execution tasks in spec-dock.
 ## Runtime command reminders
 
 - Use runtime command path only: `./spec-dock/scripts/spec-dock ...`
+- Normal issue execution lifecycle:
+  - `./spec-dock/scripts/spec-dock issue start <target>`
+  - `./spec-dock/scripts/spec-dock issue finish`
+- `issue start -F` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch.
+- `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
+- Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
 - Dependency mutation is command-first:
   - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
   - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`

--- a/src/spec_dock/assets/spec_dock/docs/README.md
+++ b/src/spec_dock/assets/spec_dock/docs/README.md
@@ -48,6 +48,10 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 ./spec-dock/scripts/spec-dock import epic <num-or-canonical-url> --title "..." [--initiative <id>] [--allow-foreign-url]
 ./spec-dock/scripts/spec-dock import issue <num-or-canonical-url> --title "..." [--epic <id>] [--allow-foreign-url]
 
+./spec-dock/scripts/spec-dock issue start <github-issue-number>
+./spec-dock/scripts/spec-dock issue start --id <issue-id>
+./spec-dock/scripts/spec-dock issue finish
+
 ./spec-dock/scripts/spec-dock active set <id|#num|url>
 ./spec-dock/scripts/spec-dock active set --id <node-id>
 ./spec-dock/scripts/spec-dock active set --github-issue <n>
@@ -69,6 +73,7 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 - `new issue --create-github-issue` は default create の explicit alias
 - `--no-github` / `--allow-foreign-url` は compatibility flag として残るが、current contract mismatch を auto-migrate せず reject/fail-fast しうる
 - `import` は読み取り確認のみで、GitHub を更新しない。canonical URL は current repo と照合し、cross-repo node import は reject される
+- Issue 実行の通常入口は `issue start <target>`、終了導線は `issue finish`。`active set` / `active set --checkout` は manual / recovery 用の low-level command として使う
 - `active set` / `deps check` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える
 - 依存関係の追加/削除/確認は metadata の直編集ではなく `./spec-dock/scripts/spec-dock deps add/remove/check` を使い、変更後は `./spec-dock/scripts/spec-dock validate` と `./spec-dock/scripts/spec-dock sync --github` で整合を確認する
 - legacy sequential discussion docs は grandfathered only。新規作成で sequence reuse / auto-rename / auto-repair はしない

--- a/src/spec_dock/assets/spec_dock/docs/github.md
+++ b/src/spec_dock/assets/spec_dock/docs/github.md
@@ -36,32 +36,24 @@ gh issue create --title "<title>" --body "<body>"
 ./spec-dock/scripts/spec-dock new issue --epic 124 --title "..." --github-issue 123
 ```
 
-### 1.3 Issue ブランチ checkout（`active set <github_issue_number>`）
+### 1.3 Issue ブランチ checkout（`issue start <github_issue_number>`）
 
-GitHub Issue 番号から **ブランチ作成/checkout → active 設定 → sync** まで一括で行えます。
-
-```bash
-./spec-dock/scripts/spec-dock active set 123
-```
-
-内部的に実行されるコマンド（概要）:
+GitHub Issue 番号から **active issue 設定 → ブランチ作成/checkout** を一括で行えます。通常の Issue 実行では `issue start` を primary path として使います。
 
 ```bash
-gh issue develop 123 --name work/iss-00123 --checkout
+./spec-dock/scripts/spec-dock issue start 123
 ```
 
 注意:
 - 安全のため、**未コミット/未追跡の変更がある場合はエラーで中断**します（作業を保護するため）
 - 仕様ツリー内に `github.issue_number == 123` のノードが存在しない場合もエラーになります
+- `issue start` は issue node のみを対象にします。initiative / epic を checkout する manual / recovery 作業では `active set <target> --checkout` を明示してください
 
 補足:
-- `active set iss-00123` のようにノードIDで直接指定した場合でも、そのノードが GitHub Issue に紐づいていれば checkout します（initiative/epic/issue 共通）。
-- ブランチ名は日本語タイトルを使わず、`work/<node-id>` 形式を使います（例: `work/iss-00123`, `work/epic-00123`, `work/init-00123`）。
-- `work/<node-id>` が linked branch として既にある場合は、その既存 branch の checkout を優先します。
-- linked branch に `work/<node-id>` が無い場合は、`gh issue develop --name work/<node-id> --checkout` で作成します。
-- linked branch に legacy ブランチ（例: `gh-issue-123`）しか無い場合は、その legacy を一時 checkout してノードを解決し、最終的に `work/<node-id>` へ移行します（legacy が複数ある場合は非決定的なためエラー）。
-- `gh issue develop --name ...` が使えない環境では、互換のため `gh issue checkout` / `gh issue develop --checkout` にフォールバックします。
-- 互換フォールバックが使われた場合、最終的な branch 名は `gh` の挙動に依存するため `work/<node-id>` と一致しない可能性があります。
+- `issue start --id iss-00123` のように issue node ID で直接指定できます。
+- `active set iss-00123 --checkout` は同じ checkout 命名 contract を使いますが、unfinished issue guard を持たない manual / recovery 用の low-level command です。
+- ブランチ名は日本語タイトルを使わず、`<node-id>-<slug>` 形式を使います（例: `iss-00123-add-refresh-token`）。
+- desired branch が既にある場合は、その既存 branch の checkout を優先します。
 
 ## 2) 「どのリポジトリに作るか」はどう決まるか
 

--- a/src/spec_dock/assets/spec_dock/docs/guide.md
+++ b/src/spec_dock/assets/spec_dock/docs/guide.md
@@ -85,14 +85,17 @@ spec-dock/
 ## 最短 workflow
 
 1. 既存ノードに収まるか確認し、必要なら `new` / `import` する
-2. `active set` で作業対象を固定する
+2. Issue 実行では `issue start <target>` で作業対象を固定し、対象ブランチへ checkout する
 3. 対象 scope の `workflow_*.md` を正本にし、requirement / design は shared playbook、plan は `phase_plan.md` → `phase_plan_<scope>.md` の順で書く
 4. Initiative は Epic 分解、Epic は Issue 分割、Issue は agent-native / behavior-slice based execution contract を plan に落とす
-5. `validate` / `sync` で整合性と生成物を更新する
+5. `validate` / `sync` で整合性と生成物を更新し、Issue lifecycle を閉じる場合は `issue finish` を使う
 
 ## 代表コマンド（runtime script）
 
 ```bash
+./spec-dock/scripts/spec-dock issue start <github-issue-number>
+./spec-dock/scripts/spec-dock issue start --id <issue-id>
+./spec-dock/scripts/spec-dock issue finish
 ./spec-dock/scripts/spec-dock active set <id|#num|url>
 ./spec-dock/scripts/spec-dock deps check <target> --github
 ./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>
@@ -100,6 +103,8 @@ spec-dock/
 ./spec-dock/scripts/spec-dock validate
 ./spec-dock/scripts/spec-dock sync --github
 ```
+
+`active set` / `active set --checkout` は manual / recovery 用の low-level command です。通常の Issue 実行では `issue start` / `issue finish` を入口にします。
 
 
 ## 次に読む

--- a/src/spec_dock/assets/spec_dock/docs/reference_github.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_github.md
@@ -89,9 +89,9 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 
 - `issue start <target>` は issue node を解決して active set と checkout を一操作で行います
 - `issue start` は unfinished active issue branch 上で別 issue を start しようとした場合だけ default で block します
-- `issue start -F` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
+- `issue start -f` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
 - `main` / `master` / `develop` / `staging` や non-issue branch からの `issue start` は block しません
-- `issue start` の block message では `issue finish`、`issue start <target> -F`、manual `active set` の次アクションを案内します
+- `issue start` の block message では `issue finish`、`issue start <target> -f`、manual `active set` の次アクションを案内します
 
 `active set` は target を active として固定します。
 

--- a/src/spec_dock/assets/spec_dock/docs/reference_github.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_github.md
@@ -11,7 +11,7 @@
 ## 1. 前提（どのリポジトリが対象になるか）
 
 spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略するわけではありません。  
-`import` / `active set` / deps check / sync の `gh issue view` 系では repo slug が分かっている場合に `--repo owner/repo` を付け、same-repo URL import でも current repo を明示して読み取ります。  
+`import` / `issue start` / `issue finish` / `active set` / deps check / sync の `gh issue view` 系では repo slug が分かっている場合に `--repo owner/repo` を付け、same-repo URL import でも current repo を明示して読み取ります。
 一方で `gh issue create` / `gh issue list` は repo root を `cwd` にして実行し、対象リポジトリ解決は **`gh` の通常解釈**に委ねます。
 
 補足:
@@ -41,6 +41,11 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
   - remote mutation は close-only です。GitHub side delete は扱いません
   - close command 自体は local tree / docs / generated artifacts を直接更新しません
   - close 後の local `done` 観測は `./spec-dock/scripts/spec-dock sync --github` の既存経路に委ねます
+- `issue finish` は active issue lifecycle の通常終了 command です
+  - `./spec-dock/scripts/spec-dock issue finish` を受け付けます
+  - active issue の linked GitHub issue を close し、already-closed も success として扱います
+  - `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+  - active state は close / already-closed の確認成功後にだけ解除されます
 - `delete` は local spec node を削除し、linked GitHub Issue があれば close-only で扱います
   - top-level command として `./spec-dock/scripts/spec-dock delete <target> --yes` / `--id <node-id> --yes` / `--github-issue <n> --yes` を受け付けます
   - `issue` target は leaf delete を行い、linked GitHub issue は local delete 前に close します
@@ -78,7 +83,15 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - canonical でない URL-like target（例: `git@github.com:owner/repo/issues/123`）は reject します
 - current repo を検証できない場合（origin 未設定 / GitHub 以外の remote）は、canonical URL import を fail-closed で reject します
 
-## 4. `active set` と checkout（安全装置）
+## 4. `issue start` / `active set` と checkout（安全装置）
+
+通常の issue execution 開始は `issue start` を primary path とし、`active set` は manual / recovery path として残します。
+
+- `issue start <target>` は issue node を解決して active set と checkout を一操作で行います
+- `issue start` は unfinished active issue branch 上で別 issue を start しようとした場合だけ default で block します
+- `issue start -F` / `--force` は unfinished active issue guard だけを bypass します。依存未解決や dirty worktree など他の safety check は bypass しません
+- `main` / `master` / `develop` / `staging` や non-issue branch からの `issue start` は block しません
+- `issue start` の block message では `issue finish`、`issue start <target> -F`、manual `active set` の次アクションを案内します
 
 `active set` は target を active として固定します。
 
@@ -86,6 +99,7 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - 後方互換として `active set <target>` は維持されます
 - explicit form として `active set --id <node-id>` / `active set --github-issue <n>` も使えます
 - checkout は `active set <target> --checkout` を明示したときだけ実行します
+- `active set` は direct manual / recovery command であり、unfinished active issue guard の対象外です
 - target 解決はローカル node（`.meta.json`）を優先し、未解決なら checkout/active 変更なしで失敗します
 - `--checkout` 時に作業ツリーが dirty の場合は安全のため checkout を中断します
 - `--checkout` を伴う場合、ブランチ名は `<id>-<slug>`（不適合なら `<id>`）へ正規化されます（非ASCIIブランチ名を避ける）。詳細は [reference_naming.md](reference_naming.md) を参照してください。

--- a/src/spec_dock/assets/spec_dock/docs/reference_naming.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_naming.md
@@ -22,7 +22,7 @@
 ### 1.2 ブランチ命名（checkout 後の正規化）
 
 - `issue start <target>`
-- `issue start <target> -F`
+- `issue start <target> -f`
 - `active set <target> --checkout`
   - デフォルト（`active set <target>`）は no-checkout のため、ブランチ操作は行いません
   - `issue start` は issue node 専用です。initiative / epic / issue の target kind を問わないのは `active set <target> --checkout` のみです
@@ -171,7 +171,7 @@ validation / allocation の扱い:
 
 ### 5.2 対象
 
-- `issue start <target>` / `issue start <target> -F`
+- `issue start <target>` / `issue start <target> -f`
   - issue node のみを受け付けます
 - `active set <target> --checkout` を明示した場合
   - target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません

--- a/src/spec_dock/assets/spec_dock/docs/reference_naming.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_naming.md
@@ -21,8 +21,11 @@
 
 ### 1.2 ブランチ命名（checkout 後の正規化）
 
+- `issue start <target>`
+- `issue start <target> -F`
 - `active set <target> --checkout`
   - デフォルト（`active set <target>`）は no-checkout のため、ブランチ操作は行いません
+  - `issue start` は issue node 専用です。initiative / epic / issue の target kind を問わないのは `active set <target> --checkout` のみです
 
 ---
 
@@ -159,18 +162,20 @@ validation / allocation の扱い:
 
 ---
 
-## 5. `active set --checkout` のブランチ命名（日本語ブランチを避ける）
+## 5. `issue start` / `active set --checkout` のブランチ命名（日本語ブランチを避ける）
 
 ### 5.1 目的
 
-`active set --checkout` では、ブランチ名を **ASCII かつ git 的に妥当**な形式へ寄せます。  
+`issue start` と `active set --checkout` では、ブランチ名を **ASCII かつ git 的に妥当**な形式へ寄せます。
 これにより、非ASCII名や不正ref名による運用トラブルを避けます。
 
 ### 5.2 対象
 
-- `active set <target> --checkout` を明示した場合のみ
-- target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません
-- `--checkout` を付けない場合は **ブランチ操作しません**
+- `issue start <target>` / `issue start <target> -F`
+  - issue node のみを受け付けます
+- `active set <target> --checkout` を明示した場合
+  - target の node 種別（initiative / epic / issue）や GitHub 紐づき有無は問いません
+- `active set` で `--checkout` を付けない場合は **ブランチ操作しません**
 
 ### 5.3 望ましいブランチ名（desired）
 

--- a/src/spec_dock/assets/spec_dock/docs/workflow-tree.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow-tree.md
@@ -105,20 +105,28 @@ Issueは単独で「要件→設計→計画→実装→報告」まで完結す
 
 詳細: `reference_sync.md`
 
-### 5.2 いま作業する対象の固定（active）
+### 5.2 いま作業する対象の固定（issue start / issue finish / active）
 
 ```bash
+./spec-dock/scripts/spec-dock issue start 123          # primary path（checkout + active）
+./spec-dock/scripts/spec-dock issue start iss-00123
+./spec-dock/scripts/spec-dock issue finish
+
 ./spec-dock/scripts/spec-dock active show
-./spec-dock/scripts/spec-dock active set 123          # GitHub issue number（checkout + active + sync）
-./spec-dock/scripts/spec-dock active set iss-00123     # node id（issue）
-./spec-dock/scripts/spec-dock active set epic-00123    # node id（epic）
-./spec-dock/scripts/spec-dock active set init-00123    # node id（initiative）
+./spec-dock/scripts/spec-dock active set 123          # GitHub issue number（active only / no-checkout）
+./spec-dock/scripts/spec-dock active set 123 --checkout
+./spec-dock/scripts/spec-dock active set iss-00123    # node id（issue）
+./spec-dock/scripts/spec-dock active set epic-00123   # node id（epic）
+./spec-dock/scripts/spec-dock active set init-00123   # node id（initiative）
 ./spec-dock/scripts/spec-dock active clear
 ```
 
+- 通常の issue execution の開始/終了は `issue start <target>` / `issue finish` を primary lifecycle path とする。
+- `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。
+- `active set` は manual / recovery / low-level path として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う。
+- `active set <target>` のデフォルトは active only / no-checkout。ブランチ移動が必要な場合だけ `active set <target> --checkout` を使う。通常の issue 開始では `issue start` を使う。
 - `active` は生成物（gitignore）で、**「いま触る対象」の入口**だけを提供する。
 - エージェントは `spec-dock/active/context-pack.md` を入口にする。
-- GitHub Issue に紐づくノード（`github.issue_number` があるノード）を `active set` した場合、`active set` は checkout も行う。
 - active が未設定のレイヤーは placeholder（`spec-dock/system/active-none/**`）へ向く。
   - placeholder は編集対象外（best-effortで read-only）
 

--- a/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
@@ -15,13 +15,17 @@ Issue は実装の最小単位です。
 - 共通 phase playbook: [phase_requirement.md](phase_requirement.md), [phase_design.md](phase_design.md), [phase_plan.md](phase_plan.md)
 - Issue plan playbook: [phase_plan_issue.md](phase_plan_issue.md)
 
-## 作成と active set
+## 作成と issue start
 
 ```bash
 ./spec-dock/scripts/spec-dock new issue --epic <epic-id> --title "..."
 ./spec-dock/scripts/spec-dock new issue --create-github-issue --epic <epic-id> --title "..."
 
 ./spec-dock/scripts/spec-dock import issue <num|#num|canonical-url> --title "..." [--epic <epic-id>]
+
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url>
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -F
+./spec-dock/scripts/spec-dock issue finish
 
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
 ./spec-dock/scripts/spec-dock active set --id <issue-id>
@@ -38,6 +42,14 @@ Issue は実装の最小単位です。
 - `import issue` の canonical URL は current repo と照合され、current repo を検証できない場合も含めて foreign GitHub issue URL は fail-closed で reject される
 - `--allow-foreign-url` は compatibility flag として残るが、cross-repo node identity import の成功経路にはならない
 - canonical でない URL-like target は受け付けない
+- 通常の issue execution 開始は `./spec-dock/scripts/spec-dock issue start <target>` を primary path とし、active set と checkout を一操作で完了する
+- `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。`main` / `master` / `develop` / `staging` や non-issue branch からの start は block しない
+- `./spec-dock/scripts/spec-dock issue start <target> -F` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
+- 通常の issue 完了は `./spec-dock/scripts/spec-dock issue finish` を primary path とする。active issue の linked GitHub issue を close し、already-closed も success として扱い、その確認後に active state を解除する
+`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
+- delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う
+- `issue finish` 後は active issue が clear されていてよく、active issue が残っていること自体を `complete` condition にしてはならない
+- `active set` は manual / recovery command として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う
 - `active set` のデフォルトは no-checkout。ブランチ移動が必要な場合だけ `--checkout`
 - `active set` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える
 - 依存未解決なら `active set` は通常失敗する。確認は `./spec-dock/scripts/spec-dock deps check <target> --github`
@@ -78,8 +90,8 @@ Issue は実装の最小単位です。
 - 各 step は step result approval を得てから次へ進む
 - docs impact が `none` でない場合は、final quality gate の前に docs refresh / docs impact resolution step を置く
 - `git diff <base>...HEAD` を見る final diff review quality gate は独立 step にし、reviewer approval まで終える
-- route だけ、または `active set` だけでは Issue work は完了しない
-- `complete` と報告してよいのは、active issue が set され、その対象 issue を確認でき、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている証跡が記録されている場合のみである
+- route だけ、または manual `active set` だけでは Issue work は完了しない。通常の開始/終了は `issue start` / `issue finish` を使う
+- `complete` と報告してよいのは、`issue finish` 前に active issue が set されその対象 issue を確認できる状態で、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている証跡が記録され、その evidence を確認している場合のみである
 - 4 点の issue docs のいずれかが untouched、template、placeholder、または実質未記入の状態で残る場合は `未完了` であり、成功報告をしてはならない
 - required step（`sync` / `validate` / `required review`）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
 - `blocked` は、外部依存、権限不足、サービス停止、その他の環境条件によって次の required action を進められない状態を指す
@@ -95,7 +107,8 @@ Issue は実装の最小単位です。
 - `Test Contract Closure` に required closure id、step、evidence level、pre-implementation evidence、verification command、result を残す
 - `Closure Coverage` に各 required closure id と verification evidence の対応を残す
 - `Closure Delta` に追加・削除・変更・未実装 row と re-review 要否を残す
-- `complete` 判定に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡を残す
+- `complete` 判定に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡を、`issue finish` 前に active issue を確認できる状態の report に残す
+- `issue finish` 後は active issue が clear されていてよく、`complete` 判定は active state の残存ではなく `issue finish` 前に記録・確認した report evidence で行う
 - `complete` 判定に必要な required closure id は、report の `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved no-op として閉じている必要がある
 - required step（`sync` / `validate` / `required review`）を未実施にした場合、または実行しても成功、pass、approval に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
 - `blocked` / `未完了` の場合は reason と next action を残し、環境 blocker と product gap を混在させない
@@ -153,7 +166,7 @@ Issue は実装の最小単位です。
   - docs impact / docs refresh step が必要なら入っている
   - final diff review quality gate が独立している
 - report:
-  - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が残っている
+  - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が、`issue finish` 前に active issue を確認できる状態の report に残っている
   - required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で閉じている
   - required row の削除、locked expectation 変更、required 変更、spec link 意味変更がある場合は re-review 証跡が残っている
   - required step を未実施にした場合、または実行しても成功、pass、approval に到達しなかった場合は `blocked` / `未完了` の reason と next action が残っている

--- a/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
@@ -24,7 +24,7 @@ Issue は実装の最小単位です。
 ./spec-dock/scripts/spec-dock import issue <num|#num|canonical-url> --title "..." [--epic <epic-id>]
 
 ./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url>
-./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -F
+./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -f
 ./spec-dock/scripts/spec-dock issue finish
 
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
@@ -44,7 +44,7 @@ Issue は実装の最小単位です。
 - canonical でない URL-like target は受け付けない
 - 通常の issue execution 開始は `./spec-dock/scripts/spec-dock issue start <target>` を primary path とし、active set と checkout を一操作で完了する
 - `issue start` は unfinished active issue branch 上で別 issue を始めようとした場合だけ default で block する。`main` / `master` / `develop` / `staging` や non-issue branch からの start は block しない
-- `./spec-dock/scripts/spec-dock issue start <target> -F` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
+- `./spec-dock/scripts/spec-dock issue start <target> -f` / `--force` は unfinished active issue guard だけを bypass する。依存未解決や他の readiness check は bypass しない
 - 通常の issue 完了は `./spec-dock/scripts/spec-dock issue finish` を primary path とする。active issue の linked GitHub issue を close し、already-closed も success として扱い、その確認後に active state を解除する
 `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
 - delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う

--- a/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
@@ -18,6 +18,7 @@ Issue は実装の最小単位です。
 ## 作成と issue start
 
 ```bash
+# primary lifecycle
 ./spec-dock/scripts/spec-dock new issue --epic <epic-id> --title "..."
 ./spec-dock/scripts/spec-dock new issue --create-github-issue --epic <epic-id> --title "..."
 
@@ -27,6 +28,7 @@ Issue は実装の最小単位です。
 ./spec-dock/scripts/spec-dock issue start <issue-id|github-issue-number|url> -f
 ./spec-dock/scripts/spec-dock issue finish
 
+# manual / recovery only
 ./spec-dock/scripts/spec-dock active set <issue-id|github-issue-number|url>
 ./spec-dock/scripts/spec-dock active set --id <issue-id>
 ./spec-dock/scripts/spec-dock active set --github-issue <n>
@@ -49,6 +51,7 @@ Issue は実装の最小単位です。
 `issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, sync, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
 - delivery completion の判定と required evidence の記録・確認は、`issue finish` の前に、active issue が set され対象 issue を確認できる状態で `spec-dock/active/issue/report.md` に対して行う
 - `issue finish` 後は active issue が clear されていてよく、active issue が残っていること自体を `complete` condition にしてはならない
+- `issue finish` 後に issue branch のまま `./spec-dock/scripts/spec-dock sync --github` を実行すると、branch-derived active restoration により active が復元され得る。active clear を保ちたい final sync は `main` などの non-issue branch に移動してから実行するか、finish 後 sync 自体を避ける
 - `active set` は manual / recovery command として維持する。unfinished active issue guard の対象外であり、必要時だけ direct に使う
 - `active set` のデフォルトは no-checkout。ブランチ移動が必要な場合だけ `--checkout`
 - `active set` は `<target>` の後方互換を維持しつつ、`--id` / `--github-issue` の explicit form も使える

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
@@ -199,6 +199,36 @@ class CloseNodeResult:
     warnings: list[str]
 
 
+@dataclass(frozen=True)
+class IssueStartRequest:
+    target: TargetRef
+    force: bool
+    issue_limit: int
+
+
+@dataclass(frozen=True)
+class IssueStartResult:
+    target_display: str
+    requested_issue_id: str
+    active_set: ActiveSetResult
+    forced: bool
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class IssueFinishRequest:
+    pass
+
+
+@dataclass(frozen=True)
+class IssueFinishResult:
+    issue_id: str
+    github_issue_number: int
+    already_closed: bool
+    active_cleared: bool
+    warnings: list[str]
+
+
 DeleteTerminalStatus = Literal[
     "ok",
     "invalid_selector_combination",
@@ -396,6 +426,12 @@ class UseCases:
     )
     close_node: Callable[[CloseNodeRequest], CloseNodeResult] = lambda _req: (_ for _ in ()).throw(
         RuntimeError("close_node is not configured")
+    )
+    issue_start: Callable[[IssueStartRequest], IssueStartResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("issue_start is not configured")
+    )
+    issue_finish: Callable[[IssueFinishRequest], IssueFinishResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("issue_finish is not configured")
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
         lambda _req: DoctorResult(ok=True, findings=[], warnings=[])

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from ..domain.active import infer_active_node_from_branch
+from ..domain.ids import format_id, parse_id
+from ..domain.models import SpecGraph, SpecNode, SpecNodeKind, SpecNodeSeed
+from ..domain.tree import build_graph
+from ..infra.contracts import ActiveManifest, StoredMetaRecord
+from .close_node import close_node
+from .contracts import (
+    ClearActiveRequest,
+    CloseNodeRequest,
+    IssueFinishRequest,
+    IssueFinishResult,
+    IssueStartRequest,
+    IssueStartResult,
+    SetActiveRequest,
+    TargetRef,
+)
+from .github_issue_targets import normalize_repo_slug
+from .ports import Ports
+from .repo_context import resolve_current_repo_slug
+from .set_active import clear_active, set_active
+
+
+def _to_spec_node_seed(record: StoredMetaRecord) -> SpecNodeSeed:
+    return SpecNodeSeed(
+        kind=cast(SpecNodeKind, record.kind),
+        id=record.id,
+        title=record.title,
+        slug=record.slug,
+        path=Path(record.path),
+        meta_path=Path(record.meta_path),
+        parent_id=record.parent_id,
+        initiative_id=record.initiative_id,
+        epic_id=record.epic_id,
+        github_issue_number=record.github_issue_number,
+        github_repo_owner=record.github_repo_owner,
+        github_repo_name=record.github_repo_name,
+    )
+
+
+def _resolve_repo_root(ports: Ports) -> Path:
+    if ports.repo_root is None:
+        raise RuntimeError("repo_root is required")
+    return ports.repo_root
+
+
+def _resolve_specdock_dir(ports: Ports) -> Path:
+    if ports.specdock_dir is not None:
+        return ports.specdock_dir
+    if ports.repo_root is not None:
+        return ports.repo_root / "spec-dock"
+    raise RuntimeError("specdock_dir is required")
+
+
+def _build_graph(ports: Ports) -> SpecGraph:
+    records = ports.node_reader.load_node_records()
+    if not records:
+        raise RuntimeError("No nodes found. Create at least one initiative/epic/issue.")
+    return build_graph([_to_spec_node_seed(record) for record in records])
+
+
+def _find_existing_id_by_num(graph: SpecGraph, *, prefix: str, num: int, local: bool) -> str | None:
+    for node_id in graph.nodes_by_id.keys():
+        try:
+            parsed_prefix, is_local, parsed_num = parse_id(str(node_id))
+        except RuntimeError:
+            continue
+        if parsed_prefix == prefix and parsed_num == num and is_local == local:
+            return str(node_id)
+    return None
+
+
+def _resolve_target_node(graph: SpecGraph, target: TargetRef, *, current_repo_slug: str | None) -> SpecNode:
+    if target.kind == "github_issue":
+        if target.github_issue_number is None:
+            raise RuntimeError("TargetRef.github_issue_number is required")
+        matches = [
+            node
+            for node in graph.nodes_by_id.values()
+            if node.github_issue_number == int(target.github_issue_number) and node.kind in ("initiative", "epic", "issue")
+        ]
+        target_repo_slug = normalize_repo_slug(target.github_repo_owner, target.github_repo_name)
+        if target_repo_slug is not None:
+            allow_current_unscoped = current_repo_slug is not None and target_repo_slug == current_repo_slug
+            matches = [
+                node
+                for node in matches
+                if (
+                    normalize_repo_slug(node.github_repo_owner, node.github_repo_name) == target_repo_slug
+                    or (
+                        allow_current_unscoped
+                        and normalize_repo_slug(node.github_repo_owner, node.github_repo_name) is None
+                    )
+                )
+            ]
+            scope = f" in repo scope ({target_repo_slug})"
+        else:
+            scope = ""
+        if not matches:
+            raise RuntimeError(
+                f"No node found for github.issue_number={int(target.github_issue_number)}{scope}. Create/link the node first."
+            )
+        if len(matches) > 1:
+            ids = ", ".join(sorted(f"{node.kind}:{node.id}" for node in matches))
+            raise RuntimeError(f"Ambiguous github.issue_number={int(target.github_issue_number)}{scope}: {ids}")
+        return matches[0]
+
+    if target.kind != "node_id":
+        raise RuntimeError(f"Unsupported target kind: {target.kind}")
+    if target.node_id is None:
+        raise RuntimeError("TargetRef.node_id is required")
+
+    raw_id = str(target.node_id).strip().lower()
+    prefix, is_local, num = parse_id(raw_id)
+    resolved = _find_existing_id_by_num(graph, prefix=prefix, num=num, local=is_local) or format_id(
+        prefix,
+        num,
+        local=is_local,
+    )
+    node = graph.nodes_by_id.get(resolved)
+    if node is None or node.kind not in ("initiative", "epic", "issue"):
+        raise RuntimeError(f"Node not found: {resolved}")
+    return node
+
+
+def _active_issue_id(manifest: ActiveManifest | None) -> str | None:
+    if manifest is None or manifest.issue is None:
+        return None
+    return manifest.issue.id
+
+
+def _github_state_for_node(node: SpecNode, ports: Ports, *, current_repo_slug: str | None) -> str:
+    if node.github_issue_number is None:
+        return "UNKNOWN"
+    if ports.issue_gateway is None:
+        return "UNKNOWN"
+    repo_slug = normalize_repo_slug(node.github_repo_owner, node.github_repo_name) or current_repo_slug
+    try:
+        snapshot = ports.issue_gateway.issue_view_snapshot(
+            _resolve_repo_root(ports),
+            int(node.github_issue_number),
+            repo_slug=repo_slug,
+        )
+    except RuntimeError:
+        return "UNKNOWN"
+    state = str(snapshot.state).strip().upper()
+    return state or "UNKNOWN"
+
+
+def _format_issue_target(node: SpecNode) -> str:
+    return node.id
+
+
+def _finish_failure_guidance(*, active_issue_id: str, error: RuntimeError) -> str:
+    return "\n".join(
+        [
+            f"issue finish failed while closing GitHub issue for active issue {active_issue_id}.",
+            "Active selection was not cleared.",
+            "Recovery:",
+            "  spec-dock/scripts/spec-dock active show",
+            "  spec-dock/scripts/spec-dock issue finish",
+            "  gh issue view <github-issue-number>",
+            str(error),
+        ]
+    )
+
+
+def _finish_active_clear_failure_guidance(
+    *,
+    active_issue_id: str,
+    github_issue_number: int,
+    error: RuntimeError,
+) -> str:
+    return "\n".join(
+        [
+            f"issue finish failed after GitHub close/already-closed step for active issue {active_issue_id}.",
+            f"GitHub issue #{github_issue_number} may have been closed successfully or may already have been closed.",
+            "Active selection was not cleared.",
+            "Recovery:",
+            "  spec-dock/scripts/spec-dock active show",
+            "  spec-dock/scripts/spec-dock issue finish",
+            "  spec-dock/scripts/spec-dock active set <issue-id> --checkout",
+            "Use manual active recovery if active metadata is stale or points at the wrong issue.",
+            str(error),
+        ]
+    )
+
+
+def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
+    if ports.active_state_store is None:
+        raise RuntimeError("active_state_store is required")
+    if ports.git_gateway is None:
+        raise RuntimeError("git_gateway is required")
+
+    graph = _build_graph(ports)
+    current_repo_slug = resolve_current_repo_slug(ports)
+    requested = _resolve_target_node(graph, req.target, current_repo_slug=current_repo_slug)
+    if requested.kind != "issue":
+        raise RuntimeError(f"issue start only accepts issue nodes: target={requested.id} kind={requested.kind}")
+
+    specdock_dir = _resolve_specdock_dir(ports)
+    active_load = ports.active_state_store.load_active_manifest(specdock_dir)
+    active_issue_id = _active_issue_id(active_load.manifest)
+    current_branch = ports.git_gateway.current_branch_or_none(_resolve_repo_root(ports)) or "(detached)"
+
+    if active_issue_id is not None and active_issue_id != requested.id and not req.force:
+        active_node = graph.nodes_by_id.get(active_issue_id)
+        branch_node, _reason = infer_active_node_from_branch(
+            graph,
+            branch=current_branch,
+            current_repo_slug=current_repo_slug,
+        )
+        if active_node is not None and branch_node is not None and branch_node.id == active_issue_id:
+            github_state = _github_state_for_node(active_node, ports, current_repo_slug=current_repo_slug)
+            if github_state != "CLOSED":
+                requested_target = _format_issue_target(requested)
+                raise RuntimeError(
+                    "\n".join(
+                        [
+                            "issue start blocked: unfinished active issue branch",
+                            f"- current active issue: {active_issue_id}",
+                            f"- current branch: {current_branch}",
+                            f"- requested issue: {requested.id}",
+                            f"- github state: {github_state}",
+                            "Next commands:",
+                            "  spec-dock/scripts/spec-dock issue finish",
+                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -F",
+                            f"  spec-dock/scripts/spec-dock active set {requested_target} --checkout",
+                        ]
+                    )
+                )
+
+    active_set_result = set_active(
+        SetActiveRequest(
+            target=req.target,
+            force=False,
+            checkout=True,
+            use_github=True,
+            issue_limit=req.issue_limit,
+        ),
+        ports,
+    )
+    warnings = list(active_set_result.warnings)
+    if req.force:
+        warnings.insert(0, f"issue start forced=true guard=unfinished_active_issue requested={requested.id}")
+    return IssueStartResult(
+        target_display=_format_issue_target(requested),
+        requested_issue_id=requested.id,
+        active_set=active_set_result,
+        forced=bool(req.force),
+        warnings=warnings,
+    )
+
+
+def issue_finish(req: IssueFinishRequest, ports: Ports) -> IssueFinishResult:
+    del req
+    if ports.active_state_store is None:
+        raise RuntimeError("active_state_store is required")
+
+    specdock_dir = _resolve_specdock_dir(ports)
+    active_load = ports.active_state_store.load_active_manifest(specdock_dir)
+    active_issue_id = _active_issue_id(active_load.manifest)
+    if active_issue_id is None:
+        raise RuntimeError(
+            "issue finish requires an active issue. Recovery: run issue start <issue> or active set <issue> --checkout."
+        )
+
+    try:
+        close_result = close_node(
+            CloseNodeRequest(
+                target=TargetRef(kind="node_id", node_id=active_issue_id, github_issue_number=None),
+            ),
+            ports,
+        )
+    except RuntimeError as error:
+        raise RuntimeError(_finish_failure_guidance(active_issue_id=active_issue_id, error=error)) from error
+    try:
+        clear_result = clear_active(ClearActiveRequest(), ports)
+    except RuntimeError as error:
+        raise RuntimeError(
+            _finish_active_clear_failure_guidance(
+                active_issue_id=active_issue_id,
+                github_issue_number=close_result.github_issue_number,
+                error=error,
+            )
+        ) from error
+    warnings = [*active_load.warnings, *close_result.warnings, *clear_result.warnings]
+    return IssueFinishResult(
+        issue_id=close_result.node_id,
+        github_issue_number=close_result.github_issue_number,
+        already_closed=close_result.already_closed,
+        active_cleared=clear_result.cleared,
+        warnings=warnings,
+    )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -228,7 +228,7 @@ def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
                             f"- github state: {github_state}",
                             "Next commands:",
                             "  spec-dock/scripts/spec-dock issue finish",
-                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -F",
+                            f"  spec-dock/scripts/spec-dock issue start {requested_target} -f",
                             f"  spec-dock/scripts/spec-dock active set {requested_target} --checkout",
                         ]
                     )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py
@@ -234,11 +234,12 @@ def issue_start(req: IssueStartRequest, ports: Ports) -> IssueStartResult:
                     )
                 )
 
+    checkout = active_issue_id != requested.id
     active_set_result = set_active(
         SetActiveRequest(
             target=req.target,
             force=False,
-            checkout=True,
+            checkout=checkout,
             use_github=True,
             issue_limit=req.issue_limit,
         ),

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -15,6 +15,8 @@ from ..application.contracts import UseCases
 from ..application.import_node import import_epic as application_import_epic
 from ..application.import_node import import_initiative as application_import_initiative
 from ..application.import_node import import_issue as application_import_issue
+from ..application.issue_lifecycle import issue_finish as application_issue_finish
+from ..application.issue_lifecycle import issue_start as application_issue_start
 from ..application.mutate_deps import mutate_deps as application_mutate_deps
 from ..application.ports import Ports
 from ..application.set_active import clear_active as application_clear_active
@@ -242,6 +244,8 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         mutate_deps=lambda req: application_mutate_deps(req, ports),
         delete_node=lambda req: application_delete_node(req, ports),
         close_node=lambda req: application_close_node(req, ports),
+        issue_start=lambda req: application_issue_start(req, ports),
+        issue_finish=lambda req: application_issue_finish(req, ports),
         validate_tree=lambda req: application_validate_tree(req, ports),
         doctor=lambda req: application_doctor(req, ports),
     )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
@@ -51,6 +51,11 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     _bind_leaf(sub.add_parser("delete", help="Delete local spec nodes with safeguards"), registry, "delete")
     _bind_leaf(sub.add_parser("close", help="Close the linked GitHub issue for a node target"), registry, "close")
 
+    p_issue = sub.add_parser("issue", help="Run guided issue lifecycle commands")
+    issue_sub = p_issue.add_subparsers(dest="issue_cmd", required=True)
+    _bind_leaf(issue_sub.add_parser("start", help="Set active issue and checkout its branch"), registry, "issue_start")
+    _bind_leaf(issue_sub.add_parser("finish", help="Close active issue and clear active pointers"), registry, "issue_finish")
+
     _bind_leaf(
         sub.add_parser("sync", help="Generate index.json/tree.json (optionally enrich from GitHub)"),
         registry,

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
@@ -6,6 +6,7 @@ from ..commands import delete as delete_commands
 from ..commands import deps as deps_commands
 from ..commands import doctor as doctor_commands
 from ..commands import import_cmd as import_commands
+from ..commands import issue as issue_commands
 from ..commands import new as new_commands
 from ..commands import sync as sync_commands
 from ..commands import validate as validate_commands
@@ -19,6 +20,7 @@ def build_registry() -> CommandRegistry:
     items.update(active_commands.command_specs())
     items.update(delete_commands.command_specs())
     items.update(close_commands.command_specs())
+    items.update(issue_commands.command_specs())
     items.update(sync_commands.command_specs())
     items.update(deps_commands.command_specs())
     items.update(validate_commands.command_specs())

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py
@@ -45,7 +45,7 @@ def _add_issue_start_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--id", help="Explicit issue node id target (e.g. iss-00123)")
     parser.add_argument("--github-issue", type=int, help="Explicit GitHub issue number target (e.g. 123)")
     parser.add_argument(
-        "-F",
+        "-f",
         "--force",
         action="store_true",
         help="Bypass only the unfinished active issue guard; dependency readiness checks still apply.",

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from ..application.contracts import IssueFinishRequest, IssueStartRequest, TargetRef, UseCases
+from ..presentation.cli_text import render_issue_finish_text, render_issue_start_text
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+from .targets import parse_explicit_target_flags
+
+
+@dataclass(frozen=True)
+class IssueStartArgs(CommandArgs):
+    target_ref: TargetRef
+    force: bool
+    gh_limit: int
+
+
+@dataclass(frozen=True)
+class IssueFinishArgs(CommandArgs):
+    pass
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "issue_start": CommandSpec(
+            add_arguments=_add_issue_start_arguments,
+            args_factory=_issue_start_args,
+            run=_run_issue_start,
+        ),
+        "issue_finish": CommandSpec(
+            add_arguments=_add_issue_finish_arguments,
+            args_factory=_issue_finish_args,
+            run=_run_issue_finish,
+        ),
+    }
+
+
+def _add_issue_start_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "target",
+        nargs="?",
+        help="GitHub issue number (digits only: 123 / #123 / URL) or issue node id (e.g. iss-00123)",
+    )
+    parser.add_argument("--id", help="Explicit issue node id target (e.g. iss-00123)")
+    parser.add_argument("--github-issue", type=int, help="Explicit GitHub issue number target (e.g. 123)")
+    parser.add_argument(
+        "-F",
+        "--force",
+        action="store_true",
+        help="Bypass only the unfinished active issue guard; dependency readiness checks still apply.",
+    )
+    parser.add_argument("--gh-limit", type=int, default=10000, help="gh issue list limit (default: 10000)")
+
+
+def _add_issue_finish_arguments(parser: argparse.ArgumentParser) -> None:
+    del parser
+
+
+def _issue_start_args(ns: argparse.Namespace) -> CommandArgs:
+    target_ref, _target_display = parse_explicit_target_flags(
+        positional_target=getattr(ns, "target", None),
+        node_id=getattr(ns, "id", None),
+        github_issue=getattr(ns, "github_issue", None),
+        command_label="issue start",
+    )
+    return IssueStartArgs(
+        target_ref=target_ref,
+        force=bool(getattr(ns, "force", False)),
+        gh_limit=int(getattr(ns, "gh_limit", 10000)),
+    )
+
+
+def _issue_finish_args(ns: argparse.Namespace) -> CommandArgs:
+    del ns
+    return IssueFinishArgs()
+
+
+def _run_issue_start(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    typed = _expect_issue_start_args(args)
+    result = use_cases.issue_start(
+        IssueStartRequest(
+            target=typed.target_ref,
+            force=typed.force,
+            issue_limit=typed.gh_limit,
+        )
+    )
+    return CommandOutcome(exit_code=0, text=render_issue_start_text(result))
+
+
+def _run_issue_finish(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    _expect_issue_finish_args(args)
+    result = use_cases.issue_finish(IssueFinishRequest())
+    return CommandOutcome(exit_code=0, text=render_issue_finish_text(result))
+
+
+def _expect_issue_start_args(args: CommandArgs) -> IssueStartArgs:
+    if not isinstance(args, IssueStartArgs):
+        raise RuntimeError("Invalid command args for issue start")
+    return args
+
+
+def _expect_issue_finish_args(args: CommandArgs) -> IssueFinishArgs:
+    if not isinstance(args, IssueFinishArgs):
+        raise RuntimeError("Invalid command args for issue finish")
+    return args

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -13,6 +13,8 @@ from ..application.contracts import (
     DepsCheckResult,
     DoctorResult,
     ImportNodeResult,
+    IssueFinishResult,
+    IssueStartResult,
     MutateDepsError,
     MutateDepsResult,
     SyncCommandResult,
@@ -253,6 +255,37 @@ def render_close_text(result: CloseNodeResult, *, target_display: str) -> CliTex
                 "spec-dock: ok (close) "
                 f"target={target_display} node={result.node_id} kind={result.node_kind} "
                 f"github=#{result.github_issue_number} state={state} already_closed={'true' if result.already_closed else 'false'}"
+            )
+        ],
+        stderr_lines=[],
+        warnings=list(result.warnings),
+    )
+
+
+def render_issue_start_text(result: IssueStartResult) -> CliText:
+    selection = result.active_set.selection
+    ini = selection.initiative_id or "(none)"
+    epic = selection.epic_id or "(none)"
+    issue = selection.issue_id or "(none)"
+    stdout_lines = [
+        (
+            "spec-dock: ok (issue start) "
+            f"target={result.target_display} initiative={ini} epic={epic} issue={issue}"
+        )
+    ]
+    if result.active_set.branch is not None:
+        stdout_lines.append(f"spec-dock: ok (issue checkout) branch={result.active_set.branch.desired}")
+    return CliText(stdout_lines=stdout_lines, stderr_lines=[], warnings=list(result.warnings))
+
+
+def render_issue_finish_text(result: IssueFinishResult) -> CliText:
+    return CliText(
+        stdout_lines=[
+            (
+                "spec-dock: ok (issue finish) "
+                f"issue={result.issue_id} github=#{result.github_issue_number} state=CLOSED "
+                f"active_cleared={'true' if result.active_cleared else 'false'} "
+                f"already_closed={'true' if result.already_closed else 'false'}"
             )
         ],
         stderr_lines=[],

--- a/tests/cli_runtime/test_issue_lifecycle.py
+++ b/tests/cli_runtime/test_issue_lifecycle.py
@@ -468,16 +468,20 @@ class TestCliIssueLifecycle(CliRuntimeHarness):
             bin_dir = Path(bin_tmp)
             self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
             test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            initial_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
 
             first = self._run_runtime_capture(target, ["issue", "start", "101"], env=test_env)
             self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
             self._commit_all(target, "active first issue")
+            issue_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
             same = self._run_runtime_capture(target, ["issue", "start", "101"], env=test_env)
             self.assertEqual(same.returncode, 0, same.stdout + same.stderr)
             self.assertNotIn("issue start blocked", same.stderr)
+            same_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(same_branch, issue_branch)
             self._commit_all(target, "same issue restart")
 
-            self._run_git(target, ["checkout", "main"])
+            self._run_git(target, ["checkout", initial_branch])
             main_start = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
             self.assertEqual(main_start.returncode, 0, main_start.stdout + main_start.stderr)
             self.assertNotIn("issue start blocked", main_start.stderr)

--- a/tests/cli_runtime/test_issue_lifecycle.py
+++ b/tests/cli_runtime/test_issue_lifecycle.py
@@ -272,7 +272,7 @@ class TestCliIssueLifecycle(CliRuntimeHarness):
             self.assertIn("requested issue: iss-00102", p.stderr)
             self.assertIn("github state: OPEN", p.stderr)
             self.assertIn("issue finish", p.stderr)
-            self.assertIn("issue start iss-00102 -F", p.stderr)
+            self.assertIn("issue start iss-00102 -f", p.stderr)
             self.assertIn("active set iss-00102 --checkout", p.stderr)
             self.assertEqual((target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8"), before)
             after_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
@@ -374,7 +374,7 @@ class TestCliIssueLifecycle(CliRuntimeHarness):
             self.assertIn("github state: UNKNOWN", p.stderr)
             self.assertIn("Next commands:", p.stderr)
             self.assertIn("spec-dock/scripts/spec-dock issue finish", p.stderr)
-            self.assertIn("spec-dock/scripts/spec-dock issue start iss-00102 -F", p.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue start iss-00102 -f", p.stderr)
             self.assertIn("spec-dock/scripts/spec-dock active set iss-00102 --checkout", p.stderr)
             self.assertEqual((target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8"), before)
             after_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
@@ -411,13 +411,26 @@ class TestCliIssueLifecycle(CliRuntimeHarness):
             self._run_runtime(target, ["issue", "start", "101"], env=test_env)
             self._commit_all(target, "active first issue")
 
-            p = self._run_runtime_capture(target, ["issue", "start", "102", "-F"], env=test_env)
+            p = self._run_runtime_capture(target, ["issue", "start", "102", "-f"], env=test_env)
             self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
             self.assertIn("active set blocked", p.stderr)
             self.assertNotIn("spec-dock: ok (issue start)", p.stdout)
             self.assertEqual(self._active_issue_id(target), "iss-00101")
             current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
             self.assertEqual(current, "iss-00101-first-issue")
+
+    def test_issue_start_rejects_legacy_force_short_options(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            uppercase = self._run_runtime_capture(target, ["issue", "start", "102", "-F"])
+            old_t = self._run_runtime_capture(target, ["issue", "start", "102", "-t"])
+
+            self.assertNotEqual(uppercase.returncode, 0, uppercase.stdout + uppercase.stderr)
+            self.assertIn("unrecognized arguments: -F", uppercase.stderr)
+            self.assertNotEqual(old_t.returncode, 0, old_t.stdout + old_t.stderr)
+            self.assertIn("unrecognized arguments: -t", old_t.stderr)
 
     def test_issue_start_force_switches_when_dependency_ready_and_warns(self) -> None:
         if os.name == "nt":

--- a/tests/cli_runtime/test_issue_lifecycle.py
+++ b/tests/cli_runtime/test_issue_lifecycle.py
@@ -509,6 +509,42 @@ class TestCliIssueLifecycle(CliRuntimeHarness):
             current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
             self.assertEqual(current, "iss-00102-second-issue")
 
+    def test_issue_start_then_finish_closes_open_issue_and_clears_active(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            state_path = self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            started = self._run_runtime_capture(target, ["issue", "start", "--id", "iss-00101"], env=test_env)
+            self.assertEqual(started.returncode, 0, started.stdout + started.stderr)
+            self.assertIn("spec-dock: ok (issue start)", started.stdout)
+            self.assertIn("issue=iss-00101", started.stdout)
+            self.assertIn("spec-dock: ok (issue checkout) branch=iss-00101-first-issue", started.stdout)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+            started_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(started_branch, "iss-00101-first-issue")
+
+            finished = self._run_runtime_capture(target, ["issue", "finish"], env=test_env)
+
+            self.assertEqual(finished.returncode, 0, finished.stdout + finished.stderr)
+            self.assertIn("spec-dock: ok (issue finish)", finished.stdout)
+            self.assertIn("issue=iss-00101", finished.stdout)
+            self.assertIn("github=#101", finished.stdout)
+            self.assertIn("active_cleared=true", finished.stdout)
+            self.assertIn("already_closed=false", finished.stdout)
+            self.assertIsNone(self._active_issue_id(target))
+            finished_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(finished_branch, "iss-00101-first-issue")
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertEqual(state["101"]["state"], "CLOSED")
+
     def test_issue_finish_closes_open_issue_and_clears_active(self) -> None:
         if os.name == "nt":
             self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")

--- a/tests/cli_runtime/test_issue_lifecycle.py
+++ b/tests/cli_runtime/test_issue_lifecycle.py
@@ -1,0 +1,621 @@
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.cli_runtime.harness import CliRuntimeHarness, main
+
+
+def _runtime_modules():
+    runtime_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "spec_dock"
+        / "assets"
+        / "spec_dock"
+        / "scripts"
+    )
+    sys.path.insert(0, str(runtime_scripts_dir))
+    try:
+        from spec_dock_runtime.application import contracts as app_contracts
+        from spec_dock_runtime.application import issue_lifecycle as app_issue_lifecycle
+        from spec_dock_runtime.application import ports as app_ports
+        from spec_dock_runtime.domain import models as domain_models
+        from spec_dock_runtime.infra import contracts as infra_contracts
+    finally:
+        sys.path.pop(0)
+    return app_contracts, app_issue_lifecycle, app_ports, domain_models, infra_contracts
+
+
+class _StubNodeReader:
+    def load_node_records(self):
+        return []
+
+
+class _StubActiveStateStore:
+    def __init__(self, infra_contracts) -> None:
+        self._infra_contracts = infra_contracts
+
+    def load_active_manifest(self, specdock_dir: Path):
+        del specdock_dir
+        return self._infra_contracts.ActiveManifestLoadResult(
+            manifest=self._infra_contracts.ActiveManifest(
+                initiative=None,
+                epic=None,
+                issue=self._infra_contracts.ActiveManifestEntry(
+                    id="iss-00101",
+                    path="spec-dock/initiatives/init-00001/epics/epic-00002/issues/iss-00101",
+                ),
+            ),
+            source="agent.active",
+            warnings=[],
+        )
+
+
+class TestIssueLifecycleApplication(unittest.TestCase):
+    def test_issue_finish_clear_active_failure_includes_recovery_guidance(self) -> None:
+        app_contracts, app_issue_lifecycle, app_ports, domain_models, infra_contracts = _runtime_modules()
+        original_close_node = app_issue_lifecycle.close_node
+        original_clear_active = app_issue_lifecycle.clear_active
+        try:
+            for already_closed in (False, True):
+                with self.subTest(already_closed=already_closed):
+                    close_calls = []
+
+                    def fake_close_node(req, ports):
+                        close_calls.append((req, ports))
+                        return app_contracts.CloseNodeResult(
+                            node_id="iss-00101",
+                            node_kind="issue",
+                            github_issue_number=101,
+                            issue_snapshot=domain_models.IssueSnapshot(
+                                issue_number=101,
+                                state="CLOSED",
+                                title="First issue",
+                                labels=[],
+                                updated_at="2026-05-05T00:00:00Z",
+                                url="https://github.com/example/repo/issues/101",
+                            ),
+                            already_closed=already_closed,
+                            warnings=[],
+                        )
+
+                    def fake_clear_active(req, ports):
+                        del req, ports
+                        raise RuntimeError("clear active failed")
+
+                    app_issue_lifecycle.close_node = fake_close_node
+                    app_issue_lifecycle.clear_active = fake_clear_active
+
+                    with tempfile.TemporaryDirectory() as tmp:
+                        repo_root = Path(tmp)
+                        ports = app_ports.Ports(
+                            node_reader=_StubNodeReader(),
+                            repo_root=repo_root,
+                            specdock_dir=repo_root / "spec-dock",
+                            active_state_store=_StubActiveStateStore(infra_contracts),
+                        )
+                        with self.assertRaises(RuntimeError) as raised:
+                            app_issue_lifecycle.issue_finish(app_contracts.IssueFinishRequest(), ports)
+
+                    message = str(raised.exception)
+                    self.assertEqual(len(close_calls), 1)
+                    self.assertIn("issue finish failed after GitHub close/already-closed step", message)
+                    self.assertIn("GitHub issue #101 may have been closed successfully", message)
+                    self.assertIn("may already have been closed", message)
+                    self.assertIn("Active selection was not cleared.", message)
+                    self.assertIn("spec-dock/scripts/spec-dock active show", message)
+                    self.assertIn("spec-dock/scripts/spec-dock issue finish", message)
+                    self.assertIn("spec-dock/scripts/spec-dock active set <issue-id> --checkout", message)
+                    self.assertIn("manual active recovery", message)
+                    self.assertIn("clear active failed", message)
+        finally:
+            app_issue_lifecycle.close_node = original_close_node
+            app_issue_lifecycle.clear_active = original_clear_active
+
+
+class TestCliIssueLifecycle(CliRuntimeHarness):
+    def _commit_all(self, target: Path, message: str) -> None:
+        self._run_git(target, ["add", "-A"])
+        self._run_git(
+            target,
+            ["-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "--allow-empty", "-m", message],
+        )
+
+    def _prepare_clean_repo_with_two_issues(self, target: Path) -> None:
+        self.assertEqual(main(["init", str(target)]), 0)
+        self._init_origin_repo(target)
+        self._run_git(
+            target,
+            ["-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "--allow-empty", "-m", "init"],
+        )
+        self._create_same_repo_linked_hierarchy(target, issue_issue_number=101, issue_title="First issue")
+        self._run_runtime(target, ["new", "issue", "--epic", "2", "--title", "Second issue", "--github-issue", "102"])
+        self._commit_all(target, "spec tree")
+
+    def _make_gh_stub(
+        self,
+        bin_dir: Path,
+        *,
+        states: dict[int, str],
+        fail_view_numbers: set[int] | None = None,
+        fail_close_numbers: set[int] | None = None,
+    ) -> Path:
+        state_path = bin_dir / "gh-state.json"
+        payload = {
+            str(number): {
+                "number": int(number),
+                "state": state,
+                "title": f"Issue {number}",
+                "labels": [],
+                "updatedAt": "2026-05-05T00:00:00Z",
+                "url": f"https://github.com/example/repo/issues/{number}",
+            }
+            for number, state in states.items()
+        }
+        state_path.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+        fail_numbers = sorted(int(number) for number in (fail_view_numbers or set()))
+        fail_close = sorted(int(number) for number in (fail_close_numbers or set()))
+        gh_path = bin_dir / "gh"
+        gh_path.write_text(
+            (
+                "#!/usr/bin/env python3\n"
+                "import json\n"
+                "import sys\n"
+                "from pathlib import Path\n\n"
+                f"STATE_PATH = Path({state_path.as_posix()!r})\n"
+                f"FAIL_VIEW = {fail_numbers!r}\n"
+                f"FAIL_CLOSE = {fail_close!r}\n"
+                "args = sys.argv[1:]\n"
+                "state = json.loads(STATE_PATH.read_text(encoding='utf-8'))\n"
+                "if args[:2] == ['issue', 'list']:\n"
+                "    print(json.dumps(list(state.values())))\n"
+                "    raise SystemExit(0)\n"
+                "if args[:2] == ['issue', 'view']:\n"
+                "    number = int(args[2])\n"
+                "    if number in FAIL_VIEW:\n"
+                "        print(f'view failed: {number}', file=sys.stderr)\n"
+                "        raise SystemExit(1)\n"
+                "    print(json.dumps(state[str(number)]))\n"
+                "    raise SystemExit(0)\n"
+                "if args[:2] == ['issue', 'close']:\n"
+                "    number = int(args[2])\n"
+                "    if number in FAIL_CLOSE:\n"
+                "        print(f'close failed: {number}', file=sys.stderr)\n"
+                "        raise SystemExit(1)\n"
+                "    item = state[str(number)]\n"
+                "    item['state'] = 'CLOSED'\n"
+                "    STATE_PATH.write_text(json.dumps(state) + '\\n', encoding='utf-8')\n"
+                "    raise SystemExit(0)\n"
+                "print(f'unexpected gh args: {args}', file=sys.stderr)\n"
+                "raise SystemExit(99)\n"
+            ),
+            encoding="utf-8",
+        )
+        gh_path.chmod(0o755)
+        return state_path
+
+    def _active_issue_id(self, target: Path) -> str | None:
+        active_path = target / "spec-dock" / ".agent" / "active.json"
+        if not active_path.exists():
+            return None
+        active = json.loads(active_path.read_text(encoding="utf-8"))
+        issue = active.get("issue")
+        if not isinstance(issue, dict):
+            return None
+        return issue.get("id")
+
+    def test_issue_start_sets_active_and_checks_out_issue_branch(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            p = self._run_runtime_capture(target, ["issue", "start", "--id", "iss-00101"], env=test_env)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("spec-dock: ok (issue start)", p.stdout)
+            self.assertIn("issue=iss-00101", p.stdout)
+            self.assertIn("spec-dock: ok (issue checkout) branch=iss-00101-first-issue", p.stdout)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00101-first-issue")
+
+    def test_issue_start_rejects_non_issue_node(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            p = self._run_runtime_capture(target, ["issue", "start", "--id", "epic-00002"], env=test_env)
+            self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("issue start only accepts issue nodes", p.stderr)
+            self.assertIsNone(self._active_issue_id(target))
+
+    def test_issue_start_blocks_different_open_issue_from_active_issue_branch(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            before = (target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8")
+            before_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+
+            p = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
+            self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("issue start blocked: unfinished active issue branch", p.stderr)
+            self.assertIn("current active issue: iss-00101", p.stderr)
+            self.assertIn("current branch: iss-00101-first-issue", p.stderr)
+            self.assertIn("requested issue: iss-00102", p.stderr)
+            self.assertIn("github state: OPEN", p.stderr)
+            self.assertIn("issue finish", p.stderr)
+            self.assertIn("issue start iss-00102 -F", p.stderr)
+            self.assertIn("active set iss-00102 --checkout", p.stderr)
+            self.assertEqual((target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8"), before)
+            after_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(after_branch, before_branch)
+
+    def test_direct_active_set_checkout_bypasses_issue_lifecycle_guard(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            issue_meta = (
+                target
+                / "spec-dock"
+                / "initiatives"
+                / "init-00001-auth-platform"
+                / "epics"
+                / "epic-00002-jwt-auth"
+                / "issues"
+                / "iss-00102-second-issue"
+                / ".meta.json"
+            )
+            meta = json.loads(issue_meta.read_text(encoding="utf-8"))
+            meta.pop("github", None)
+            self._write_json_force(issue_meta, meta)
+            self._commit_all(target, "make second issue locally ready")
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            self._commit_all(target, "active first issue")
+            active_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(active_branch, "iss-00101-first-issue")
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+
+            p = self._run_runtime_capture(target, ["active", "set", "iss-00102", "--checkout"])
+
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("spec-dock: ok (active set)", p.stdout)
+            self.assertNotIn("issue start blocked", p.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00102")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00102-second-issue")
+
+    def test_issue_start_allows_different_issue_from_closed_active_issue_branch(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            self._commit_all(target, "active closed issue")
+            active_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(active_branch, "iss-00101-first-issue")
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+            self._make_gh_stub(bin_dir, states={101: "CLOSED", 102: "OPEN"})
+
+            p = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
+
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertNotIn("issue start blocked", p.stderr)
+            self.assertIn("spec-dock: ok (issue start)", p.stdout)
+            self.assertIn("issue=iss-00102", p.stdout)
+            self.assertEqual(self._active_issue_id(target), "iss-00102")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00102-second-issue")
+
+    def test_issue_start_blocks_when_active_issue_github_state_unknown(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            before = (target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8")
+            before_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+
+            unknown_bin_dir = Path(bin_tmp)
+            self._make_gh_stub(unknown_bin_dir, states={101: "OPEN", 102: "OPEN"}, fail_view_numbers={101})
+            p = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
+
+            self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("issue start blocked: unfinished active issue branch", p.stderr)
+            self.assertIn("github state: UNKNOWN", p.stderr)
+            self.assertIn("Next commands:", p.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue finish", p.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue start iss-00102 -F", p.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock active set iss-00102 --checkout", p.stderr)
+            self.assertEqual((target / "spec-dock" / ".agent" / "active.json").read_text(encoding="utf-8"), before)
+            after_branch = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(after_branch, before_branch)
+
+    def test_issue_start_force_bypasses_only_lifecycle_guard_not_dependency_guard(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            issue_meta = (
+                target
+                / "spec-dock"
+                / "initiatives"
+                / "init-00001-auth-platform"
+                / "epics"
+                / "epic-00002-jwt-auth"
+                / "issues"
+                / "iss-00102-second-issue"
+                / ".meta.json"
+            )
+            meta = json.loads(issue_meta.read_text(encoding="utf-8"))
+            meta["depends_on"] = ["iss-00101"]
+            self._write_json_force(issue_meta, meta)
+            self._commit_all(target, "add dependency")
+
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            self._commit_all(target, "active first issue")
+
+            p = self._run_runtime_capture(target, ["issue", "start", "102", "-F"], env=test_env)
+            self.assertNotEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("active set blocked", p.stderr)
+            self.assertNotIn("spec-dock: ok (issue start)", p.stdout)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00101-first-issue")
+
+    def test_issue_start_force_switches_when_dependency_ready_and_warns(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            self._run_runtime(target, ["issue", "start", "101"], env=test_env)
+            self._commit_all(target, "active first issue")
+
+            p = self._run_runtime_capture(target, ["issue", "start", "--github-issue", "102", "--force"], env=test_env)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("spec-dock: ok (issue start)", p.stdout)
+            self.assertIn("issue=iss-00102", p.stdout)
+            self.assertIn("issue start forced=true", p.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00102")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00102-second-issue")
+
+    def test_issue_start_from_main_and_same_issue_restart_do_not_trigger_guard(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            first = self._run_runtime_capture(target, ["issue", "start", "101"], env=test_env)
+            self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+            self._commit_all(target, "active first issue")
+            same = self._run_runtime_capture(target, ["issue", "start", "101"], env=test_env)
+            self.assertEqual(same.returncode, 0, same.stdout + same.stderr)
+            self.assertNotIn("issue start blocked", same.stderr)
+            self._commit_all(target, "same issue restart")
+
+            self._run_git(target, ["checkout", "main"])
+            main_start = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
+            self.assertEqual(main_start.returncode, 0, main_start.stdout + main_start.stderr)
+            self.assertNotIn("issue start blocked", main_start.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00102")
+
+    def test_issue_start_from_non_issue_branch_allows_switching_open_active_issue(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self._prepare_clean_repo_with_two_issues(target)
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN", 102: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            first = self._run_runtime_capture(target, ["issue", "start", "101"], env=test_env)
+            self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+            self._commit_all(target, "active first issue")
+            self._run_git(target, ["checkout", "-b", "maintenance-check"])
+
+            p = self._run_runtime_capture(target, ["issue", "start", "102"], env=test_env)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertNotIn("issue start blocked", p.stderr)
+            self.assertIn("spec-dock: ok (issue start)", p.stdout)
+            self.assertEqual(self._active_issue_id(target), "iss-00102")
+            current = self._run_git(target, ["rev-parse", "--abbrev-ref", "HEAD"]).stdout.strip()
+            self.assertEqual(current, "iss-00102-second-issue")
+
+    def test_issue_finish_closes_open_issue_and_clears_active(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            self._create_same_repo_linked_hierarchy(target, issue_issue_number=101, issue_title="First issue")
+            self._run_runtime(target, ["active", "set", "--id", "iss-00101", "--force"])
+            bin_dir = Path(bin_tmp)
+            state_path = self._make_gh_stub(bin_dir, states={101: "OPEN"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            p = self._run_runtime_capture(target, ["issue", "finish"], env=test_env)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("spec-dock: ok (issue finish)", p.stdout)
+            self.assertIn("issue=iss-00101", p.stdout)
+            self.assertIn("github=#101", p.stdout)
+            self.assertIn("active_cleared=true", p.stdout)
+            self.assertIn("already_closed=false", p.stdout)
+            self.assertIsNone(self._active_issue_id(target))
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertEqual(state["101"]["state"], "CLOSED")
+
+    def test_issue_finish_already_closed_clears_active(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            self._create_same_repo_linked_hierarchy(target, issue_issue_number=101, issue_title="First issue")
+            self._run_runtime(target, ["active", "set", "--id", "iss-00101", "--force"])
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "CLOSED"})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+
+            p = self._run_runtime_capture(target, ["issue", "finish"], env=test_env)
+            self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+            self.assertIn("already_closed=true", p.stdout)
+            self.assertIsNone(self._active_issue_id(target))
+
+    def test_issue_finish_failures_leave_active_unchanged(self) -> None:
+        if os.name == "nt":
+            self.skipTest("This test uses a python gh stub with shebang; skip on Windows.")
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as bin_tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            no_active = self._run_runtime_capture(target, ["issue", "finish"])
+            self.assertNotEqual(no_active.returncode, 0, no_active.stdout + no_active.stderr)
+            self.assertIn("issue finish requires an active issue", no_active.stderr)
+            self.assertIn("Recovery:", no_active.stderr)
+            self.assertIn("issue start <issue>", no_active.stderr)
+            self.assertIn("active set <issue> --checkout", no_active.stderr)
+            self.assertIsNone(self._active_issue_id(target))
+
+            self._create_same_repo_linked_hierarchy(target, issue_issue_number=101, issue_title="First issue")
+            linked_meta_path = (
+                target
+                / "spec-dock"
+                / "initiatives"
+                / "init-00001-auth-platform"
+                / "epics"
+                / "epic-00002-jwt-auth"
+                / "issues"
+                / "iss-00101-first-issue"
+                / ".meta.json"
+            )
+            linked_meta = json.loads(linked_meta_path.read_text(encoding="utf-8"))
+            unlinked_meta = dict(linked_meta)
+            unlinked_meta.pop("github", None)
+            self._write_json_force(linked_meta_path, unlinked_meta)
+            self._run_runtime(target, ["active", "set", "--id", "iss-00101", "--force"])
+            no_link = self._run_runtime_capture(target, ["issue", "finish"])
+            self.assertNotEqual(no_link.returncode, 0, no_link.stdout + no_link.stderr)
+            self.assertIn("issue finish failed while closing GitHub issue", no_link.stderr)
+            self.assertIn("Active selection was not cleared.", no_link.stderr)
+            self.assertIn("Recovery:", no_link.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue finish", no_link.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock active show", no_link.stderr)
+            self.assertIn("Node is not linked to a GitHub issue", no_link.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+
+            active_path = target / "spec-dock" / ".agent" / "active.json"
+            stale_active = json.loads(active_path.read_text(encoding="utf-8"))
+            stale_active["issue"]["id"] = "iss-00999"
+            self._write_json_force(active_path, stale_active)
+            node_not_found = self._run_runtime_capture(target, ["issue", "finish"])
+            self.assertNotEqual(node_not_found.returncode, 0, node_not_found.stdout + node_not_found.stderr)
+            self.assertIn("issue finish failed while closing GitHub issue", node_not_found.stderr)
+            self.assertIn("Active selection was not cleared.", node_not_found.stderr)
+            self.assertIn("Recovery:", node_not_found.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue finish", node_not_found.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock active show", node_not_found.stderr)
+            self.assertIn("Node not found: iss-00999", node_not_found.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00999")
+
+            self._write_json_force(linked_meta_path, linked_meta)
+            self._run_runtime(target, ["active", "set", "--id", "iss-00101", "--force"])
+            bin_dir = Path(bin_tmp)
+            self._make_gh_stub(bin_dir, states={101: "OPEN"}, fail_view_numbers={101})
+            test_env = {"PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+            close_failure = self._run_runtime_capture(target, ["issue", "finish"], env=test_env)
+            self.assertNotEqual(close_failure.returncode, 0, close_failure.stdout + close_failure.stderr)
+            self.assertIn("issue finish failed while closing GitHub issue", close_failure.stderr)
+            self.assertIn("Active selection was not cleared.", close_failure.stderr)
+            self.assertIn("Recovery:", close_failure.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue finish", close_failure.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock active show", close_failure.stderr)
+            self.assertIn("view failed: 101", close_failure.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")
+
+            self._make_gh_stub(bin_dir, states={101: "OPEN"}, fail_close_numbers={101})
+            close_command_failure = self._run_runtime_capture(target, ["issue", "finish"], env=test_env)
+            self.assertNotEqual(close_command_failure.returncode, 0, close_command_failure.stdout + close_command_failure.stderr)
+            self.assertIn("issue finish failed while closing GitHub issue", close_command_failure.stderr)
+            self.assertIn("Active selection was not cleared.", close_command_failure.stderr)
+            self.assertIn("Recovery:", close_command_failure.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock issue finish", close_command_failure.stderr)
+            self.assertIn("spec-dock/scripts/spec-dock active show", close_command_failure.stderr)
+            self.assertIn("close failed: 101", close_command_failure.stderr)
+            self.assertEqual(self._active_issue_id(target), "iss-00101")

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -124,11 +124,17 @@ class TestInitUpdate(CliRuntimeHarness):
         ),
     }
     _DOGFOODING_RUNTIME_MIRROR_PROVIDER_ASSET_MAP = {
+        "spec-dock/scripts/spec_dock_runtime/application/contracts.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py"
+        ),
         "spec-dock/scripts/spec_dock_runtime/application/create_node.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/create_node.py"
         ),
         "spec-dock/scripts/spec_dock_runtime/application/doctor.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/application/issue_lifecycle.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/issue_lifecycle.py"
         ),
         "spec-dock/scripts/spec_dock_runtime/application/repo_context.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/repo_context.py"
@@ -138,6 +144,18 @@ class TestInitUpdate(CliRuntimeHarness):
         ),
         "spec-dock/scripts/spec_dock_runtime/application/import_node.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/import_node.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/cli/parser.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/cli/registry.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/commands/issue.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/issue.py"
         ),
         "spec-dock/scripts/spec_dock_runtime/commands/new.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/new.py"
@@ -150,6 +168,9 @@ class TestInitUpdate(CliRuntimeHarness):
         ),
         "spec-dock/scripts/spec_dock_runtime/infra/git_cli.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/git_cli.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py"
         ),
     }
 
@@ -628,6 +649,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00055-close-linked-github-issues-from-specdock-command/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00056-delete-local-spec-nodes-with-safeguards-and-epic-final-closeout/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/.meta.json",
@@ -668,6 +690,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00055-close-linked-github-issues-from-specdock-command/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00056-delete-local-spec-nodes-with-safeguards-and-epic-final-closeout/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/.meta.json": [],


### PR DESCRIPTION
## 概要

Issue lifecycle の通常導線として `spec-dock issue start` / `spec-dock issue finish` を追加します。

- `issue start` で issue を active 化し、対応ブランチへ checkout
- 未完了 active issue branch から別 issue を開始しようとした場合は default block
- `issue start -f` / `--force` は unfinished active issue guard のみを bypass
- `issue finish` で linked GitHub issue close / already-closed 確認後に active clear
- `active set` は manual / recovery path として維持
- provider / dogfooding runtime、docs、skill、README を lifecycle contract に同期

## 検証

- `./spec-dock/scripts/spec-dock validate`
  - `spec-dock: ok (validate) nodes=37`
- `python -m unittest tests.cli_runtime.test_issue_lifecycle -v`
  - `Ran 16 tests ... OK`
- `python -m unittest discover -v`
  - `Ran 764 tests ... OK`
- manual GitHub-backed lifecycle test
  - `manual-tests/reports/2026-05-05-iss-00088-issue-lifecycle/`
  - normal start / unfinished guard / `-f` readiness preservation / direct active set boundary / non-issue branch start / finish success / already-closed finish / failure recovery / cleanup を確認
- 外部レビュー
  - consultant: conditional pass findings を反映
  - QA reviewer: pass with P2 findings を反映
  - spec reviewer: P1 修正後、fresh re-review pass

## 補足

`issue finish` は lifecycle closure であり、commit / push / PR / merge / validate / test / review の完了を保証しません。delivery evidence は finish 前に report へ記録する契約です。

Closes #88
