### PR TITLE
docs(spec-planning): issue planの具体テストケース表記を標準化

### DIFF
--- a/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -19,8 +19,10 @@ description: Leaf skill for issue execution tasks in spec-dock.
   - `spec-dock/docs/phase_design.md`
   - `spec-dock/docs/phase_plan.md`
   - `spec-dock/docs/phase_plan_issue.md`
+  - `spec-dock/docs/authoring/issue-plan.md`
 - Keep templates as scaffolds. Use the docs above for authoring guidance, including Issue dependency analysis, `Module Dependency Diagram`, Linux `tree` style file-change planning, and step ordering.
 - Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
+- In spec authoring mode, Issue `plan.md` must satisfy `spec-dock/docs/authoring/issue-plan.md`. Each implementation step needs a `具体テストケース一覧` that uses card-style nested list test cases, not a wide table, with each concrete test case id at the start of the top-level bullet.
 - In spec authoring mode, do not move from requirement to design, design to plan, or plan to implementation until a fresh `spec-reviewer` returns `review_status: pass`; fix findings and re-run a fresh reviewer until pass.
 - Record each `Spec Authoring Gate` in `spec-dock/active/issue/report.md`, including investigation, user questions/answers, reviewer verdict, fixes, and promotion decision.
 - In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
@@ -34,6 +36,7 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - If sub-agents are unavailable, use degraded mode and record the environment reason, alternate verification, and added review evidence. Degraded mode never waives `code-reviewer`, `qa-reviewer`, or `spec-reviewer` gates.
 - Role selection matrix: `repo-analyst` maps code paths, impact, dependencies, and existing patterns before implementation; `dev-coder` handles bounded implementation steps with a clear write scope; `doc-writer` updates docs / templates / workflow / skill text; `qa-reviewer` owns final test adequacy and integration-test need; `code-reviewer` owns per-step diffs and the issue-wide integrated diff; `spec-reviewer` owns requirement / design / plan / report / implementation / docs alignment.
 - Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
+- Before implementation starts, stop if any implementation step is missing `具体テストケース一覧`, if concrete test cases are only global / table-only / abstract, or if a test case lacks the standard `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields. Docs-only or approved-no-op steps must state the test-not-needed reason and alternate verification.
 - Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
 - Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
 - Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.

--- a/.codex/prompts/execute-issue.md
+++ b/.codex/prompts/execute-issue.md
@@ -30,16 +30,21 @@ Before implementation starts:
    execution and completion.
 5. Treat `spec-dock/docs/workflow_spec_authoring.md` as the source of truth if
    requirement, design, or plan is not implementation-ready.
+6. Read `spec-dock/docs/authoring/issue-plan.md` when it exists and use it as
+   the Issue `plan.md` authoring contract for step-local concrete test cases.
 
 If the active issue docs are missing, contradictory, template-only, or not
 implementation-ready, do not start coding. Repair the issue docs through the
 spec authoring workflow and fresh spec-reviewer gates before implementation.
+Missing step-local `具体テストケース一覧`, table-only concrete test cases, or
+cases without `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields means
+the plan is not implementation-ready.
 
 When implementation is ready:
 
 - Follow `plan.md` step order exactly.
-- Use each step's step-local test cases, closure ids, close conditions,
-  verification commands, and evidence paths.
+- Use each step's card-style nested `具体テストケース一覧`, closure ids, close
+  conditions, verification commands, and evidence paths.
 - Preserve the `1 implementation step = 1 code-reviewer scope = 1 commit`
   contract unless the approved issue plan is amended and re-reviewed first.
 - Record implementation delegation decisions, step evidence, reviewer results,

--- a/spec-dock/docs/authoring/issue-plan.md
+++ b/spec-dock/docs/authoring/issue-plan.md
@@ -1,0 +1,81 @@
+# authoring: issue plan
+
+Issue の `plan.md` を作成・更新するときの agent-facing entrypoint です。
+共通正本は `workflow_spec_authoring.md`、`phase_plan.md`、`phase_plan_issue.md`、`workflow_issue.md` です。この文書は、それらを Issue plan 作成時に読み落とさないための entrypoint です。
+
+## 読む順序
+
+この文書を入口として読んだあと、次の共通正本へ進む。
+
+1. `workflow_spec_authoring.md`
+2. `phase_plan.md`
+3. `phase_plan_issue.md`
+4. `workflow_issue.md`
+5. `templates/issue/plan.md`
+
+## この artifact の責務
+
+- reviewer-pass 済みの `requirement.md` と `design.md` を、実装可能な step、検証、review gate、commit gate、final quality gate へ変換する。
+- `Spec-Locked Closure Index` で仕様 coverage を固定し、各 implementation step の `具体テストケース一覧` で TDD 実行入力を固定する。
+- step 順、依存、対象ファイル、検証方法、report evidence を実装者が判断せずに実行できる粒度へ落とす。
+
+## 必須項目
+
+- `この計画で満たす要件ID`
+- `依存関係から導く実装順序`
+- `ステップ一覧`
+- `要件 ↔ ステップ対応`
+- `Spec-Locked Closure Index`
+- 各 implementation step の `具体テストケース一覧`
+- 各 implementation step の `step closure contract`
+- 各 implementation step の `behavior slice execution`
+- 各 implementation step の `step gate`
+- `S90 docs impact resolution / docs refresh`
+- `S99 final quality gate`
+- `Final Exit Contract`
+
+## 具体テストケース一覧
+
+各 implementation step は、PC の Markdown preview / GitHub 表示で読みやすいカード型のネストリストで具体テストケースを書く。横長テーブルに押し込まない。
+ここで先頭に置く ID は concrete test case id であり、`Spec-Locked Closure Index` の closure `id` や `test ids` alias とは別物として扱う。step に複数の closure id または複数の concrete test case がある場合は、各 case に `関連 closure id` を置いて紐付ける。1 step = 1 closure id = 1 concrete case で対応が明らかな場合だけ省略してよい。
+
+標準形:
+
+```markdown
+#### 具体テストケース一覧
+
+- `tc-s01-001` acceptance: 作成後に自動 sync される
+  - 前提: temp repo に GitHub issue 作成 stub があり、sync artifact は作成前の状態。
+  - 操作: `spec-dock new issue --create-github-issue ...` を実行する。
+  - 期待結果: 手動 `sync` なしで `.agent/index-all.json` と `dashboard.md` に新 issue が反映される。
+  - 失敗検出: 作成は成功するが派生 artifact が stale のまま残る回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_new.py` に red-first test を追加する。
+  - 関連 closure id: `tc-001`
+
+- `tc-s01-002` negative: 作成失敗時は post-sync しない
+  - 前提: create preflight が失敗する不正な parent id を指定する。
+  - 操作: `spec-dock new issue --epic missing ...` を実行する。
+  - 期待結果: command は失敗し、post-sync は呼ばれず、既存 artifact は変化しない。
+  - 失敗検出: mutation failure 後に sync が走り、artifact が意図せず更新される回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_new.py` の failure-path test。
+  - 関連 closure id: `tc-002`
+```
+
+## reviewer fail 条件
+
+- implementation step に `具体テストケース一覧` がない。
+- concrete test case が step-local ではなく、global test plan だけに置かれている。
+- `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` のいずれかが欠けている。
+- 「テストを追加する」「動作確認する」など、実装者が fixture / command / expected observation を判断する必要がある抽象表現だけになっている。
+- 1ケースの本文が横長 table に押し込まれ、Markdown preview / GitHub 上で読みづらい。
+- docs-only / approved-no-op step で、テスト不要理由と代替検証方法が明記されていない。
+
+## 記法ルール
+
+- 1つのテストケースは1つの top-level bullet にする。
+- top-level bullet は ``- `tc-s01-001` acceptance: <短い説明>`` の形にし、先頭の backtick 付き ID は concrete test case id として扱う。
+- 標準の下位項目は `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` の5つにする。
+- 必要な場合だけ `対象ファイル`、`fixture`、`manual evidence` を追加する。
+- `関連 closure id` は、step に複数の closure id または複数の concrete test case がある場合は必須にする。1 step = 1 closure id = 1 concrete case で対応が明らかな場合だけ省略してよい。
+- 1項目が長くなりすぎる場合は2文までに抑え、詳細は `discussions/` または `report.md` に分離する。
+- `Spec-Locked Closure Index` は coverage ledger なので table のままでよい。具体テストケース本文とは役割を分ける。

--- a/spec-dock/docs/phase_plan_issue.md
+++ b/spec-dock/docs/phase_plan_issue.md
@@ -41,6 +41,12 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - required row の削除、`locked expectation` の変更、`required` の変更、`spec link` の意味変更は plan amendment と re-review を必須にする
 - typo / link correction は `report.md` の `Closure Delta` に記録してよい。新規 bug による regression 追加は Central index と step closure contract へ追加し、report に記録する
 - `test bundle` は必要な範囲で acceptance / characterization / property or invariant / regression / negative を分類する
+- 各 implementation step は `具体テストケース一覧` を必須で持つ。これは TDD 実行入力であり、`Spec-Locked Closure Index` や `test bundle` の代替ではない
+- `具体テストケース一覧` は PC の Markdown preview / GitHub 表示で読みやすいカード型ネストリストを標準にする。横長 table は trace matrix や短い index に限定し、1ケースの本文を table に押し込まない
+- 各 concrete test case は top-level bullet を ``- `tc-s01-001` acceptance: <短い説明>`` の形にし、下位項目として `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を持つ
+- concrete test case id は検索できるように各 concrete test case の先頭へ backtick 付きで置く。これは Central index の closure `id` や `test ids` alias とは別物であり、必要な場合だけ `関連 closure id` で紐付ける
+- docs-only / approved-no-op step で concrete test case を置かない場合は、テスト不要理由と代替検証方法を `具体テストケース一覧` に明記する
+- `具体テストケース一覧` がない implementation step、または「テストを追加する」「動作確認する」だけの抽象表現は implementation-ready ではない
 - `pre-implementation evidence` は expected red / characterization pass / test sensitivity evidence のいずれかを明記する
 - `test sensitivity evidence` は failing-first を完全要求できない場合に、bug-seed / mutation / contract mismatch / property violation などでテストが欠陥を検出できることを示す
 - 各 step の close 判定は Issue 全体の一覧表ではなく、その step の `step closure contract` を正本にする
@@ -77,6 +83,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - `Spec-Locked Closure Index` を置く
 - `実装ステップ` を step / block / behavior slice で書く
 - 各 behavior slice の `step closure contract` / `test bundle` / `pre-implementation evidence` / `bounded implementation batch` / `verification` を置き、`test bundle` は closure index の `id` を参照できるようにする
+- 各 implementation step に `具体テストケース一覧` を置き、ネストリストで `前提` / `操作` / `期待結果` / `失敗検出` / `検証方法` を書く
 - `refactor / tidy` には `目的` と `guardrail` を置き、具体的な refactor 内容は `report.md` へ送る
 - 各 step gate に `code-reviewer gate`、`commit gate`、`no-op gate`、`report update` を置く
 - `S90 docs impact resolution / docs refresh` を必須で置く
@@ -100,6 +107,9 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - every required row が non-placeholder の `spec link`、`observable input/state`、`locked expectation`、`evidence level`、`closure evidence` を持つ
 - every required row に step-local close condition と planned verification evidence path がある
 - behavior slice が step closure contract、test bundle、pre-implementation evidence を持ち、bounded implementation batch として原因局所化できる
+- 各 implementation step が step-local な `具体テストケース一覧` を持ち、各 case が `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を含む
+- concrete test case が横長 table に押し込まれて読みづらい場合、または global test plan だけで step-local case がない場合は fail とする
+- docs-only / approved-no-op step は、テスト不要理由と inspection / manual / docs diff などの代替検証方法を持つ
 - 各 implementation step が commit 単位として設計され、`code-reviewer gate`、`commit gate`、`no-op gate` を持っている
 - step 順が design の依存関係分析、Module Dependency Diagram、directory / file change plan と矛盾しない
 - 各 step の `depends on` / `unblocks` / `target files` が、実装順と変更対象の確認に使える

--- a/spec-dock/docs/workflow_spec_authoring.md
+++ b/spec-dock/docs/workflow_spec_authoring.md
@@ -20,12 +20,13 @@ scope 固有の lifecycle / governance は `workflow_initiative.md` / `workflow_
 ## authoring lifecycle
 
 1. 対象 scope と既存 node を確認する。
-2. 対象 scope の `workflow_*.md` と phase playbook を読む。
-3. 調査結果、仮説、選択肢、質問を必要に応じて `discussions/` に分離する。
-4. 対象 artifact を更新する。
-5. fresh `spec-reviewer` を起動し、対象 artifact と upstream artifact を review する。
-6. `fail` なら修正し、fresh `spec-reviewer` で再レビューする。
-7. `pass` なら `report.md` に gate evidence を残し、次 phase へ進む。
+2. 対象 artifact に対応する `docs/authoring/<scope>-<phase>.md` がある場合は最初に読む。
+3. 対象 scope の `workflow_*.md` と phase playbook を読む。
+4. 調査結果、仮説、選択肢、質問を必要に応じて `discussions/` に分離する。
+5. 対象 artifact を更新する。
+6. fresh `spec-reviewer` を起動し、対象 artifact と upstream artifact を review する。
+7. `fail` なら修正し、fresh `spec-reviewer` で再レビューする。
+8. `pass` なら `report.md` に gate evidence を残し、次 phase へ進む。
 
 ## requirement gate
 
@@ -46,6 +47,7 @@ scope 固有の lifecycle / governance は `workflow_initiative.md` / `workflow_
 - reviewer-pass 済み requirement / design を前提にする。
 - 分解、順序、依存、検証、review gate、完了条件、downstream handoff を固定する。
 - 未解決設計論点や未承認 requirement を plan に先送りしない。
+- Issue plan は `docs/authoring/issue-plan.md` の concrete test case contract に従い、各 implementation step に step-local な `具体テストケース一覧` を置く。
 - `spec-reviewer` は plan が requirement / design と矛盾せず、次工程へ安全に渡せることを確認する。
 
 ## downstream handoff

--- a/spec-dock/templates/issue/plan.md
+++ b/spec-dock/templates/issue/plan.md
@@ -62,7 +62,7 @@ ID: "<ISS_ID>"
 
 ## Spec-Locked Closure Index（仕様固定クロージャ索引）
 
-> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。具体テストケース本文は各 implementation step の `具体テストケース一覧` にカード型ネストリストで置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
 
 | id | phase / step | slice | type | spec link | locked expectation | observable input/state | bug class guarded | required | evidence level | closure evidence |
 |---|---|---|---|---|---|---|---|---|---|---|
@@ -83,6 +83,7 @@ ID: "<ISS_ID>"
 - 詳細化方針:
   - 通常 Issue は step / behavior slice ごとに 1〜3 件程度の検証契約を書く。
   - 中央 index は重複するテストケース表にせず、仕様ロック、担当 step、required、evidence level、closure evidence だけを追う。
+  - 具体テストケース本文は横長 table にせず、各 step の `具体テストケース一覧` にネストリストで書く。
   - public CLI behavior、shipped scaffold / runtime contract、template / system docs の互換性、installer / update / migration、filesystem / GitHub / active store、negative path、既存 regression、複数 Agent 並列実装の領域では詳細化する。
 
 ## レビュー / QA ゲート方針
@@ -106,6 +107,7 @@ ID: "<ISS_ID>"
 - plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
 - 各 implementation step は commit 単位として設計し、`code-reviewer gate` を pass してから `commit gate` で閉じる。
 - `approved-no-op` は差分なしの場合だけ許可し、理由、確認対象、差分なし確認コマンドを report に残す。
+- implementation step を追加する場合は S01 の subsections を複製し、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
 
 ## 実装ステップ
 
@@ -134,6 +136,28 @@ ID: "<ISS_ID>"
   - negative:
 - pre-implementation evidence:
   - expected red / characterization pass / test sensitivity evidence:
+
+#### 具体テストケース一覧
+
+- `tc-s01-001` acceptance: <短い説明>
+  - 前提: ...
+  - 操作: ...
+  - 期待結果: ...
+  - 失敗検出: ...
+  - 検証方法: ...
+  - 関連 closure id: tc-001
+
+- `tc-s01-002` negative: <短い説明>
+  - 前提: ...
+  - 操作: ...
+  - 期待結果: ...
+  - 失敗検出: ...
+  - 検証方法: ...
+  - 関連 closure id: tc-002
+
+- docs-only / approved-no-op step の場合:
+  - テスト不要理由: ...
+  - 代替検証方法: ...
 - report draft update before review:
   - verification / closure / review intent evidence to include in the step diff:
 - notes:
@@ -193,7 +217,8 @@ ID: "<ISS_ID>"
   - clean check result:
 
 ### Sxx — <next observable behavior>
-- ...
+- S01 の subsections を複製して記入する。
+- `具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
 
 ### S90 — docs impact resolution / docs refresh
 - 対象:

--- a/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -19,8 +19,10 @@ description: Leaf skill for issue execution tasks in spec-dock.
   - `spec-dock/docs/phase_design.md`
   - `spec-dock/docs/phase_plan.md`
   - `spec-dock/docs/phase_plan_issue.md`
+  - `spec-dock/docs/authoring/issue-plan.md`
 - Keep templates as scaffolds. Use the docs above for authoring guidance, including Issue dependency analysis, `Module Dependency Diagram`, Linux `tree` style file-change planning, and step ordering.
 - Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
+- In spec authoring mode, Issue `plan.md` must satisfy `spec-dock/docs/authoring/issue-plan.md`. Each implementation step needs a `具体テストケース一覧` that uses card-style nested list test cases, not a wide table, with each concrete test case id at the start of the top-level bullet.
 - In spec authoring mode, do not move from requirement to design, design to plan, or plan to implementation until a fresh `spec-reviewer` returns `review_status: pass`; fix findings and re-run a fresh reviewer until pass.
 - Record each `Spec Authoring Gate` in `spec-dock/active/issue/report.md`, including investigation, user questions/answers, reviewer verdict, fixes, and promotion decision.
 - In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
@@ -34,6 +36,7 @@ description: Leaf skill for issue execution tasks in spec-dock.
 - If sub-agents are unavailable, use degraded mode and record the environment reason, alternate verification, and added review evidence. Degraded mode never waives `code-reviewer`, `qa-reviewer`, or `spec-reviewer` gates.
 - Role selection matrix: `repo-analyst` maps code paths, impact, dependencies, and existing patterns before implementation; `dev-coder` handles bounded implementation steps with a clear write scope; `doc-writer` updates docs / templates / workflow / skill text; `qa-reviewer` owns final test adequacy and integration-test need; `code-reviewer` owns per-step diffs and the issue-wide integrated diff; `spec-reviewer` owns requirement / design / plan / report / implementation / docs alignment.
 - Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
+- Before implementation starts, stop if any implementation step is missing `具体テストケース一覧`, if concrete test cases are only global / table-only / abstract, or if a test case lacks the standard `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields. Docs-only or approved-no-op steps must state the test-not-needed reason and alternate verification.
 - Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
 - Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
 - Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.

--- a/src/spec_dock/assets/install_root/.codex/prompts/execute-issue.md
+++ b/src/spec_dock/assets/install_root/.codex/prompts/execute-issue.md
@@ -30,16 +30,21 @@ Before implementation starts:
    execution and completion.
 5. Treat `spec-dock/docs/workflow_spec_authoring.md` as the source of truth if
    requirement, design, or plan is not implementation-ready.
+6. Read `spec-dock/docs/authoring/issue-plan.md` when it exists and use it as
+   the Issue `plan.md` authoring contract for step-local concrete test cases.
 
 If the active issue docs are missing, contradictory, template-only, or not
 implementation-ready, do not start coding. Repair the issue docs through the
 spec authoring workflow and fresh spec-reviewer gates before implementation.
+Missing step-local `具体テストケース一覧`, table-only concrete test cases, or
+cases without `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields means
+the plan is not implementation-ready.
 
 When implementation is ready:
 
 - Follow `plan.md` step order exactly.
-- Use each step's step-local test cases, closure ids, close conditions,
-  verification commands, and evidence paths.
+- Use each step's card-style nested `具体テストケース一覧`, closure ids, close
+  conditions, verification commands, and evidence paths.
 - Preserve the `1 implementation step = 1 code-reviewer scope = 1 commit`
   contract unless the approved issue plan is amended and re-reviewed first.
 - Record implementation delegation decisions, step evidence, reviewer results,

--- a/src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md
+++ b/src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md
@@ -1,0 +1,81 @@
+# authoring: issue plan
+
+Issue の `plan.md` を作成・更新するときの agent-facing entrypoint です。
+共通正本は `workflow_spec_authoring.md`、`phase_plan.md`、`phase_plan_issue.md`、`workflow_issue.md` です。この文書は、それらを Issue plan 作成時に読み落とさないための entrypoint です。
+
+## 読む順序
+
+この文書を入口として読んだあと、次の共通正本へ進む。
+
+1. `workflow_spec_authoring.md`
+2. `phase_plan.md`
+3. `phase_plan_issue.md`
+4. `workflow_issue.md`
+5. `templates/issue/plan.md`
+
+## この artifact の責務
+
+- reviewer-pass 済みの `requirement.md` と `design.md` を、実装可能な step、検証、review gate、commit gate、final quality gate へ変換する。
+- `Spec-Locked Closure Index` で仕様 coverage を固定し、各 implementation step の `具体テストケース一覧` で TDD 実行入力を固定する。
+- step 順、依存、対象ファイル、検証方法、report evidence を実装者が判断せずに実行できる粒度へ落とす。
+
+## 必須項目
+
+- `この計画で満たす要件ID`
+- `依存関係から導く実装順序`
+- `ステップ一覧`
+- `要件 ↔ ステップ対応`
+- `Spec-Locked Closure Index`
+- 各 implementation step の `具体テストケース一覧`
+- 各 implementation step の `step closure contract`
+- 各 implementation step の `behavior slice execution`
+- 各 implementation step の `step gate`
+- `S90 docs impact resolution / docs refresh`
+- `S99 final quality gate`
+- `Final Exit Contract`
+
+## 具体テストケース一覧
+
+各 implementation step は、PC の Markdown preview / GitHub 表示で読みやすいカード型のネストリストで具体テストケースを書く。横長テーブルに押し込まない。
+ここで先頭に置く ID は concrete test case id であり、`Spec-Locked Closure Index` の closure `id` や `test ids` alias とは別物として扱う。step に複数の closure id または複数の concrete test case がある場合は、各 case に `関連 closure id` を置いて紐付ける。1 step = 1 closure id = 1 concrete case で対応が明らかな場合だけ省略してよい。
+
+標準形:
+
+```markdown
+#### 具体テストケース一覧
+
+- `tc-s01-001` acceptance: 作成後に自動 sync される
+  - 前提: temp repo に GitHub issue 作成 stub があり、sync artifact は作成前の状態。
+  - 操作: `spec-dock new issue --create-github-issue ...` を実行する。
+  - 期待結果: 手動 `sync` なしで `.agent/index-all.json` と `dashboard.md` に新 issue が反映される。
+  - 失敗検出: 作成は成功するが派生 artifact が stale のまま残る回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_new.py` に red-first test を追加する。
+  - 関連 closure id: `tc-001`
+
+- `tc-s01-002` negative: 作成失敗時は post-sync しない
+  - 前提: create preflight が失敗する不正な parent id を指定する。
+  - 操作: `spec-dock new issue --epic missing ...` を実行する。
+  - 期待結果: command は失敗し、post-sync は呼ばれず、既存 artifact は変化しない。
+  - 失敗検出: mutation failure 後に sync が走り、artifact が意図せず更新される回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_new.py` の failure-path test。
+  - 関連 closure id: `tc-002`
+```
+
+## reviewer fail 条件
+
+- implementation step に `具体テストケース一覧` がない。
+- concrete test case が step-local ではなく、global test plan だけに置かれている。
+- `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` のいずれかが欠けている。
+- 「テストを追加する」「動作確認する」など、実装者が fixture / command / expected observation を判断する必要がある抽象表現だけになっている。
+- 1ケースの本文が横長 table に押し込まれ、Markdown preview / GitHub 上で読みづらい。
+- docs-only / approved-no-op step で、テスト不要理由と代替検証方法が明記されていない。
+
+## 記法ルール
+
+- 1つのテストケースは1つの top-level bullet にする。
+- top-level bullet は ``- `tc-s01-001` acceptance: <短い説明>`` の形にし、先頭の backtick 付き ID は concrete test case id として扱う。
+- 標準の下位項目は `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` の5つにする。
+- 必要な場合だけ `対象ファイル`、`fixture`、`manual evidence` を追加する。
+- `関連 closure id` は、step に複数の closure id または複数の concrete test case がある場合は必須にする。1 step = 1 closure id = 1 concrete case で対応が明らかな場合だけ省略してよい。
+- 1項目が長くなりすぎる場合は2文までに抑え、詳細は `discussions/` または `report.md` に分離する。
+- `Spec-Locked Closure Index` は coverage ledger なので table のままでよい。具体テストケース本文とは役割を分ける。

--- a/src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md
@@ -41,6 +41,12 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - required row の削除、`locked expectation` の変更、`required` の変更、`spec link` の意味変更は plan amendment と re-review を必須にする
 - typo / link correction は `report.md` の `Closure Delta` に記録してよい。新規 bug による regression 追加は Central index と step closure contract へ追加し、report に記録する
 - `test bundle` は必要な範囲で acceptance / characterization / property or invariant / regression / negative を分類する
+- 各 implementation step は `具体テストケース一覧` を必須で持つ。これは TDD 実行入力であり、`Spec-Locked Closure Index` や `test bundle` の代替ではない
+- `具体テストケース一覧` は PC の Markdown preview / GitHub 表示で読みやすいカード型ネストリストを標準にする。横長 table は trace matrix や短い index に限定し、1ケースの本文を table に押し込まない
+- 各 concrete test case は top-level bullet を ``- `tc-s01-001` acceptance: <短い説明>`` の形にし、下位項目として `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を持つ
+- concrete test case id は検索できるように各 concrete test case の先頭へ backtick 付きで置く。これは Central index の closure `id` や `test ids` alias とは別物であり、必要な場合だけ `関連 closure id` で紐付ける
+- docs-only / approved-no-op step で concrete test case を置かない場合は、テスト不要理由と代替検証方法を `具体テストケース一覧` に明記する
+- `具体テストケース一覧` がない implementation step、または「テストを追加する」「動作確認する」だけの抽象表現は implementation-ready ではない
 - `pre-implementation evidence` は expected red / characterization pass / test sensitivity evidence のいずれかを明記する
 - `test sensitivity evidence` は failing-first を完全要求できない場合に、bug-seed / mutation / contract mismatch / property violation などでテストが欠陥を検出できることを示す
 - 各 step の close 判定は Issue 全体の一覧表ではなく、その step の `step closure contract` を正本にする
@@ -77,6 +83,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - `Spec-Locked Closure Index` を置く
 - `実装ステップ` を step / block / behavior slice で書く
 - 各 behavior slice の `step closure contract` / `test bundle` / `pre-implementation evidence` / `bounded implementation batch` / `verification` を置き、`test bundle` は closure index の `id` を参照できるようにする
+- 各 implementation step に `具体テストケース一覧` を置き、ネストリストで `前提` / `操作` / `期待結果` / `失敗検出` / `検証方法` を書く
 - `refactor / tidy` には `目的` と `guardrail` を置き、具体的な refactor 内容は `report.md` へ送る
 - 各 step gate に `code-reviewer gate`、`commit gate`、`no-op gate`、`report update` を置く
 - `S90 docs impact resolution / docs refresh` を必須で置く
@@ -100,6 +107,9 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - every required row が non-placeholder の `spec link`、`observable input/state`、`locked expectation`、`evidence level`、`closure evidence` を持つ
 - every required row に step-local close condition と planned verification evidence path がある
 - behavior slice が step closure contract、test bundle、pre-implementation evidence を持ち、bounded implementation batch として原因局所化できる
+- 各 implementation step が step-local な `具体テストケース一覧` を持ち、各 case が `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を含む
+- concrete test case が横長 table に押し込まれて読みづらい場合、または global test plan だけで step-local case がない場合は fail とする
+- docs-only / approved-no-op step は、テスト不要理由と inspection / manual / docs diff などの代替検証方法を持つ
 - 各 implementation step が commit 単位として設計され、`code-reviewer gate`、`commit gate`、`no-op gate` を持っている
 - step 順が design の依存関係分析、Module Dependency Diagram、directory / file change plan と矛盾しない
 - 各 step の `depends on` / `unblocks` / `target files` が、実装順と変更対象の確認に使える

--- a/src/spec_dock/assets/spec_dock/docs/workflow_spec_authoring.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow_spec_authoring.md
@@ -20,12 +20,13 @@ scope 固有の lifecycle / governance は `workflow_initiative.md` / `workflow_
 ## authoring lifecycle
 
 1. 対象 scope と既存 node を確認する。
-2. 対象 scope の `workflow_*.md` と phase playbook を読む。
-3. 調査結果、仮説、選択肢、質問を必要に応じて `discussions/` に分離する。
-4. 対象 artifact を更新する。
-5. fresh `spec-reviewer` を起動し、対象 artifact と upstream artifact を review する。
-6. `fail` なら修正し、fresh `spec-reviewer` で再レビューする。
-7. `pass` なら `report.md` に gate evidence を残し、次 phase へ進む。
+2. 対象 artifact に対応する `docs/authoring/<scope>-<phase>.md` がある場合は最初に読む。
+3. 対象 scope の `workflow_*.md` と phase playbook を読む。
+4. 調査結果、仮説、選択肢、質問を必要に応じて `discussions/` に分離する。
+5. 対象 artifact を更新する。
+6. fresh `spec-reviewer` を起動し、対象 artifact と upstream artifact を review する。
+7. `fail` なら修正し、fresh `spec-reviewer` で再レビューする。
+8. `pass` なら `report.md` に gate evidence を残し、次 phase へ進む。
 
 ## requirement gate
 
@@ -46,6 +47,7 @@ scope 固有の lifecycle / governance は `workflow_initiative.md` / `workflow_
 - reviewer-pass 済み requirement / design を前提にする。
 - 分解、順序、依存、検証、review gate、完了条件、downstream handoff を固定する。
 - 未解決設計論点や未承認 requirement を plan に先送りしない。
+- Issue plan は `docs/authoring/issue-plan.md` の concrete test case contract に従い、各 implementation step に step-local な `具体テストケース一覧` を置く。
 - `spec-reviewer` は plan が requirement / design と矛盾せず、次工程へ安全に渡せることを確認する。
 
 ## downstream handoff

--- a/src/spec_dock/assets/spec_dock/templates/issue/plan.md
+++ b/src/spec_dock/assets/spec_dock/templates/issue/plan.md
@@ -62,7 +62,7 @@ ID: "<ISS_ID>"
 
 ## Spec-Locked Closure Index（仕様固定クロージャ索引）
 
-> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+> これは Issue 全体のテストケース一覧ではなく、エージェントが仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の test contract と close 条件は各 step の `step closure contract` に置く。具体テストケース本文は各 implementation step の `具体テストケース一覧` にカード型ネストリストで置く。private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
 
 | id | phase / step | slice | type | spec link | locked expectation | observable input/state | bug class guarded | required | evidence level | closure evidence |
 |---|---|---|---|---|---|---|---|---|---|---|
@@ -83,6 +83,7 @@ ID: "<ISS_ID>"
 - 詳細化方針:
   - 通常 Issue は step / behavior slice ごとに 1〜3 件程度の検証契約を書く。
   - 中央 index は重複するテストケース表にせず、仕様ロック、担当 step、required、evidence level、closure evidence だけを追う。
+  - 具体テストケース本文は横長 table にせず、各 step の `具体テストケース一覧` にネストリストで書く。
   - public CLI behavior、shipped scaffold / runtime contract、template / system docs の互換性、installer / update / migration、filesystem / GitHub / active store、negative path、既存 regression、複数 Agent 並列実装の領域では詳細化する。
 
 ## レビュー / QA ゲート方針
@@ -106,6 +107,7 @@ ID: "<ISS_ID>"
 - plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
 - 各 implementation step は commit 単位として設計し、`code-reviewer gate` を pass してから `commit gate` で閉じる。
 - `approved-no-op` は差分なしの場合だけ許可し、理由、確認対象、差分なし確認コマンドを report に残す。
+- implementation step を追加する場合は S01 の subsections を複製し、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
 
 ## 実装ステップ
 
@@ -134,6 +136,28 @@ ID: "<ISS_ID>"
   - negative:
 - pre-implementation evidence:
   - expected red / characterization pass / test sensitivity evidence:
+
+#### 具体テストケース一覧
+
+- `tc-s01-001` acceptance: <短い説明>
+  - 前提: ...
+  - 操作: ...
+  - 期待結果: ...
+  - 失敗検出: ...
+  - 検証方法: ...
+  - 関連 closure id: tc-001
+
+- `tc-s01-002` negative: <短い説明>
+  - 前提: ...
+  - 操作: ...
+  - 期待結果: ...
+  - 失敗検出: ...
+  - 検証方法: ...
+  - 関連 closure id: tc-002
+
+- docs-only / approved-no-op step の場合:
+  - テスト不要理由: ...
+  - 代替検証方法: ...
 - report draft update before review:
   - verification / closure / review intent evidence to include in the step diff:
 - notes:
@@ -193,7 +217,8 @@ ID: "<ISS_ID>"
   - clean check result:
 
 ### Sxx — <next observable behavior>
-- ...
+- S01 の subsections を複製して記入する。
+- `具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
 
 ### S90 — docs impact resolution / docs refresh
 - 対象:

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -81,6 +81,9 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/docs/workflow_spec_authoring.md": (
             "src/spec_dock/assets/spec_dock/docs/workflow_spec_authoring.md"
         ),
+        "spec-dock/docs/authoring/issue-plan.md": (
+            "src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md"
+        ),
         "spec-dock/docs/workflow_initiative.md": (
             "src/spec_dock/assets/spec_dock/docs/workflow_initiative.md"
         ),
@@ -883,6 +886,60 @@ class TestInitUpdate(CliRuntimeHarness):
                 legacy_token,
                 guide_text,
                 f"guide contains legacy link token: {legacy_token}",
+            )
+
+    def _assert_concrete_test_cases_nested_list_contract(self, text: str, *, source: str) -> None:
+        marker = "#### 具体テストケース一覧"
+        self.assertIn(marker, text, f"{source} must include concrete test case section")
+        section = text.split(marker, 1)[1]
+        section_end_candidates = [
+            index
+            for index in (
+                section.find("\n#### "),
+                section.find("\n## "),
+            )
+            if index != -1
+        ]
+        if section_end_candidates:
+            section = section[: min(section_end_candidates)]
+        self.assertNotRegex(
+            section,
+            r"(?m)^\|.*\|$",
+            f"{source} concrete test case section must not contain table rows",
+        )
+        case_pattern = re.compile(
+            r"(?m)^- `tc-s\d{2}-\d{3}` [a-z-]+: .+\n"
+            r"(?:  - .+\n)+"
+        )
+        case_blocks = case_pattern.findall(section)
+        self.assertGreaterEqual(
+            len(case_blocks),
+            2,
+            f"{source} must include at least two concrete nested test case examples",
+        )
+        require_related_closure_id = len(case_blocks) > 1
+        for case_block in case_blocks:
+            self.assertRegex(
+                case_block,
+                r"(?m)^- `tc-s\d{2}-\d{3}` [a-z-]+: .+$",
+                f"{source} concrete case must start with a backticked concrete test case id bullet",
+            )
+            for label in ("前提", "操作", "期待結果", "失敗検出", "検証方法"):
+                self.assertRegex(
+                    case_block,
+                    rf"(?m)^  - {label}: .+",
+                    f"{source} concrete case missing nested {label}: {case_block}",
+                )
+            if require_related_closure_id:
+                self.assertRegex(
+                    case_block,
+                    r"(?m)^  - 関連 closure id: .+",
+                    f"{source} multi-case section must map each case to related closure id: {case_block}",
+                )
+            self.assertNotRegex(
+                case_block,
+                r"(?m)^\|.*\|$",
+                f"{source} concrete case must not use a table row: {case_block}",
             )
 
     def _assert_checked_in_dogfooding_mirror_docs_match_provider_assets(self, repo_root: Path) -> None:
@@ -1857,6 +1914,7 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertTrue((docs_dir / "phase_requirement.md").is_file())
             self.assertTrue((docs_dir / "phase_design.md").is_file())
             self.assertTrue((docs_dir / "phase_plan.md").is_file())
+            self.assertTrue((docs_dir / "authoring" / "issue-plan.md").is_file())
             self.assertTrue((docs_dir / "reference_github.md").is_file())
             self.assertTrue((docs_dir / "reference_naming.md").is_file())
             self.assertTrue((docs_dir / "reference_sync.md").is_file())
@@ -1891,10 +1949,30 @@ class TestInitUpdate(CliRuntimeHarness):
             phase_requirement = (docs_dir / "phase_requirement.md").read_text(encoding="utf-8")
             phase_design = (docs_dir / "phase_design.md").read_text(encoding="utf-8")
             phase_plan = (docs_dir / "phase_plan.md").read_text(encoding="utf-8")
+            issue_plan_authoring = (docs_dir / "authoring" / "issue-plan.md").read_text(
+                encoding="utf-8"
+            )
             self.assertIn("fresh `spec-reviewer`", workflow_spec_authoring)
             self.assertIn("`review_status: pass`", workflow_spec_authoring)
             self.assertIn("Spec Authoring Gate", workflow_spec_authoring)
             self.assertIn("scope / non-scope", workflow_spec_authoring)
+            self.assertIn("docs/authoring/<scope>-<phase>.md", workflow_spec_authoring)
+            self.assertIn("docs/authoring/issue-plan.md", workflow_spec_authoring)
+            self.assertIn("具体テストケース一覧", workflow_spec_authoring)
+            self.assertIn("カード型のネストリスト", issue_plan_authoring)
+            self.assertIn("横長テーブルに押し込まない", issue_plan_authoring)
+            self.assertIn("- `tc-s01-001` acceptance: <短い説明>", issue_plan_authoring)
+            self.assertIn("concrete test case id", issue_plan_authoring)
+            self.assertIn("関連 closure id", issue_plan_authoring)
+            self.assertIn("この文書を入口として読んだあと", issue_plan_authoring)
+            self.assertIn("複数の closure id または複数の concrete test case", issue_plan_authoring)
+            self._assert_concrete_test_cases_nested_list_contract(
+                issue_plan_authoring,
+                source="docs/authoring/issue-plan.md",
+            )
+            for fragment in ("前提", "操作", "期待結果", "失敗検出", "検証方法"):
+                self.assertIn(fragment, issue_plan_authoring)
+            self.assertIn("Spec-Locked Closure Index", issue_plan_authoring)
             for workflow_text in (workflow_initiative, workflow_epic, workflow_issue):
                 self.assertIn("workflow_spec_authoring.md", workflow_text)
                 self.assertIn("fresh `spec-reviewer`", workflow_text)
@@ -3060,6 +3138,20 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("negative:", issue_plan)
         self.assertIn("pre-implementation evidence:", issue_plan)
         self.assertIn("expected red / characterization pass / test sensitivity evidence", issue_plan)
+        self.assertIn("#### 具体テストケース一覧", issue_plan)
+        self.assertIn("- `tc-s01-001` acceptance: <短い説明>", issue_plan)
+        self.assertIn("- `tc-s01-002` negative: <短い説明>", issue_plan)
+        self.assertIn("具体テストケース本文は横長 table にせず", issue_plan)
+        self._assert_concrete_test_cases_nested_list_contract(
+            issue_plan,
+            source="templates/issue/plan.md",
+        )
+        for fragment in ("前提:", "操作:", "期待結果:", "失敗検出:", "検証方法:"):
+            self.assertIn(fragment, issue_plan)
+        self.assertIn("テスト不要理由:", issue_plan)
+        self.assertIn("代替検証方法:", issue_plan)
+        self.assertIn("S01 の subsections を複製して記入する", issue_plan)
+        self.assertIn("implementation-ready ではない", issue_plan)
         self.assertIn("#### step closure contract", issue_plan)
         self.assertIn("closure id:", issue_plan)
         self.assertIn("close 条件:", issue_plan)
@@ -3158,6 +3250,15 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("`test id alias` と `resolves to closure id`", phase_plan_issue)
         self.assertIn("`test bundle` は Central index の `locked expectation` / `observable input/state` を再記述しない", phase_plan_issue)
         self.assertIn("各 step の close 判定は Issue 全体の一覧表ではなく", phase_plan_issue)
+        self.assertIn("`具体テストケース一覧`", phase_plan_issue)
+        self.assertIn("カード型ネストリスト", phase_plan_issue)
+        self.assertIn("横長 table は trace matrix", phase_plan_issue)
+        self.assertIn("- `tc-s01-001` acceptance: <短い説明>", phase_plan_issue)
+        self.assertIn("concrete test case id", phase_plan_issue)
+        self.assertIn("closure `id` や `test ids` alias とは別物", phase_plan_issue)
+        for fragment in ("`前提`", "`操作`", "`期待結果`", "`失敗検出`", "`検証方法`"):
+            self.assertIn(fragment, phase_plan_issue)
+        self.assertIn("implementation-ready ではない", phase_plan_issue)
         self.assertIn("plan amendment と re-review を必須", phase_plan_issue)
         self.assertIn("every `required=yes` closure row", phase_plan_issue)
         self.assertIn("every bundle `closure id` が Central index に存在", phase_plan_issue)
@@ -3221,6 +3322,7 @@ class TestInitUpdate(CliRuntimeHarness):
             / "src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md"
         ).read_text(encoding="utf-8")
         self.assertIn("spec-dock/docs/phase_plan_issue.md", issue_execution_skill)
+        self.assertIn("spec-dock/docs/authoring/issue-plan.md", issue_execution_skill)
         self.assertIn("Keep templates as scaffolds", issue_execution_skill)
         self.assertIn("Spec authoring mode", issue_execution_skill)
         self.assertIn("Execution mode", issue_execution_skill)
@@ -3243,6 +3345,12 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("final commit hash plus post-commit clean evidence are recorded in external delivery evidence", issue_execution_skill)
         self.assertIn("required closure id", issue_execution_skill)
         self.assertIn("behavior slice `closure ids` / `test ids`", issue_execution_skill)
+        self.assertIn("具体テストケース一覧", issue_execution_skill)
+        self.assertIn("table-only", issue_execution_skill)
+        self.assertIn("concrete test case id", issue_execution_skill)
+        self.assertNotIn("each test id at the start", issue_execution_skill)
+        for fragment in ("`前提`", "`操作`", "`期待結果`", "`失敗検出`", "`検証方法`"):
+            self.assertIn(fragment, issue_execution_skill)
         self.assertIn("verification command, or evidence path", issue_execution_skill)
         self.assertIn("Step Contract Closure", issue_execution_skill)
         self.assertIn("Test Contract Closure", issue_execution_skill)
@@ -9287,6 +9395,13 @@ assert observed == {{"branch": "123-fix-login", "current_repo_slug": "current/re
                 "spec-dock/active/issue/plan.md",
                 "spec-dock/active/issue/report.md",
                 "spec-dock/docs/workflow_issue.md",
+                "spec-dock/docs/authoring/issue-plan.md",
+                "具体テストケース一覧",
+                "前提",
+                "操作",
+                "期待結果",
+                "失敗検出",
+                "検証方法",
                 "1 implementation step = 1 code-reviewer scope = 1 commit",
             ),
         }


### PR DESCRIPTION
## 概要

- Issue `plan.md` の具体テストケース表記を、横長 table ではなく step-local なカード型ネストリストへ標準化する。
- provider asset と dogfooding mirror の docs / template / prompt / skill をそろえ、実装前 gate と reviewer gate で同じ契約を参照できるようにする。

## 背景・目的

- 具体テストケースを `前提` / `操作` / `期待結果` / `失敗検出` / `検証方法` まで書くと、Markdown table は横に伸びて GitHub 上で読みづらくなる。
- 実装者と reviewer が step ごとの TDD 入力を正確に読めるよう、縦方向に展開する nested list を標準形式として固定する。

## 変更内容

- `docs/authoring/issue-plan.md` を追加し、Issue plan 作成時の agent-facing entrypoint として具体テストケース形式、review fail 条件、closure mapping ルールを定義した。
- `templates/issue/plan.md` に `具体テストケース一覧` scaffold を追加し、複数 case では `関連 closure id` を明示する形にした。
- `phase_plan_issue.md` と `workflow_spec_authoring.md` に、step-local concrete test case contract と authoring entrypoint 読み順を反映した。
- `/execute-issue` prompt と `spec-dock-issue-execution` skill に、実装前の implementation-ready gate としてこの契約を読む指示を追加した。
- `tests/test_init_update.py` に、provider/dogfooding parity、install 後 scaffold、nested list 構造、section 内 table 禁止、`関連 closure id` の検証を追加した。

## 影響範囲

- 仕様書作成 workflow、Issue plan template、Codex prompt、agent skill、dogfooding workspace に影響する。
- runtime command の実行ロジック、CLI 契約、DB、外部 API 連携には影響しない。

## 検証

- [x] `python -m unittest tests.test_init_update -v` が成功（164 tests）
- [x] `./spec-dock/scripts/spec-dock validate` が成功
- [x] `git diff --check` が成功
- [x] 複数の fresh spec-reviewer によるレビューと指摘修正を実施し、最終レビューで `review_status: pass`

## リスク・注意点

- 既存の作成済み issue plan には自動適用されない。新規作成または更新時の authoring 契約として効く。
- `Spec-Locked Closure Index` は coverage ledger として table のまま残すため、具体テストケース本文との役割分離を維持する必要がある。

## 確認観点

- `具体テストケース一覧` が step-local に置かれ、横長 table へ戻っていないか。
- concrete test case id と closure id / `test ids` alias の区別が、docs / template / skill / prompt で一貫しているか。
- provider asset と dogfooding mirror の同期が維持されているか。

## フォローアップ

- なし