### PR TITLE
docs(spec-dock): 実装委任オーケストレーション契約を整備

### DIFF
--- a/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -1,93 +1,27 @@
 ---
 name: spec-dock-issue-execution
-description: Leaf skill for issue execution tasks in spec-dock.
+description: Execute an active spec-dock issue while keeping spec-dock/docs/workflow_issue.md as the source of truth.
 ---
 
-# Spec-dock Issue Execution
+# Spec-Dock Issue Execution
 
-- Use this skill for issue execution work.
-- Typical fit: implement the active issue through approved behavior-slice execution and update `report.md`.
-- Start from `spec-dock/active/context-pack.md`, then follow the issue workflow.
-- `spec-dock/docs/workflow_issue.md` is the source of truth for issue execution and completion.
-- `spec-dock/docs/workflow_spec_authoring.md` is the source of truth for issue requirement / design / plan phase promotion before execution.
-- Normal lifecycle path: start with `./spec-dock/scripts/spec-dock issue start <target>` and finish with `./spec-dock/scripts/spec-dock issue finish`.
-`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
-- Treat direct `./spec-dock/scripts/spec-dock active set ...` as a manual / recovery command, not the primary issue execution path.
-- For shared phase authoring method, use:
-  - `spec-dock/docs/workflow_spec_authoring.md`
-  - `spec-dock/docs/phase_requirement.md`
-  - `spec-dock/docs/phase_design.md`
-  - `spec-dock/docs/phase_plan.md`
-  - `spec-dock/docs/phase_plan_issue.md`
-  - `spec-dock/docs/authoring/issue-plan.md`
-- Keep templates as scaffolds. Use the docs above for authoring guidance, including Issue dependency analysis, `Module Dependency Diagram`, Linux `tree` style file-change planning, and step ordering.
-- Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
-- In spec authoring mode, Issue `plan.md` must satisfy `spec-dock/docs/authoring/issue-plan.md`. Each implementation step needs a `具体テストケース一覧` that uses card-style nested list test cases, not a wide table, with each concrete test case id at the start of the top-level bullet.
-- In spec authoring mode, do not move from requirement to design, design to plan, or plan to implementation until a fresh `spec-reviewer` returns `review_status: pass`; fix findings and re-run a fresh reviewer until pass.
-- Record each `Spec Authoring Gate` in `spec-dock/active/issue/report.md`, including investigation, user questions/answers, reviewer verdict, fixes, and promotion decision.
-- Before invoking reviewer or specialist sub-agents for an active issue, confirm workflow-scoped delegation consent for the current repo/worktree, active issue, session, and named roles. A current user request may grant that scope; record the consent scope and boundary in `spec-dock/active/issue/report.md`.
-- With workflow-scoped delegation consent, invoke required named reviewer / read-only specialist roles autonomously within the active issue scope. Do not ask for per-phase confirmation; do re-confirm before scope expansion, non-named roles, write-capable delegation, destructive operations, external publishing, credentialed access, or browser/private external systems.
-- Reviewer gate states are `passed`, `failed`, `unavailable`, `denied`, `waived`, and `provisional`. Only a fresh `passed` result satisfies a required reviewer gate. `waived` requires explicit user risk acceptance in `report.md`. `provisional` is orchestrator self-check evidence, not a replacement for `spec-reviewer`, `code-reviewer`, or `qa-reviewer`.
-- Degraded mode may support status gathering, local self-check, or alternate verification evidence, but it never satisfies a required reviewer gate, implementation readiness gate, or final quality gate. Reviewer `unavailable`, `denied`, `failed`, stale, missing, waived, or provisional is blocked / incomplete unless an explicit user waiver is recorded where the workflow allows it.
-- In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
-- Execution mode: follow the approved issue docs. If the docs are missing required detail or contradict the implementation path, update/review the docs before implementation continues.
-- Record report-scoped delivery completion evidence in `spec-dock/active/issue/report.md` before running `./spec-dock/scripts/spec-dock issue finish`, because `issue finish` clears active state after lifecycle closure. Final commit hash and post-commit clean evidence are recorded after the final commit as external delivery evidence.
-- Treat `Spec-Locked Closure Index` as the issue-wide coverage ledger, not as a single test-case catalog. Execute and close work through each step's `step closure contract`.
-- Treat each implementation step as a commit unit: `1 implementation step = 1 code-reviewer scope = 1 commit`.
-- Before each implementation step starts, run an `Implementation Delegation Gate` decision and record it in `spec-dock/active/issue/report.md`.
-- Delegation is conditionally mandatory when a step crosses multiple layers, modules, or packages; affects runtime / CLI / infra / templates / shipped scaffold / shared docs; needs existing-pattern or impact analysis; touches integration tests, migration, backward compatibility, filesystem, GitHub, or active state; or is large enough to split into an independent worker scope.
-- Use `delegated` when a sub-agent is used, and record role, scope, request, returned result, and integration outcome. Use `approved-local-execution` only for small single-file changes, mechanical wording changes, clear localized changes, or immediate blocking / tightly coupled work that the main orchestrator should handle; record the no delegation rationale.
-- If sub-agents are unavailable, denied, or blocked by host policy for a required gate, do not continue as degraded success. Record the environment reason, gate state, alternate verification, and next action; classify the issue as blocked / incomplete unless an explicit user waiver is recorded where the workflow allows it.
-- Role selection matrix: `repo-analyst` maps code paths, impact, dependencies, and existing patterns before implementation; `dev-coder` handles bounded implementation steps with a clear write scope; `doc-writer` updates docs / templates / workflow / skill text; `qa-reviewer` owns final test adequacy and integration-test need; `code-reviewer` owns per-step diffs and the issue-wide integrated diff; `spec-reviewer` owns requirement / design / plan / report / implementation / docs alignment.
-- Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
-- Before implementation starts, stop if any implementation step is missing `具体テストケース一覧`, if concrete test cases are only global / table-only / abstract, or if a test case lacks the standard `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields. Docs-only or approved-no-op steps must state the test-not-needed reason and alternate verification.
-- Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
-- Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
-- Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.
-- For every implementation step with changes, run the `code-reviewer` sub-agent on that step diff and iterate fixes / re-review until `review_status: pass`.
-- Implementation delegation does not replace review gates. Even if `dev-coder` or another worker implemented the step, the resulting step diff still requires per-step `code-reviewer` pass.
-- After the step `code-reviewer` pass, commit the step scope before moving to the next implementation step. Prefer `$git-commit-conventional-ja` or an equivalent Japanese multi-line Conventional Commit flow grounded in the staged diff.
-- Do not mix multiple implementation steps in one commit. If the step is too large for one reviewable commit, split the plan step before implementation continues.
-- Use `approved-no-op` only when the step has no diff. Record the no-op reason, checked contracts/files, diff-clean command, and review or read-only confirmation evidence in `spec-dock/active/issue/report.md`.
-- Do not skip the docs impact resolution step or the final quality gate.
-- In `S90 docs impact resolution`, inspect docs / templates / README / workflow / skill / migration notes impact. If docs updates are required, use `doc-writer` for the update and `spec-reviewer` for docs/spec alignment review.
-- In `S99 final quality gate`, run `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`. Iterate fixes and re-run the failing reviewer until all three pass.
-- `qa-reviewer` owns test adequacy and whether an issue-wide integration test must be added before pass.
-- The final `code-reviewer` owns the integrated issue diff, structure, responsibility boundaries, regression risk, and maintainability. It does not replace per-step code review.
-- `spec-reviewer` owns requirement fulfillment and consistency across requirement, design, plan, report, implementation, tests, and docs.
-- After all final reviewers pass, update the final report ledger with each step closure, final review results, final commit scope, and the post-commit external evidence destination. Then create the final commit and confirm no unintended staged or unstaged changes remain.
-- Delivery completion must be confirmed before `issue finish` while the active issue is still set and confirmable, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
-- `spec-dock/active/issue/report.md` must record command evidence for required `sync`, `validate`, implementation delegation decisions, per-step code review, step commit / approved-no-op, final QA review, final issue-wide code review, final spec review, and final report ledger / final commit scope before the final commit, including whether each required step succeeded, passed, reached approval, reached `delegated` / `approved-local-execution`, or reached `committed` / `approved-no-op`.
-- Do not run `issue finish` until every required step has been executed, every required `sync` / `validate` step has succeeded or passed, every required review step has reached approval or pass, every implementation step has delegation evidence as `delegated`, `approved-local-execution`, or degraded mode for delegation availability only, every implementation step is `committed` or valid `approved-no-op`, the final report ledger and final commit scope are recorded in `spec-dock/active/issue/report.md`, the final commit is complete, no unintended staged / unstaged changes remain, and the final commit hash plus post-commit clean evidence are recorded in external delivery evidence such as the final response, PR, or issue comment.
-- After `issue finish`, do not require the active issue to remain set. Treat `issue finish` as lifecycle closure / GitHub close / active clear only.
-- If any required step is skipped, or executed without a successful, pass, approved, `committed`, or valid `approved-no-op` outcome, classify the issue as `blocked` or `incomplete`, record the reason and next action in `spec-dock/active/issue/report.md`, and do not report the issue as complete.
-- Treat the issue as `blocked` only when an external dependency, missing permission, unavailable service, or other environment condition prevents the next required action.
-- When blocked, record the reason and next action in `spec-dock/active/issue/report.md`. Include blocker type and impact when applicable.
-- Keep environment blockers separate from product gaps; missing implementation, missing docs updates, or missing evidence are incomplete unless an environment blocker prevents progress.
-- When incomplete, record the reason and next action in `spec-dock/active/issue/report.md`.
-- Do not report the issue as complete while it is incomplete or blocked.
-- Primary workflow: `spec-dock/docs/workflow_issue.md`.
-- `spec-dock/docs/reference_deps.md`
-- `spec-dock/docs/reference_sync.md`
-- `spec-dock/docs/reference_github.md`
-- `spec-dock/docs/reference_naming.md`
-- `spec-dock/docs/workflow_spec_authoring.md`
+Use `spec-dock/docs/workflow_issue.md` as the source of truth. This skill is only a concise reminder for issue execution.
 
-## Runtime command reminders
+- Keep the parent agent responsible for orchestration, context, acceptance evidence, and final closure. Delegates may implement bounded tasks, but they do not own the issue.
+- Preserve parent invariants before, during, and after delegated work: active issue context, allowed paths, acceptance criteria, reviewer requirements, and stop conditions remain the parent agent's responsibility.
+- Route runtime, tests, and scaffold behavior to `dev-coder`.
+- Route shipped docs, templates, skills, and workflow text to `doc-writer`.
+- Treat unavailable tooling, denied access, host conflicts, waiver requests, and similar blockers as stop/incomplete unless explicit workflow policy evidence says they count as success.
+- When review fails, perform bounded delegated follow-up and rerun review. Parent direct fixes require a documented Parent Implementation Exception.
 
-- Use runtime command path only: `./spec-dock/scripts/spec-dock ...`
-- Normal issue execution lifecycle:
-  - `./spec-dock/scripts/spec-dock issue start <target>`
-  - `./spec-dock/scripts/spec-dock issue finish`
-- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch. It does not bypass dependency readiness, target validation, or checkout safety.
-- `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
-- Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
-- After `issue finish`, avoid running `sync` on the just-finished issue branch when you need active clear to remain clear. `sync` can restore active from branch-derived issue context; move to `main` or another non-issue branch before final sync, or skip post-finish sync.
-- Dependency mutation is command-first:
-  - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
-  - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`
-  - `./spec-dock/scripts/spec-dock deps check <target>`
-- Keep report evidence aligned with workflow checks:
-  - `./spec-dock/scripts/spec-dock validate`
-  - `./spec-dock/scripts/spec-dock sync`
-- Use `--no-github` only for explicit cache/local verification with no GitHub calls.
+## Runtime Command Reminders
+
+- Use the shipped runtime path: `./spec-dock/scripts/spec-dock ...`.
+- Normal lifecycle is `issue start <target>` before execution and `issue finish` only after the workflow completion gates pass.
+- `issue start -f` / `issue start --force` bypasses only the unfinished-active-issue guard; it does not bypass readiness, target validation, or checkout safety.
+- After `issue finish`, avoid `sync` on the just-finished issue branch when active clear must remain clear.
+- Mutate dependencies command-first with `deps add`, `deps remove`, and `deps check`: `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`, `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`, and `./spec-dock/scripts/spec-dock deps check <target>`.
+- Evidence commands include `validate` and `sync`: `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync`.
+- Use `--no-github` only for explicit cache/local verification without GitHub calls.
+
+Do not copy the full workflow here; update `workflow_issue.md` when execution policy changes.

--- a/spec-dock/docs/authoring/issue-plan.md
+++ b/spec-dock/docs/authoring/issue-plan.md
@@ -18,6 +18,7 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - reviewer-pass 済みの `requirement.md` と `design.md` を、実装可能な step、検証、review gate、commit gate、final quality gate へ変換する。
 - `Spec-Locked Closure Index` で仕様 coverage を固定し、各 implementation step の `具体テストケース一覧` で TDD 実行入力を固定する。
 - step 順、依存、対象ファイル、検証方法、report evidence を実装者が判断せずに実行できる粒度へ落とす。
+- `workflow_issue.md` の delegated-by-default policy を再定義せず、各 implementation step の `delegation contract` として委任先、入力、許可範囲、検証、reviewer focus、停止条件、出力を具体化する。
 
 ## 必須項目
 
@@ -26,6 +27,7 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - `ステップ一覧`
 - `要件 ↔ ステップ対応`
 - `Spec-Locked Closure Index`
+- 各 implementation step の `delegation contract`
 - 各 implementation step の `具体テストケース一覧`
 - 各 implementation step の `step closure contract`
 - 各 implementation step の `behavior slice execution`
@@ -33,6 +35,34 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - `S90 docs impact resolution / docs refresh`
 - `S99 final quality gate`
 - `Final Exit Contract`
+
+## delegation contract
+
+各 implementation step は、`workflow_issue.md` の `Parent Agent Invariant`、`Implementation Delegation Gate`、delegated worker handoff、reviewer gate mapping を参照し、その step 固有の handoff contract を持つ。
+この欄は execution policy の再定義ではない。plan author は、worker が追加判断なしに作業でき、reviewer が scope / verification / report evidence を確認できるように、次の項目を step-local に埋める。
+
+標準項目:
+
+- `delegated role`:
+  - runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary worker とする。
+- `input docs`:
+  - `requirement.md`、`design.md`、`plan.md`、該当 workflow / authoring docs、target files などの source of truth。
+- `allowed paths`:
+  - `design.md` の `ディレクトリ / ファイル変更計画` から、その step が触る subset。
+- `forbidden changes`:
+  - scope 外ファイル、別 step の変更、source-of-truth 逸脱、runtime と docs の不用意な混在など。
+- `acceptance criteria`:
+  - closure index と step closure contract へ追跡できる、観測可能な完了条件。
+- `required tests or docs-only verification`:
+  - targeted command、manual evidence、inspection、docs diff など、その step の検証方法。
+- `reviewer focus`:
+  - `workflow_issue.md` の mapping に従い、code / runtime / tests / scaffold behavior は `code-reviewer`、docs-only / template-only / skill-text-only は `spec-reviewer` docs/spec alignment を基本にする。
+- `stop conditions`:
+  - 入力 docs の矛盾、許可パス外変更が必要、検証不能、delegated role 不適合、host policy / tool 制約、acceptance 未達など。
+- `output required`:
+  - changed files、worker summary、verification result、unresolved risks、report へ転記する delegation evidence。
+
+複数 layer / package / shipped asset にまたがる step は、親 Codex が直接実装せず、allowed paths と dependency boundary を明記して委任する。docs-only / template-only / skill-text-only step であっても、shipped artifact を変更する場合は `doc-writer` 委任と docs/spec alignment review を plan に残す。
 
 ## 具体テストケース一覧
 
@@ -64,6 +94,9 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 ## reviewer fail 条件
 
 - implementation step に `具体テストケース一覧` がない。
+- implementation step に `delegation contract` がない、または `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` のいずれかが欠けている。
+- `delegation contract` が `workflow_issue.md` と矛盾する execution policy を再定義している。
+- delegated worker work を reviewer gate の代替として扱っている、または step の変更種別と reviewer focus が矛盾している。
 - concrete test case が step-local ではなく、global test plan だけに置かれている。
 - `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` のいずれかが欠けている。
 - 「テストを追加する」「動作確認する」など、実装者が fixture / command / expected observation を判断する必要がある抽象表現だけになっている。

--- a/spec-dock/docs/phase_plan_issue.md
+++ b/spec-dock/docs/phase_plan_issue.md
@@ -16,6 +16,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
   - review / QA / spec gate 方針
   - 依存関係から導いた step 順
   - nested execution structure
+  - per-step delegation contract
   - docs impact gate
   - final quality gate with `qa-reviewer` / issue-wide `code-reviewer` / `spec-reviewer`
   - final exit contract
@@ -35,6 +36,15 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - 各 behavior slice には closure index の `id` に対応する `step closure contract`、`test bundle`、`pre-implementation evidence`、`bounded implementation batch`、`verification`、`refactor / tidy` を置く
 - Central index は仕様由来の `spec link`、`locked expectation`、`observable input/state`、`bug class guarded`、`required`、`evidence level`、closure owner step を所有する
 - `step closure contract` はその step で満たす closure `id`、close condition、test bundle、pre-implementation evidence、verification command / evidence path、report evidence を所有する
+- 各 implementation step には `delegation contract` を置く。これは `workflow_issue.md` の `Parent Agent Invariant`、`Implementation Delegation Gate`、delegated worker handoff、reviewer gate mapping を plan step へ埋め込むための欄であり、実行 policy を再定義しない
+- `delegation contract` は `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` を持つ
+- `delegated role` は step の変更種別に合わせる。runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary worker とし、混在する場合は step を分割するか reviewer focus と gate を明記する
+- `input docs` は `requirement.md`、`design.md`、`plan.md`、該当 workflow / authoring docs、target files など、worker が判断を補わずに読める正本を列挙する
+- `allowed paths` は `design.md` の `ディレクトリ / ファイル変更計画` から該当 step の subset として書き、`forbidden changes` には source-of-truth 逸脱、scope 外ファイル、別 step の変更、runtime / docs の混在などを明記する
+- `acceptance criteria` は closure index と step closure contract へ追跡できる観測可能な完了条件にし、`required tests or docs-only verification` は targeted command、manual evidence、inspection、docs diff など step に必要な検証を具体化する
+- `reviewer focus` は `workflow_issue.md` の reviewer gate mapping を参照して、code / runtime / tests / scaffold behavior なら `code-reviewer`、docs-only / template-only / skill-text-only なら `spec-reviewer` docs/spec alignment を基本にする。委任は reviewer gate の代替ではない
+- `stop conditions` は許可パス外変更、入力 docs の矛盾、検証不能、delegated role 不適合、host policy / tool 制約、acceptance 未達など、worker が親 Codex へ戻す条件を書く
+- `output required` は changed files、worker summary、verification result、unresolved risks、reviewer が確認すべき evidence、report へ転記する delegation evidence を指定する
 - `test bundle` は step closure contract の一部として、必要な範囲で acceptance / characterization / property or invariant / regression / negative を分類する
 - `test ids` と書く場合も Central index の closure `id` の alias として扱い、別 alias を使う場合は report の `Closure Delta` に `test id alias` と `resolves to closure id` を記録する
 - `test bundle` は Central index の `locked expectation` / `observable input/state` を再記述しない
@@ -52,7 +62,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - 各 step の close 判定は Issue 全体の一覧表ではなく、その step の `step closure contract` を正本にする
 - `step closure contract` は `close when`、`verification evidence`、`report evidence`、`residual risk` を持ち、step result approval の対象にする
 - 各 implementation step は commit 単位として設計し、`1 implementation step = 1 review scope = 1 commit` を標準にする。step が大きすぎる場合は commit をまとめず step を分割する
-- 各 step gate には `code-reviewer gate`、`commit gate`、`no-op gate` を置き、`code-reviewer` pass 後に step commit で閉じる。`approved-no-op` は差分なしの場合だけ許可する
+- 各 step gate には `step reviewer gate`、`commit gate`、`no-op gate` を置き、`workflow_issue.md` の reviewer gate mapping に従う reviewer pass 後に step commit で閉じる。`approved-no-op` は差分なしの場合だけ許可する
 - review / QA / docs / final quality gate は behavior slice の外に置き、step gate / milestone gate / `S90` / `S99` に配置する
 - `refactor / tidy` は bounded decision point として残し、事前に詳細な cleanup task を書き込まない
 - cleanup が最初から明確で大きい場合は、`bounded implementation batch` / design / 別 step で扱う
@@ -83,9 +93,10 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - `Spec-Locked Closure Index` を置く
 - `実装ステップ` を step / block / behavior slice で書く
 - 各 behavior slice の `step closure contract` / `test bundle` / `pre-implementation evidence` / `bounded implementation batch` / `verification` を置き、`test bundle` は closure index の `id` を参照できるようにする
+- 各 implementation step に `delegation contract` を置き、`workflow_issue.md` の execution policy を再定義せずに worker handoff へ必要な入力、許可範囲、禁止範囲、検証、reviewer focus、停止条件、出力を具体化する
 - 各 implementation step に `具体テストケース一覧` を置き、ネストリストで `前提` / `操作` / `期待結果` / `失敗検出` / `検証方法` を書く
 - `refactor / tidy` には `目的` と `guardrail` を置き、具体的な refactor 内容は `report.md` へ送る
-- 各 step gate に `code-reviewer gate`、`commit gate`、`no-op gate`、`report update` を置く
+- 各 step gate に `step reviewer gate`、`commit gate`、`no-op gate`、`report update` を置き、reviewer は `workflow_issue.md` の mapping に従って選ぶ
 - `S90 docs impact resolution / docs refresh` を必須で置く
 - `S99 final quality gate` を必須で置き、`qa-reviewer` のテスト十分性確認、issue-wide `code-reviewer` の統合 diff review、`spec-reviewer` の要件達成確認を配置する
 - `final exit contract` を置く
@@ -107,13 +118,16 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - every required row が non-placeholder の `spec link`、`observable input/state`、`locked expectation`、`evidence level`、`closure evidence` を持つ
 - every required row に step-local close condition と planned verification evidence path がある
 - behavior slice が step closure contract、test bundle、pre-implementation evidence を持ち、bounded implementation batch として原因局所化できる
+- 各 implementation step が `delegation contract` を持ち、`delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` を埋めている
+- `delegation contract` が `workflow_issue.md` の policy を再定義せず、step 固有の handoff contract として書かれている
+- reviewer focus が step の変更種別と矛盾する場合、または delegated worker work を reviewer gate の代替として扱っている場合は fail とする
 - 各 implementation step が step-local な `具体テストケース一覧` を持ち、各 case が `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を含む
 - concrete test case が横長 table に押し込まれて読みづらい場合、または global test plan だけで step-local case がない場合は fail とする
 - docs-only / approved-no-op step は、テスト不要理由と inspection / manual / docs diff などの代替検証方法を持つ
-- 各 implementation step が commit 単位として設計され、`code-reviewer gate`、`commit gate`、`no-op gate` を持っている
+- 各 implementation step が commit 単位として設計され、`step reviewer gate`、`commit gate`、`no-op gate` を持っている
 - step 順が design の依存関係分析、Module Dependency Diagram、directory / file change plan と矛盾しない
 - 各 step の `depends on` / `unblocks` / `target files` が、実装順と変更対象の確認に使える
-- report update が stage gate に置かれている。report-before-commit、code-reviewer pass、step commit、approved-no-op の実行順は `workflow_issue.md` の実行 contract で確認する
+- report update が stage gate に置かれている。report-before-commit、step reviewer gate pass、step commit、approved-no-op の実行順は `workflow_issue.md` の実行 contract で確認する
 - AC / EC と step の対応が取れている
 - docs impact と final quality gate が計画に埋め込まれ、`doc-writer` による必要 docs 更新、`qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` の三者 review が追跡できる
 - reviewer が「この plan で実装してよい」と判断できる

--- a/spec-dock/docs/workflow_issue.md
+++ b/spec-dock/docs/workflow_issue.md
@@ -86,7 +86,9 @@ Issue は実装の最小単位です。
 
 - 実装前に `requirement.md` / `design.md` / `plan.md` の整合を確認し、特に `design.md` の依存関係分析 / module dependency diagram / directory tree と `plan.md` の step 順が一致していることを確認して、plan upfront approval を得る
 - 実装前に `workflow_spec_authoring.md` の requirement / design / plan gate がすべて pass し、`Spec Authoring Gate` evidence が `report.md` に残っていることを確認する
-- 各 implementation step は `step closure contract / test bundle / pre-implementation evidence → implementation delegation decision → bounded implementation batch → verification → refactor/tidy → report draft update → code-reviewer → fix → re-review → commit → clean確認` の順で進める
+- `Parent Agent Invariant`: normal execution における親 Codex は inspect / plan / delegate / verify / integrate / report を担当する orchestration owner であり、code / runtime / tests / scaffold behavior / templates / shipped docs / skills / workflow text の直接実装者ではない
+- 親 Codex が直接作成・更新してよいのは、`report.md`、handoff note、phase evidence など run-local orchestration metadata に限定する。shipped docs / templates / skills / workflow text、runtime-facing scaffold、コード、テスト、runtime behavior は delegated worker work として扱う
+- 各 implementation step は `step closure contract / test bundle / pre-implementation evidence → implementation delegation decision → bounded implementation batch → verification → refactor/tidy → report draft update → step reviewer gate → fix → re-review → commit → clean確認` の順で進める
 - 完成版 `plan.md` には `Spec-Locked Closure Index`（仕様固定クロージャ索引）を置き、各 behavior slice の仕様ロックと closure owner step を実装前に固定する
 - `Spec-Locked Closure Index` は Issue 全体のテストケース一覧や詳細なテスト実装指示ではなく、観測可能な入力・状態・locked expectation・防ぐ欠陥クラス・required/evidence level を固定する coverage ledger である
 - `test bundle` は step closure contract の一部として、step の観測可能な振る舞いに必要な acceptance / characterization / property or invariant / regression / negative を分類する
@@ -94,18 +96,21 @@ Issue は実装の最小単位です。
 - 実装開始前に required closure id が behavior slice の `closure ids` / `test ids` から参照され、各 required row に step-local close condition と verification command または evidence path があることを確認する
 - required closure row、`locked expectation`、`required`、`spec link` を変更する場合は plan amendment と re-review を先に通す
 - `pre-implementation evidence` は expected red / characterization pass / test sensitivity evidence のいずれかを記録し、failing-first を完全要求できない場合もテストが欠陥を検出できる根拠を残す
-- `Implementation Delegation Gate` は各 implementation step の開始前に必ず置く。step が複数 layer / module / package にまたがる、runtime / CLI / infra / templates / shipped scaffold / shared docs に影響する、既存 pattern 調査や影響範囲分析が必要、integration test / migration / backward compatibility / filesystem / GitHub / active state に関わる、または独立 worker scope に分割できる大きさの場合は、適切なサブエージェント利用を必須にする
-- `delegated` の場合は sub-agent role、scope、依頼内容、戻り値、取り込み結果を `report.md` に残す。`approved-local-execution` は小さい単一ファイル修正、機械的文言修正、明確な localized change、または即時 blocking / tightly coupled で main agent が担当すべき場合だけ許可し、条件付き必須に該当しない理由を `no delegation rationale` として残す
+- `Implementation Delegation Gate` は各 implementation step の開始前に必ず置く。runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary delegated worker とし、step が複数 layer / module / package にまたがる、runtime / CLI / infra / templates / shipped scaffold / shared docs に影響する、既存 pattern 調査や影響範囲分析が必要、integration test / migration / backward compatibility / filesystem / GitHub / active state に関わる、または独立 worker scope に分割できる大きさの場合は、適切なサブエージェント利用を必須にする
+- delegated worker handoff には、`delegated role`、`scope`、`source of truth`、`allowed changes`、`forbidden changes`、`required verification`、`stop conditions`、`output required` を必ず含める。複数 layer / package / shipped asset にまたがる step は、親 Codex が direct implementation せず、allowed paths と dependency boundary を明記して委任する
+- `delegated` の場合は delegated role、scope、source of truth、allowed changes、forbidden changes、required verification、stop conditions、output required、worker summary、changed files、verification result、unresolved risks、取り込み結果を `report.md` に残す
+- 親 Codex が例外的に直接実装する場合は `Parent Implementation Exception` として、delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate を事前に記録する。`approved-local-execution` はこの exception record を満たす場合だけ使用し、小さい変更、機械的変更、親が修正を知っていることを理由にした無記録 direct implementation として扱ってはならない
 - reviewer gate state は `passed` / `failed` / `unavailable` / `denied` / `waived` / `provisional` のいずれかで記録する。required reviewer gate を満たすのは fresh `passed` だけである
-- `waived` はユーザーの明示的 risk acceptance が `report.md` にある場合だけ許可する。`provisional` は orchestrator self-check の記録であり、`spec-reviewer` / `code-reviewer` / `qa-reviewer` の代替ではない
-- サブエージェント機能が利用できない、拒否された、または host policy と衝突する場合、required reviewer gate は `unavailable` / `denied` として blocked / 未完了に分類する。degraded mode は status/context gathering や追加 verification に限定し、reviewer gate、implementation readiness、final quality gate を満たさない
+- `waived` はユーザーの明示的 risk acceptance が `report.md` にある場合だけ許可する。waiver は reviewer pass ではなく、delegation / reviewer gate の unavailable / denied を degraded success にしない。waiver 後に親 Codex が直接実装する場合も、別途 `Parent Implementation Exception` の user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate を必要とする
+- サブエージェント機能が利用できない、拒否された、または host policy と衝突する場合、required delegation / reviewer gate は `unavailable` / `denied` として blocked / 未完了に分類する。unavailable / denied / host conflict は degraded success でも、親 Codex の direct implementation 自動承認でもない。degraded mode は status/context gathering や追加 verification に限定し、reviewer gate、implementation readiness、final quality gate を満たさない
 - `bounded implementation batch` は step の scope、allowed files、forbidden scope に収まる最小実装単位とする
 - `refactor/tidy` は verification 後の bounded decision point とし、plan では詳細 task を事前確定しない
 - step 順は `design.md` の依存関係分析、module dependency diagram、directory / file change plan を根拠に、upstream / prerequisite から downstream へ組む
 - cleanup が既知で大きい場合は `bounded implementation batch` / design / 別 step へ切り出す
 - review / QA / spec の各 stage gate は `pass` まで回す
-- 各 implementation step は、サブエージェント `code-reviewer` の `review_status: pass` を得てから、その step の実装・テスト・必要な report draft update をまとめてコミットする
-- implementation delegation は per-step `code-reviewer` の代替ではない。`dev-coder` などの worker が実装した場合でも、その step diff は必ず `code-reviewer` pass を得る
+- reviewer gate mapping は step の変更種別で決める。code / runtime / tests / scaffold behavior を含む step は per-step `code-reviewer` pass を必要とし、docs-only / template-only / skill-text-only step は `spec-reviewer` docs/spec alignment pass を必要とする。両方を含む場合は step を分割するか、両方の reviewer focus を明記して必要な gate を通す
+- implementation delegation は reviewer gate の代替ではない。`dev-coder` / `doc-writer` などの worker が実作業した場合でも、step diff は上記 mapping に従う reviewer pass を得る
+- reviewer が `fail` を返した場合、親 Codex は原則として自分で direct fix せず、指摘を bounded delegated follow-up として同じ delegated worker または適切な worker に再委任する。親 Codex が直接修正するには `Parent Implementation Exception` を別途満たす
 - `1 implementation step = 1 review scope = 1 commit` を標準とし、複数 step の変更を 1 commit に混ぜてはならない。step が大きすぎる場合は commit をまとめず step を分割する
 - step commit 後は `git status --short` などで、次 step へ持ち越す意図しない staged / unstaged 変更がないことを確認する
 - step の close state は `committed` または `approved-no-op` のどちらかにする。`approved-no-op` は差分が本当にない場合だけ許可し、小さい変更、あとでまとめる、report だけ、時間不足を理由にしてはならない
@@ -123,7 +128,7 @@ Issue は実装の最小単位です。
 - route だけ、または manual `active set` だけでは Issue work は完了しない。通常の開始/終了は `issue start` / `issue finish` を使う
 - `complete` と報告してよいのは、`issue finish` 前に active issue が set されその対象 issue を確認できる状態で、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、各 implementation step の `Implementation Delegation Gate` が `delegated` / `approved-local-execution` / degraded mode のいずれかで閉じている証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved-no-op として閉じている証跡、全 implementation step が `committed` または正当な `approved-no-op` で閉じている証跡、final docs impact resolved、final `qa-reviewer` pass、issue-wide `code-reviewer` pass、final `spec-reviewer` pass、final report ledger が記録済みであり、final commit 済みと意図しない staged / unstaged 変更なしの post-commit external delivery evidence を確認している場合のみである。ここで degraded mode は implementation delegation availability の証跡に限られ、required reviewer gate pass ではない
 - 4 点の issue docs のいずれかが untouched、template、placeholder、または実質未記入の状態で残る場合は `未完了` であり、成功報告をしてはならない
-- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step code review / step commit / final QA review / issue-wide code review / final spec review / final commit）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
+- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step reviewer gate / step commit / final QA review / issue-wide code review / final spec review / final commit）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
 - `blocked` は、外部依存、権限不足、サービス停止、その他の環境条件によって次の required action を進められない状態を指す
 - `blocked` の場合は `report.md` に reason と next action を残す。blocker type と impact は該当する場合に併記する
 - `未完了` は、product work、docs 更新、または証跡が不足している状態を指す。product gap は環境 blocker がない限り `blocked` ではなく `未完了` として扱う
@@ -137,10 +142,11 @@ Issue は実装の最小単位です。
 - `Test Contract Closure` に required closure id、step、evidence level、pre-implementation evidence、verification command、result を残す
 - `Closure Coverage` に各 required closure id と verification evidence の対応を残す
 - `Closure Delta` に追加・削除・変更・未実装 row と re-review 要否を残す
-- `Implementation Delegation Gate` に step、decision、required reason、agent role、delegated scope、result、local-execution rationale を残す。`delegated` の場合は依頼内容、戻り値、取り込み結果を追跡し、`approved-local-execution` の場合は no delegation rationale を残す
+- `Implementation Delegation Gate` に step、decision、required reason、delegated role、scope、source of truth、allowed changes、forbidden changes、required verification、stop conditions、output required、result を残す。`delegated` の場合は worker summary、changed files、verification result、unresolved risks、parent integration decision を追跡する
+- `Parent Implementation Exception` に delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate、unavailable / denied / host conflict / waiver の扱い、risk acceptance の有無を残す。exception record がない親 Codex direct implementation は required gate 未完了として扱う
 - `Workflow Delegation Consent` に consent source、repo/worktree、active issue、session、named roles、boundary、expires / invalidation condition、`denied` / `unavailable` の場合の reason と next action を残す
 - `Reviewer Gate Status` に gate name、reviewer role、freshness、state（`passed` / `failed` / `unavailable` / `denied` / `waived` / `provisional`）、risk acceptance の有無、promotion / completion decision を残す
-- `Step Commit Gate` に step、review scope、`code-reviewer` verdict、commit scope、closure state、commit evidence、post-commit clean check を残す
+- `Step Commit Gate` に step、review scope、step reviewer verdict、commit scope、closure state、commit evidence、post-commit clean check を残す。step reviewer は reviewer gate mapping に従って `code-reviewer` または `spec-reviewer` を記録する
 - `Final QA Gate` に `qa-reviewer` verdict、テスト十分性、integration test 追加要否、追加した場合の evidence を残す
 - `Final Code Review Gate` に issue-wide `code-reviewer` verdict、統合 diff scope、修正と re-review の evidence を残す
 - `Final Spec Review Gate` に `spec-reviewer` verdict、requirement / design / plan / report / docs 整合、docs 修正が必要な場合の `doc-writer` 更新 evidence を残す
@@ -149,7 +155,7 @@ Issue は実装の最小単位です。
 - `issue finish` 後は active issue が clear されていてよく、`complete` 判定は active state の残存ではなく `issue finish` 前に記録・確認した report evidence で行う
 - `complete` 判定に必要な required closure id は、report の `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved-no-op として閉じている必要がある
 - `complete` 判定に必要な各 implementation step は、report の `Implementation Delegation Gate` で `delegated`、`approved-local-execution`、または degraded mode として閉じている必要がある。delegation evidence が不足している場合は `未完了` として扱う
-- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step code review / step commit / final QA review / issue-wide code review / final spec review / final commit）を未実施にした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
+- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step reviewer gate / step commit / final QA review / issue-wide code review / final spec review / final commit）を未実施にした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
 - `blocked` / `未完了` の場合は reason と next action を残し、環境 blocker と product gap を混在させない
 - `blocked` では blocker type と impact を該当する範囲で残す
 - stage gate ごとの reviewer verdict / test結果 / 修正内容 / no-op 理由もここに残す
@@ -205,7 +211,7 @@ Issue は実装の最小単位です。
   - docs impact / docs refresh step が必要なら入っている
   - final quality gate が独立し、`qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` の三者 review を含んでいる
   - 各 implementation step に Implementation Delegation Gate があり、条件付き必須 trigger に該当する step では適切なサブエージェント利用または degraded mode evidence がある
-  - 各 implementation step に code-reviewer gate、commit gate、no-op gate がある
+  - 各 implementation step に step reviewer gate、commit gate、no-op gate がある
 - report:
   - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が、`issue finish` 前に active issue を確認できる状態の report に残っている
   - required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で閉じている

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/.meta.json
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00098",
+  "title": "Delegated Implementation Orchestration Contract",
+  "slug": "delegated-implementation-orchestration-contract",
+  "created_at": "2026-05-15T13:59:04+09:00",
+  "updated_at": "2026-05-15T13:59:04+09:00",
+  "parent_id": "epic-00067",
+  "initiative_id": "init-local-00003",
+  "epic_id": "epic-00067",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 98,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/design.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/design.md
@@ -1,0 +1,322 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00098"
+タイトル: "Delegated Implementation Orchestration Contract"
+関連GitHub: ["#98"]
+状態: "approved"
+作成者: "Codex CLI"
+最終更新: "2026-05-15"
+依存: ["requirement.md"]
+親: ["epic-00067", "init-local-00003"]
+---
+
+# iss-00098 Delegated Implementation Orchestration Contract — 設計（HOW）
+
+## 親 Diagram 参照
+- Epic diagram:
+  - N/A: この Issue は installed layout / agent tooling の文書・テンプレート契約を局所的に強化するもので、親 Epic diagram の再掲は不要。
+- Initiative diagram:
+  - N/A: system context や container 境界は変えない。
+- 再利用する決定:
+  - `src/spec_dock/assets/install_root/` は installed agent-tooling assets の provider-side source of truth。
+  - `src/spec_dock/assets/spec_dock/` は consumer workspace に生成される `spec-dock/` scaffold の provider-side source of truth。
+  - dogfooding 側の `.agents/` と `spec-dock/` は、今回の契約変更を検証・利用する mirror であり、provider source だけ、または mirror だけを単独で更新してはならない。
+  - docs は policy / source of truth、templates は最小 scaffold、skills は concise routing / execution reminders とする。
+
+## 目的・制約
+- 目的:
+  - 親 Codex を実装者ではなく orchestration owner として固定し、実作業を plan step 単位で delegated worker に渡す contract を Issue workflow に組み込む。
+  - `dev-coder` / `doc-writer` / reviewer の責務を docs、templates、skills、report evidence に一貫して表現する。
+  - plan author が後続の実装 step を書くときに、delegation contract、reviewer gate、exception record を迷わず埋められる状態にする。
+- 必須 / 禁止:
+  - 親 Codex の通常責務は inspect / plan / delegate / verify / integrate / report に限定する。
+  - runtime / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary worker とする。
+  - `dev-coder` や `doc-writer` の実作業は reviewer gate の代替にしない。
+  - `approved-local-execution` は「小さい」「機械的」を理由にした無記録 direct implementation として残さず、exception semantics へ寄せる。
+- 非交渉制約:
+  - provider source と dogfooding mirror を同期させる。
+  - `workflow_issue.md` と `.agents/skills/spec-dock-issue-execution/SKILL.md` の execution contract を矛盾させない。
+  - Requirement / design / plan promotion は fresh `spec-reviewer` pass を必要とする。
+- 前提:
+  - 新しい CLI command や runtime enforcement は追加しない。
+  - `dev-coder`、`doc-writer`、`code-reviewer`、`qa-reviewer`、`spec-reviewer` は named role として利用可能である。
+
+## 既存実装 / 規約の理解
+- 参照した実装 / docs:
+  - `spec-dock/docs/workflow_spec_authoring.md`: phase promotion と reviewer state の正本。
+  - `spec-dock/docs/phase_design.md`: Issue design の dependency / file-change planning と UML policy の正本。
+  - `spec-dock/docs/workflow_issue.md`: Issue execution / completion contract の正本。
+  - `src/spec_dock/assets/spec_dock/docs/workflow_issue.md`: consumer scaffold provider source。
+  - `src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md`: Issue plan authoring playbook provider source。
+  - `src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md`: Issue plan authoring entrypoint provider source。
+  - `src/spec_dock/assets/spec_dock/templates/issue/plan.md`: Issue plan scaffold provider source。
+  - `src/spec_dock/assets/spec_dock/templates/issue/report.md`: Issue report scaffold provider source。
+  - `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md`: installed issue-execution skill provider source。
+  - `.agents/skills/spec-dock-issue-execution/SKILL.md`: dogfooding mirror skill。
+- 現状理解:
+  - `workflow_issue.md` には既に `Implementation Delegation Gate`、`delegated` / `approved-local-execution`、per-step `code-reviewer`、S90 docs impact、S99 final quality gate がある。
+  - `phase_plan_issue.md` と `authoring/issue-plan.md` は plan の書き方を所有し、execution policy は再定義しない。
+  - issue plan template には delegation 判断欄があるが、requirement が求める `delegation contract` の必須入力全体はまだ表現しきれていない。
+  - issue report template には delegation / review evidence の表があるが、delegated worker summary、parent integration decision、Parent Implementation Exception を必須 evidence として固定する余地がある。
+  - skill は role selection matrix と実行 reminder を持つが、docs の正本性を保つため、詳細 policy を skill へ重複展開しすぎない設計が必要。
+- 採用するパターン:
+  - `workflow_issue.md` を execution policy の正本にし、`phase_plan_issue.md` / `authoring/issue-plan.md` / templates / skill はそこへ参照・埋め込みを合わせる。
+  - provider source と dogfooding mirror を同一内容に保つ。
+  - structural docs/template assertions は `tests/test_init_update.py` で固定する。
+- 採用しないもの:
+  - runtime validator、transcript audit、`spec-dock issue delegate` の追加。
+  - skill へ workflow policy 全文を複製すること。
+  - plan step の詳細実装順や test case 本文を design へ先書きすること。
+- 影響範囲:
+  - shipped docs / templates / skills / workflow text が主対象。
+  - runtime behavior は対象外。ただし scaffold behavior と generated asset content の期待値は tests で確認する。
+
+## 採用方針 / トレードオフ
+- 論点: delegated-by-default をどこで所有するか
+  - 決定: `workflow_issue.md` が `Parent Agent Invariant`、delegated worker handoff、exception gate、reviewer gate fail condition を所有する。
+  - 理由: Issue execution / completion の正本がここにあり、plan / report / skill から参照される中心だから。
+- 論点: plan 側の責務
+  - 決定: `phase_plan_issue.md` と `authoring/issue-plan.md` は、各 implementation step に `delegation contract` をどう書くかを所有する。execution policy の再定義は避ける。
+  - 理由: plan authoring docs は step の構造化が責務であり、approval cadence や completion 判定は `workflow_issue.md` に残すべきため。
+- 論点: templates の責務
+  - 決定: plan template は step-local `delegation contract` の欄を追加し、report template は delegation evidence と `Parent Implementation Exception` の記録欄を追加する。
+  - 理由: templates は最小 scaffold だが、必須 evidence の置き場がないと future agent が workflow policy を満たせないため。
+- 論点: skills の責務
+  - 決定: issue-execution skill は「親 Codex invariant」「role selection」「docs source of truth」「stop conditions」を短く示す reminder に留める。
+  - 理由: skills に詳細 policy を重複させると docs と drift しやすい。
+- 論点: reviewer gate mapping
+  - 決定: code / runtime / tests / scaffold behavior を含む step は per-step `code-reviewer`、docs-only / template-only / skill-text-only step は `spec-reviewer` docs/spec alignment を対応 gate として明記する。S99 では `qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` を維持する。
+  - 理由: docs-only step に code review を要求すると review focus がずれ、runtime/scaffold step を spec review だけで通すと regressions を見落とす。
+
+## 依存関係分析
+- module 依存:
+  - Provider scaffold docs/templates:
+    - `src/spec_dock/assets/spec_dock/docs/workflow_issue.md` が execution policy の provider source。
+    - `src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md` と `src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md` は plan authoring から `workflow_issue.md` を参照する。
+    - `src/spec_dock/assets/spec_dock/templates/issue/plan.md` / `report.md` は上記 docs を満たす scaffold を提供する。
+  - Provider installed skill:
+    - `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md` は installed agent に配布される concise reminder。
+    - `.agents/skills/spec-dock-issue-execution/SKILL.md` は dogfooding mirror。
+  - Tests:
+    - `tests/test_init_update.py` は provider assets から生成・同期される docs/templates/skill content の structural expectations を固定する。
+- class 依存（必要時）:
+  - N/A: Python class / runtime type は変更しない。
+- function 依存（必要時）:
+  - N/A: runtime function は変更しない。テスト更新は asset content assertion のみ。
+- file 依存:
+  - `workflow_issue.md` の contract が upstream。
+  - `phase_plan_issue.md`、`authoring/issue-plan.md`、`templates/issue/plan.md`、`templates/issue/report.md`、`spec-dock-issue-execution/SKILL.md` は downstream。
+  - `tests/test_init_update.py` は provider assets と mirror generation の expected content に依存する。
+- 上流 / 前提:
+  - `requirement.md` の AC-001 から AC-006、EC-001 から EC-004。
+  - `workflow_spec_authoring.md` の reviewer state semantics。
+  - `phase_design.md` の Issue design handoff / UML / file-change planning contract。
+- 下流 / 依存先:
+  - `plan.md` はこの design の affected surfaces と responsibility boundary から step を分割する。
+  - 後続 implementation は provider source と mirror を同時更新し、tests で content drift を検出する。
+- 実装起点:
+  - design としては `workflow_issue.md` を upstream contract として固定する。plan では downstream docs/templates/skills/tests を、責務境界に沿って reviewable step に分ける。
+- 順序への影響:
+  - plan は `workflow_issue.md` の contract を先に固め、その後に plan authoring docs、templates、skill、tests/mirror verification へ落とす構造にする。
+
+## Module Dependency Diagram
+- タイトル:
+  - Delegated implementation orchestration contract surfaces
+- 答える問い:
+  - Delegated-by-default の正本をどの file が所有し、どの downstream surface がその契約を消費するか。
+- 範囲:
+  - shipped docs / templates / skills / tests の依存方向。
+- 含めない詳細:
+  - runtime CLI call graph、Python class、GitHub workflow、sub-agent runtime 実装。
+- 更新条件:
+  - execution policy の正本、provider/mirror ownership、または reviewer gate mapping が変わるとき。
+- 図:
+
+### UML（module dependency / responsibility boundary）
+```plantuml
+@startuml
+top to bottom direction
+
+rectangle "workflow_issue.md\nexecution policy source of truth" as WI
+rectangle "phase_plan_issue.md\nauthoring playbook" as PPI
+rectangle "docs/authoring/issue-plan.md\nauthoring entrypoint" as API
+rectangle "templates/issue/plan.md\nstep scaffold" as TP
+rectangle "templates/issue/report.md\nevidence scaffold" as TR
+rectangle "spec-dock-issue-execution/SKILL.md\nconcise runtime reminder" as SK
+rectangle "tests/test_init_update.py\nasset structure assertions" as TT
+
+WI --> PPI : constrains plan-writing rules
+WI --> API : referenced as execution policy
+PPI --> TP : shapes step contract scaffold
+WI --> TR : defines required evidence
+WI --> SK : supplies concise reminders
+TP --> TT : expected scaffold content
+TR --> TT : expected report content
+WI --> TT : expected workflow content
+SK --> TT : expected installed skill content
+@enduml
+```
+
+## Local Diagram Delta（必要時）
+- 変更する境界 / 責務 / 相互作用:
+  - 親 Codex、delegated worker、reviewer の責務境界を workflow text と evidence scaffold に追加する。
+  - N/A: Sequence / State 図は不要。runtime interaction や lifecycle state machine は変えない。
+
+## インターフェース契約
+- Parent Agent Invariant:
+  - 親 Codex は orchestration owner として、source docs の確認、step contract の整理、worker handoff、worker report の統合、reviewer gate 起動、final reporting を担当する。
+  - 親 Codex は code / test / scaffold / template / runtime / shipped asset の direct implementation を通常経路にしない。
+- Delegated Worker Handoff:
+  - 必須項目は `delegated role`、`scope`、`source of truth`、`allowed changes`、`forbidden changes`、`required verification`、`stop conditions`、`output required`。
+  - runtime / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary role とする。
+  - 複合 step は plan で分割するか、allowed paths と reviewer focus を分離して委任する。
+- Plan Step Delegation Contract:
+  - 各 implementation step は `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests`、`reviewer focus`、`stop conditions`、`output required` を持つ。
+  - この contract は `具体テストケース一覧`、`step closure contract`、`behavior slice execution` の代替ではなく、それらの前提境界として置く。
+- Reviewer Gate Mapping:
+  - code / runtime / tests / scaffold behavior を含む step: per-step `code-reviewer` pass が必須。final では issue-wide `code-reviewer` も必須。
+  - docs-only / template-only / skill-text-only step: `spec-reviewer` による docs/spec alignment pass が対応 gate。必要に応じて S90 docs impact でも同じ gate を使う。
+  - Issue 全体: S99 で `qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` をすべて pass まで回す。
+- Parent Implementation Exception:
+  - 必須項目は `delegation unavailable reason`、`user approval / risk acceptance`、`allowed files`、`allowed operation`、`rollback plan`、`post-change verification`、`reviewer gate`。
+  - worker unavailable / denied / host policy conflict は direct implementation の自動許可ではない。
+- Report Evidence:
+  - delegation evidence は `step id`、`delegated role`、`delegated worker summary`、`changed files`、`tests run or docs-only verification`、`reviewer verdict`、`unresolved risks`、`parent integration decision` を残す。
+
+## Sequence Delta（必要時）
+- 変更する相互作用:
+  - N/A: runtime sequence は変えない。workflow text 上の orchestration contract だけを変更する。
+- retry / transaction / external API / queue:
+  - N/A: 対象外。
+- UML:
+  - N/A: issue-level sequence delta は、runtime interaction がないため不要。
+
+## Domain Model Delta（必要時）
+- 親 model 参照:
+  - N/A: domain aggregate / entity / value object は変更しない。
+- aggregate / entity / value object 変更:
+  - N/A: 文書契約のみ。
+- domain event / policy / specification 変更:
+  - policy text と evidence schema の追加に限定する。
+- 不変条件の変更:
+  - 親 Codex direct implementation は通常不変条件に反する。例外時は `Parent Implementation Exception` が必須。
+- UML:
+  - N/A: domain model delta はない。
+
+## クラス / インターフェース詳細設計（必要時）
+- Class / Interface:
+  - N/A: source code interface は変更しない。
+- 責務:
+  - N/A
+- 連携:
+  - N/A
+- UML:
+  - N/A: exhaustive class diagram は不要。
+
+## ディレクトリ / ファイル変更計画
+```text
+.
+|-- src/
+|   |-- spec_dock/
+|   |   `-- assets/
+|   |       |-- spec_dock/
+|   |       |   |-- docs/
+|   |       |   |   |-- workflow_issue.md             # Modify: Parent Agent Invariant, delegated worker handoff, reviewer gate mapping, exception/fail conditions; upstream policy
+|   |       |   |   |-- phase_plan_issue.md           # Modify: plan step delegation contract authoring rules; depends on workflow_issue.md
+|   |       |   |   `-- authoring/
+|   |       |   |       `-- issue-plan.md          # Modify: entrypoint reminder for delegation contract fields; depends on phase_plan_issue.md
+|   |       |   `-- templates/
+|   |       |       `-- issue/
+|   |       |           |-- plan.md                      # Modify: minimal delegation contract scaffold per implementation step
+|   |       |           `-- report.md                    # Modify: delegation evidence, reviewer verdict, parent integration, exception record
+|   |       `-- install_root/
+|   |           `-- .agents/
+|   |               `-- skills/
+|   |                   `-- spec-dock-issue-execution/
+|   |                       `-- SKILL.md              # Modify: concise role routing and stop-condition reminders; docs remain SoT
+|-- spec-dock/
+|   |-- active/
+|   |   `-- issue/
+|   |       `-- design.md                            # Modify: this design only in current step
+|   |-- docs/
+|   |   |-- workflow_issue.md                         # Modify: dogfooding mirror of provider docs
+|   |   |-- phase_plan_issue.md                       # Modify: dogfooding mirror
+|   |   `-- authoring/
+|   |       `-- issue-plan.md                        # Modify: dogfooding mirror
+|   `-- templates/
+|       `-- issue/
+|           |-- plan.md                              # Modify: dogfooding mirror
+|           `-- report.md                            # Modify: dogfooding mirror
+|-- .agents/
+|   `-- skills/
+|       `-- spec-dock-issue-execution/
+|           `-- SKILL.md                              # Modify: dogfooding mirror of installed skill provider
+`-- tests/
+    `-- test_init_update.py                           # Modify: structural/content assertions for provider and mirror scaffolds
+```
+
+## 要件 → 設計マッピング
+- AC-001 -> `workflow_issue.md` と issue-execution skill に `Parent Agent Invariant` を置き、親 Codex の通常責務と direct implementation 禁止を明記する。
+- AC-002 -> `phase_plan_issue.md`、`authoring/issue-plan.md`、plan template に step-local `delegation contract` の必須項目を追加する。
+- AC-003 -> `workflow_issue.md` と skill に delegated worker handoff の必須入力・禁止範囲・停止条件・戻り値を定義する。
+- AC-004 -> `workflow_issue.md`、report template、plan gate guidance に reviewer fail condition と code/runtime/docs-only の gate mapping を固定する。
+- AC-005 -> `workflow_issue.md` と report template に `Parent Implementation Exception` の記録欄と必須項目を追加する。
+- AC-006 -> report template に delegation evidence の必須項目を追加し、future maintainer が step evidence と parent integration decision を読めるようにする。
+- EC-001 -> worker unavailable / denied / host policy conflict は `blocked` / `incomplete` または explicit waiver として扱い、direct implementation 自動許可を禁止する。
+- EC-002 -> run-local orchestration metadata は親 Codex が直接更新可能、shipped docs/templates/skills/workflow text は `doc-writer` または `dev-coder` 委任を必要とする境界を明記する。
+- EC-003 -> 複数 layer/package/shipped asset をまたぐ step は allowed paths と dependencies を明記して delegated worker に委任する。
+- EC-004 -> reviewer fail 後の修正は、原則 bounded follow-up として該当 worker に再委任する。
+- 非交渉制約 -> provider source と dogfooding mirror の両方を file-change plan に含め、docs SoT / concise skill の境界を採用方針に固定する。
+
+## テスト戦略
+- 単体:
+  - `tests/test_init_update.py` に、provider docs/templates/skill と dogfooding mirror の重要 section / label / table column が存在することを構造的に確認する assertion を追加・更新する。
+  - substring だけではなく、可能な範囲で section 見出し、required field list、template table column を検出して drift を見つける。
+- 統合:
+  - `./spec-dock/scripts/spec-dock validate` で current spec-dock artifact の構造を確認する。
+  - 必要に応じて targeted unittest で scaffold asset expectations を確認する。
+- E2E / manual:
+  - docs-only / template-only / skill-text-only のため、manual E2E は必須にしない。
+  - ただし report evidence には docs-only verification と mirror/provider parity confirmation を残す。
+- migration / rollback / feature flag if needed:
+  - migration / feature flag は不要。
+  - rollback は docs/templates/skill/test assertion の同一 commit revert で可能。runtime data migration は発生しない。
+
+## 要件 / 例外 -> verification mapping
+- AC-001:
+  - Verification: `workflow_issue.md` と skill に `Parent Agent Invariant` 相当の記述があり、親 Codex の責務と direct implementation guardrail が一致することを inspect / test assertion で確認する。
+- AC-002:
+  - Verification: plan authoring docs と plan template に `delegation contract` の必須項目が揃っていることを inspect / assertion で確認する。
+- AC-003:
+  - Verification: delegated worker handoff の必須項目が workflow docs / skill guidance / template text に反映されていることを確認する。
+- AC-004:
+  - Verification: reviewer fail condition と gate mapping が workflow docs / report template / plan guidance にあり、code/runtime/scaffold step と docs-only step の reviewer が区別されていることを確認する。
+- AC-005:
+  - Verification: `Parent Implementation Exception` の必須項目が workflow docs と report template にあることを確認する。
+- AC-006:
+  - Verification: report template の delegation evidence が step id、delegated role、worker summary、changed files、verification、reviewer verdict、unresolved risks、parent integration decision を残せることを確認する。
+- EC-001:
+  - Verification: unavailable / denied / host policy conflict が degraded success ではなく blocked / incomplete / waiver semantics になることを workflow docs と report template で確認する。
+- EC-002:
+  - Verification: orchestration metadata と shipped assets の direct update boundary が workflow docs / skill にあることを確認する。
+- EC-003:
+  - Verification: multi-layer step の allowed paths / dependencies / worker handoff rule が plan authoring docs にあることを確認する。
+- EC-004:
+  - Verification: reviewer fail 後は bounded follow-up delegation を原則にする記述が workflow docs / skill にあることを確認する。
+
+## リスク / 移行 / ロールバック（必要時）
+- リスク:
+  - docs / templates / skill に同じ policy を重複記述すると drift する。
+    - 対応: 詳細 policy は `workflow_issue.md`、authoring shape は `phase_plan_issue.md`、skill は concise reminder に分ける。
+  - docs-only step に code-reviewer を要求する、または scaffold/runtime step を spec-reviewer だけで通すと gate focus がずれる。
+    - 対応: reviewer gate mapping を明文化し、plan/report template で review focus を書けるようにする。
+  - provider source と dogfooding mirror の片方だけ更新される。
+    - 対応: file-change plan と tests で provider/mirror parity を確認する。
+- 移行:
+  - 既存 completed Issue の report を retroactive に更新しない。
+  - 新規 / 以後の Issue plan/report scaffold から contract を適用する。
+- ロールバック:
+  - runtime data migration がないため、docs/templates/skill/test assertion の変更を revert すれば戻せる。
+
+## 未確定事項
+- 現時点で plan promotion を妨げる未確定事項はない。

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/plan.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/plan.md
@@ -1,0 +1,656 @@
+---
+種別: 実装計画書（Issue）
+ID: "iss-00098"
+タイトル: "Delegated Implementation Orchestration Contract"
+関連GitHub: ["#98"]
+状態: "approved"
+作成者: "Codex CLI"
+最終更新: "2026-05-15"
+依存: ["requirement.md", "design.md"]
+親: ["epic-00067", "init-local-00003"]
+---
+
+# iss-00098 Delegated Implementation Orchestration Contract — 計画
+
+## この計画で満たす要件ID
+
+- AC-001: Parent Agent Invariant / 親 Codex の通常責務と direct implementation guardrail
+- AC-002: plan step の delegation contract 必須項目
+- AC-003: delegated worker handoff 必須項目
+- AC-004: reviewer gate fail condition と role mapping
+- AC-005: Parent Implementation Exception record
+- AC-006: report delegation evidence / reviewer verdict / parent integration decision
+- EC-001: worker unavailable / denied / host policy conflict の blocked / incomplete / waiver semantics
+- EC-002: orchestration metadata と shipped docs/templates/skills/workflow text の direct update 境界
+- EC-003: 複数 layer / package / shipped asset step の delegated worker handoff
+- EC-004: reviewer fail 後の bounded follow-up delegation
+
+## 依存関係から導く実装順序
+
+1. `workflow_issue.md` を upstream execution policy として先に固定する。
+2. plan authoring docs と plan template は、固定済み policy を consumption surface として取り込む。
+3. report template は evidence / exception policy の記録面だけを取り込む。
+4. issue-execution skill は concise reminder として canonical docs 参照を更新する。
+5. provider source の確定後、dogfooding mirror を同期する。
+6. `tests/test_init_update.py` で generated / mirrored structural content を固定する。
+7. S90 docs impact と S99 final quality gate で、docs drift と issue-wide quality を閉じる。
+
+## ステップ一覧
+
+| Step | Scope | Delegated role | Reviewer gate | Primary closure |
+| --- | --- | --- | --- | --- |
+| S10 | workflow execution policy provider doc | `doc-writer` | `spec-reviewer` | C01, C02, C03, C07, C08 |
+| S20 | plan authoring docs and plan template provider sources | `doc-writer` | `spec-reviewer` | C04, C05, C06 |
+| S30 | report template provider source | `doc-writer` | `spec-reviewer` | C09, C10, C11 |
+| S40 | issue-execution skill provider source | `doc-writer` | `spec-reviewer` | C12, C13 |
+| S50 | dogfooding mirror synchronization | `doc-writer` | `spec-reviewer` | C14 |
+| S60 | init/update structural assertions | `dev-coder` | `code-reviewer` | C15 |
+| S90 | docs impact resolution / docs refresh | `doc-writer` | `spec-reviewer` | C16 |
+| S99 | final quality gate | parent orchestrator | `qa-reviewer`, issue-wide `code-reviewer`, `spec-reviewer` | C17 |
+
+## 要件 ↔ ステップ対応
+
+| Requirement | Steps |
+| --- | --- |
+| AC-001 | S10, S40, S50, S60, S99 |
+| AC-002 | S20, S50, S60, S99 |
+| AC-003 | S10, S40, S50, S60, S99 |
+| AC-004 | S10, S30, S50, S60, S99 |
+| AC-005 | S10, S30, S50, S60, S99 |
+| AC-006 | S30, S50, S60, S99 |
+| EC-001 | S10, S30, S40, S50, S99 |
+| EC-002 | S10, S40, S99 |
+| EC-003 | S10, S20, S99 |
+| EC-004 | S10, S40, S99 |
+
+## Spec-Locked Closure Index
+
+| id | phase / step | slice | type | spec link | locked expectation | observable input/state | bug class guarded | required | evidence level | closure evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| C01 | S10 | workflow policy source | docs | AC-001, design `Parent Agent Invariant` | `workflow_issue.md` owns Parent Agent Invariant and limits parent Codex to inspect / plan / delegate / verify / integrate / report in normal execution. | Provider doc contains the invariant and normal responsibility list. | Parent Codex silently becomes direct implementer. | yes | inspect-only | S10 docs diff and spec-reviewer pass |
+| C02 | S10 | delegated worker handoff | docs | AC-003, EC-003 | `workflow_issue.md` defines handoff fields: delegated role, scope, source of truth, allowed changes, forbidden changes, required verification, stop conditions, output required. | Provider doc contains all handoff field names. | Worker handoff omits scope or verification boundary. | yes | inspect-only | S10 docs diff and S60 assertion |
+| C03 | S10 | parent exception | docs | AC-005, EC-001 | `workflow_issue.md` defines Parent Implementation Exception fields and states that unavailable / denied / host conflict does not automatically permit direct implementation. | Provider doc contains exception fields and waiver semantics. | Degraded mode is treated as reviewer pass or direct-write approval. | yes | inspect-only | S10 docs diff and S60 assertion |
+| C04 | S20 | phase plan consumer | docs | AC-002, design plan responsibility | `phase_plan_issue.md` consumes `workflow_issue.md` policy and tells authors how to write delegation contracts without redefining execution policy. | Provider phase doc references `workflow_issue.md` and required step fields. | Downstream plan doc drifts into alternate policy source. | yes | inspect-only | S20 docs diff |
+| C05 | S20 | authoring entrypoint consumer | docs | AC-002 | `docs/authoring/issue-plan.md` names required plan sections and all step delegation fields. | Provider authoring doc contains required sections and field list. | Plan authors miss required delegation evidence. | yes | inspect-only | S20 docs diff |
+| C06 | S20 | plan template scaffold | template | AC-002 | Plan template contains Spec-Locked Closure Index, step-local `具体テストケース一覧`, step closure contract, behavior slice execution, step gate, and delegation contract fields. | Provider template has reusable scaffold sections and field names. | New issue plans remain implementation-ambiguous. | yes | covered-existing | S20 template diff and S60 assertion |
+| C07 | S10 | reviewer gate mapping | docs | AC-004, EC-004 | `workflow_issue.md` maps code / runtime / tests / scaffold behavior to per-step `code-reviewer`, docs-only / template-only / skill-text-only to `spec-reviewer`, and reviewer fail to delegated follow-up. | Provider workflow doc contains gate mapping and fail semantics. | Wrong reviewer gate passes an unsuitable diff. | yes | inspect-only | S10 docs diff |
+| C08 | S10 | orchestration metadata boundary | docs | EC-002 | `workflow_issue.md` distinguishes run-local orchestration metadata from shipped docs/templates/skills/workflow text. | Provider workflow doc names allowed parent metadata and delegated shipped assets. | Parent direct-edits shipped assets as metadata. | yes | inspect-only | S10 docs diff |
+| C09 | S30 | report delegation evidence | template | AC-006 | Report template requires step id, delegated role, delegated worker summary, changed files, verification, reviewer verdict, unresolved risks, parent integration decision. | Provider report template contains evidence table or fields. | Completed issue cannot prove delegated implementation. | yes | covered-existing | S30 template diff and S60 assertion |
+| C10 | S30 | report exception record | template | AC-005, EC-001 | Report template includes Parent Implementation Exception fields and risk acceptance / reviewer gate state. | Provider report template contains all exception fields. | Direct implementation exception is unreviewed or underdocumented. | yes | covered-existing | S30 template diff and S60 assertion |
+| C11 | S30 | report consumes policy | template | design report responsibility | Report template records evidence and exceptions while referring to `workflow_issue.md` as policy source. | Provider report template avoids becoming alternate execution policy. | Report template conflicts with workflow policy. | yes | inspect-only | S30 spec-reviewer pass |
+| C12 | S40 | skill concise reminder | skill | AC-001, AC-003 | Issue-execution skill reminds parent invariant, role routing, docs source of truth, stop conditions, and does not duplicate full policy. | Provider skill is concise and links/refers to canonical docs. | Skill becomes stale policy fork. | yes | covered-existing | S40 skill diff and S60 assertion |
+| C13 | S40 | skill stop conditions | skill | EC-001, EC-004 | Skill reminds that unavailable/denied delegation and reviewer fail are stop / re-delegation conditions, not success. | Provider skill contains stop-condition reminders. | Agent proceeds after failed reviewer or unavailable worker. | yes | inspect-only | S40 skill diff |
+| C14 | S50 | provider/mirror parity | mirror | non-negotiable design constraint | Dogfooding mirror files under `spec-dock/` and `.agents/` carry the provider source changes. | Mirror files contain the same structural headings/fields as provider sources. | Dogfooding uses stale behavior while provider source changed. | yes | inspect-only | S50 parity check |
+| C15 | S60 | regression assertions | tests | design test strategy | `tests/test_init_update.py` asserts key structural content for workflow docs, plan template, report template, skill, and mirror generation. | Targeted pytest passes after adding structural assertions; pre-implementation evidence is characterization of existing test coverage, not failing-first. | Future init/update drops contract fields silently. | yes | covered-existing | `uv run pytest tests/test_init_update.py` |
+| C16 | S90 | docs impact closure | docs | workflow_issue S90 | Changed docs/templates/skill have consistent references and no unresolved docs impact remains. | Docs impact list is recorded; needed docs edits are complete or no-op is justified. | Contract references break or drift after local edits. | yes | inspect-only | S90 docs/spec alignment pass |
+| C17 | S99 | final quality gate | final | workflow_issue S99 | Final qa-reviewer, issue-wide code-reviewer, and spec-reviewer gates pass; closure evidence is complete. | Final report can cite tests, reviews, changed files, and clean scope. | Step-local pass hides issue-wide regression. | yes | manual-required | S99 final gate evidence |
+
+## 実装ステップ
+
+### S10 - Workflow execution policy provider doc
+
+- depends on: approved `requirement.md`, approved `design.md`
+- unblocks: S20, S30, S40, S50, S60
+- design refs: `Parent Agent Invariant`, `Delegated Worker Handoff`, `Reviewer Gate Mapping`, `Parent Implementation Exception`, `Report Evidence`
+- target files:
+  - `src/spec_dock/assets/spec_dock/docs/workflow_issue.md`
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: `spec-dock/active/issue/requirement.md`, `spec-dock/active/issue/design.md`, `spec-dock/docs/workflow_issue.md`, `spec-dock/docs/workflow_spec_authoring.md`
+- allowed paths: `src/spec_dock/assets/spec_dock/docs/workflow_issue.md`
+- forbidden changes: dogfooding mirror files, templates, skill files, tests, Python runtime source, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: provider `workflow_issue.md` is the upstream execution policy source and contains Parent Agent Invariant, delegated worker handoff, reviewer gate mapping, Parent Implementation Exception, unavailable/denied/waiver semantics, orchestration metadata boundary, and reviewer-fail re-delegation rule.
+- required tests or docs-only verification: docs-only verification against AC-001, AC-003, AC-004, AC-005, EC-001, EC-002, EC-003, EC-004; no automated test in this step.
+- reviewer focus: `workflow_issue.md` owns policy; no downstream docs/templates/skills are edited in this step.
+- stop conditions: required policy cannot be added without contradicting `workflow_spec_authoring.md`; approved design appears insufficient; provider source path is not readable.
+- output required: changed section summary, closure evidence for C01/C02/C03/C07/C08, docs-only verification notes.
+
+#### 具体テストケース一覧
+
+- `tc-s10-001` docs-only: Parent Agent Invariant is canonical
+  - 前提: provider `workflow_issue.md` is the execution policy source.
+  - 操作: Inspect the changed provider doc.
+  - 期待結果: Parent Codex normal responsibilities are limited to inspect / plan / delegate / verify / integrate / report, and direct implementation of shipped assets is not normal execution.
+  - 失敗検出: Parent direct implementation remains allowed as an unrecorded normal path.
+  - 検証方法: docs-only inspection recorded in report.
+  - 関連 closure id: C01
+- `tc-s10-002` docs-only: delegated worker handoff and exception fields are complete
+  - 前提: AC-003 and AC-005 field names are fixed by requirement/design.
+  - 操作: Inspect delegated worker handoff and Parent Implementation Exception sections.
+  - 期待結果: All required handoff and exception fields are present, and unavailable/denied/waiver semantics do not imply reviewer pass.
+  - 失敗検出: Missing field, degraded success wording, or direct implementation auto-approval.
+  - 検証方法: docs-only inspection recorded in report.
+  - 関連 closure id: C02, C03
+- `tc-s10-003` docs-only: reviewer mapping is explicit
+  - 前提: Step types include docs/template/skill and code/runtime/tests/scaffold behavior.
+  - 操作: Inspect reviewer gate mapping and reviewer fail handling.
+  - 期待結果: docs-only/template-only/skill-text-only maps to `spec-reviewer`; code/runtime/tests/scaffold behavior maps to `code-reviewer`; reviewer fail returns to bounded delegated follow-up.
+  - 失敗検出: Wrong reviewer is sufficient for a step type or parent fixes failed review directly without exception.
+  - 検証方法: docs-only inspection recorded in report.
+  - 関連 closure id: C07, C08
+
+#### step closure contract
+
+- closure ids: C01, C02, C03, C07, C08
+- close when: all target policy sections are present in provider `workflow_issue.md`, docs-only verification passes, and `spec-reviewer` passes.
+- test bundle: docs-only inspection cases `tc-s10-001` through `tc-s10-003`.
+- pre-implementation evidence: characterization pass by reading current `workflow_issue.md` and confirming existing `Implementation Delegation Gate` does not yet satisfy all iss-00098 fields.
+- verification evidence: diff excerpt and spec-reviewer verdict in `report.md`.
+- report evidence: Step Contract Closure rows for C01/C02/C03/C07/C08.
+- residual risk: exact prose may evolve during review, but source-of-truth ownership must not change.
+
+#### behavior slice execution
+
+1. Read current provider `workflow_issue.md` and active requirement/design.
+2. Add only the missing delegated-by-default policy sections.
+3. Verify field names and gate semantics against requirement AC/EC.
+4. Request `spec-reviewer` docs/spec alignment review.
+5. Close S10 only after reviewer pass or stop with blocker.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass for docs/spec alignment.
+- commit gate: one S10 commit after pass.
+- no-op gate: allowed only if provider doc already contains all C01/C02/C03/C07/C08 content and report records inspected sections.
+- report update: record docs-only verification, reviewer verdict, and closure IDs.
+
+### S20 - Plan authoring docs and plan template provider sources
+
+- depends on: S10
+- unblocks: S50, S60
+- design refs: `Plan Step Delegation Contract`, directory / file change plan
+- target files:
+  - `src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md`
+  - `src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md`
+  - `src/spec_dock/assets/spec_dock/templates/issue/plan.md`
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: active requirement/design, S10 changed `workflow_issue.md`, current target files, dogfooding `spec-dock/docs/phase_plan_issue.md`, `spec-dock/docs/authoring/issue-plan.md`
+- allowed paths: the three S20 target files only
+- forbidden changes: `workflow_issue.md`, report template, skill files, tests, dogfooding mirrors, Python runtime source, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: phase and authoring docs consume `workflow_issue.md`; plan template contains Spec-Locked Closure Index, step-local `具体テストケース一覧`, step closure contract, behavior slice execution, step gate, and every delegation contract field.
+- required tests or docs-only verification: docs-only verification now; structural assertions are added in S60.
+- reviewer focus: no alternate execution policy is introduced; template remains reusable and not iss-00098-specific.
+- stop conditions: template source is generated from a different source; required sections cannot fit without breaking existing template contract.
+- output required: changed section summary, closure evidence for C04/C05/C06, docs-only verification notes.
+
+#### 具体テストケース一覧
+
+- `tc-s20-001` docs-only: plan docs consume workflow policy
+  - 前提: S10 made `workflow_issue.md` the policy source.
+  - 操作: Inspect provider `phase_plan_issue.md` and `docs/authoring/issue-plan.md`.
+  - 期待結果: They reference/consume `workflow_issue.md` and describe how to author delegation contracts without redefining execution policy.
+  - 失敗検出: The docs introduce conflicting cadence, reviewer semantics, or exception policy.
+  - 検証方法: docs-only inspection recorded in report.
+  - 関連 closure id: C04, C05
+- `tc-s20-002` docs-only: plan template has all required step fields
+  - 前提: AC-002 field list is fixed.
+  - 操作: Inspect provider `templates/issue/plan.md`.
+  - 期待結果: Each implementation step scaffold includes delegated role, input docs, allowed paths, forbidden changes, acceptance criteria, required tests or docs-only verification, reviewer focus, stop conditions, and output required.
+  - 失敗検出: Future plan authors can omit delegation boundaries or verification.
+  - 検証方法: docs-only inspection now; S60 adds automated structural assertion.
+  - 関連 closure id: C06
+- `tc-s20-003` docs-only: plan template includes required execution sections
+  - 前提: `phase_plan_issue.md` requires step-local concrete test cases and closure contracts.
+  - 操作: Inspect provider plan template headings.
+  - 期待結果: Spec-Locked Closure Index, `具体テストケース一覧`, step closure contract, behavior slice execution, and step gate are present.
+  - 失敗検出: Template permits global tests only or omits step-local gate.
+  - 検証方法: docs-only inspection now; S60 adds automated structural assertion.
+  - 関連 closure id: C06
+
+#### step closure contract
+
+- closure ids: C04, C05, C06
+- close when: S20 target files contain the required consumer guidance and plan scaffold, docs-only verification passes, and `spec-reviewer` passes.
+- test bundle: docs-only cases `tc-s20-001` through `tc-s20-003`.
+- pre-implementation evidence: characterization pass by inspecting current plan docs/template and recording missing AC-002 field coverage.
+- verification evidence: diff excerpt and spec-reviewer verdict.
+- report evidence: Step Contract Closure rows for C04/C05/C06.
+- residual risk: S60 may tighten exact strings for testability; any wording-only adjustment stays within S20 contract.
+
+#### behavior slice execution
+
+1. Read S10 policy and current provider plan docs/template.
+2. Update provider plan docs as policy consumers.
+3. Update provider plan template with required scaffold sections and fields.
+4. Verify the template is reusable and not iss-00098-specific.
+5. Request `spec-reviewer` and close only on pass.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass for docs/template alignment.
+- commit gate: one S20 commit after pass.
+- no-op gate: allowed only if all C04/C05/C06 expectations already exist.
+- report update: record docs-only verification and reviewer verdict.
+
+### S30 - Report template provider source
+
+- depends on: S10
+- unblocks: S50, S60
+- design refs: `Report Evidence`, `Parent Implementation Exception`
+- target files:
+  - `src/spec_dock/assets/spec_dock/templates/issue/report.md`
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: active requirement/design, S10 changed `workflow_issue.md`, current report template
+- allowed paths: `src/spec_dock/assets/spec_dock/templates/issue/report.md`
+- forbidden changes: workflow docs, plan docs, plan template, skill files, tests, dogfooding mirrors, Python runtime source, active issue `requirement.md` / `design.md` / `plan.md`
+- acceptance criteria: report template captures delegation evidence, reviewer verdict, parent integration decision, unresolved risks, Parent Implementation Exception, and waiver/unavailable/denied semantics while referring to `workflow_issue.md` as policy source.
+- required tests or docs-only verification: docs-only verification now; structural assertions are added in S60.
+- reviewer focus: evidence scaffold does not become an alternate execution policy.
+- stop conditions: report template structure cannot accept required evidence without broad report workflow redesign.
+- output required: changed section summary and closure evidence for C09/C10/C11.
+
+#### 具体テストケース一覧
+
+- `tc-s30-001` docs-only: delegation evidence fields are complete
+  - 前提: AC-006 field list is fixed.
+  - 操作: Inspect provider report template delegation evidence section.
+  - 期待結果: step id, delegated role, worker summary, changed files, verification, reviewer verdict, unresolved risks, and parent integration decision can be recorded.
+  - 失敗検出: Completed reports cannot reconstruct delegated work or parent integration judgment.
+  - 検証方法: docs-only inspection now; S60 adds automated structural assertion.
+  - 関連 closure id: C09
+- `tc-s30-002` docs-only: Parent Implementation Exception is recordable
+  - 前提: AC-005 and EC-001 define exception and waiver fields.
+  - 操作: Inspect provider report template exception section.
+  - 期待結果: delegation unavailable reason, user approval / risk acceptance, allowed files, allowed operation, rollback plan, post-change verification, and reviewer gate are recordable.
+  - 失敗検出: Parent direct implementation can occur without full exception evidence.
+  - 検証方法: docs-only inspection now; S60 adds automated structural assertion.
+  - 関連 closure id: C10
+- `tc-s30-003` docs-only: report remains evidence surface
+  - 前提: `workflow_issue.md` owns execution policy.
+  - 操作: Inspect report template wording.
+  - 期待結果: The template points to policy and records evidence; it does not redefine reviewer pass, waiver, or delegation semantics.
+  - 失敗検出: Report template conflicts with S10 policy wording.
+  - 検証方法: docs-only inspection and spec-reviewer review.
+  - 関連 closure id: C11
+
+#### step closure contract
+
+- closure ids: C09, C10, C11
+- close when: provider report template contains required evidence and exception fields, docs-only verification passes, and `spec-reviewer` passes.
+- test bundle: docs-only cases `tc-s30-001` through `tc-s30-003`.
+- pre-implementation evidence: characterization pass by inspecting current report template evidence gaps.
+- verification evidence: diff excerpt and spec-reviewer verdict.
+- report evidence: Step Contract Closure rows for C09/C10/C11.
+- residual risk: S60 may require stable labels for assertions; wording can be adjusted without changing policy.
+
+#### behavior slice execution
+
+1. Read S10 policy and current provider report template.
+2. Add evidence and exception recording surfaces only.
+3. Verify template references policy rather than owning it.
+4. Request `spec-reviewer`.
+5. Close on pass.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass.
+- commit gate: one S30 commit after pass.
+- no-op gate: allowed only if C09/C10/C11 already exist.
+- report update: record docs-only verification and reviewer verdict.
+
+### S40 - Issue-execution skill provider source
+
+- depends on: S10
+- unblocks: S50, S60
+- design refs: skill responsibility and concise reminder policy
+- target files:
+  - `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md`
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: active requirement/design, S10 changed `workflow_issue.md`, current provider skill, dogfooding mirror skill
+- allowed paths: `src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md`
+- forbidden changes: workflow docs, templates, tests, dogfooding mirrors, Python runtime source, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: skill concisely reminds parent invariant, role routing, canonical docs, stop conditions, unavailable/denied/waiver semantics, and reviewer-fail re-delegation without duplicating full workflow policy.
+- required tests or docs-only verification: docs-only verification now; structural assertion added in S60 if current tests cover installed skill content.
+- reviewer focus: concise reminder only; no policy fork.
+- stop conditions: skill source is generated externally or missing from provider assets.
+- output required: changed reminder summary and closure evidence for C12/C13.
+
+#### 具体テストケース一覧
+
+- `tc-s40-001` docs-only: skill stays concise and canonical-doc driven
+  - 前提: `workflow_issue.md` owns policy.
+  - 操作: Inspect provider issue-execution skill.
+  - 期待結果: Skill points executors to canonical docs and summarizes role routing without embedding full policy.
+  - 失敗検出: Skill duplicates long policy text or contradicts workflow docs.
+  - 検証方法: docs-only inspection now; S60 assertion if supported.
+  - 関連 closure id: C12
+- `tc-s40-002` docs-only: skill stop conditions are explicit
+  - 前提: EC-001 and EC-004 require stop/re-delegation semantics.
+  - 操作: Inspect skill reminders for unavailable/denied delegation and reviewer fail.
+  - 期待結果: Skill tells parent Codex to stop or re-delegate, not treat these states as success.
+  - 失敗検出: Agent proceeds after unavailable worker or failed reviewer.
+  - 検証方法: docs-only inspection.
+  - 関連 closure id: C13
+
+#### step closure contract
+
+- closure ids: C12, C13
+- close when: provider skill contains concise reminders and stop conditions, docs-only verification passes, and `spec-reviewer` passes.
+- test bundle: docs-only cases `tc-s40-001` and `tc-s40-002`.
+- pre-implementation evidence: characterization pass by inspecting current skill for missing delegated-by-default reminder fields.
+- verification evidence: diff excerpt and spec-reviewer verdict.
+- report evidence: Step Contract Closure rows for C12/C13.
+- residual risk: brevity is subjective; reviewer focus is source-of-truth consistency and absence of full policy duplication.
+
+#### behavior slice execution
+
+1. Read S10 policy and provider skill.
+2. Update only concise reminder bullets/sections.
+3. Verify canonical docs remain the source of truth.
+4. Request `spec-reviewer`.
+5. Close on pass.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass.
+- commit gate: one S40 commit after pass.
+- no-op gate: allowed only if C12/C13 already exist.
+- report update: record docs-only verification and reviewer verdict.
+
+### S50 - Dogfooding mirror synchronization
+
+- depends on: S10, S20, S30, S40
+- unblocks: S60, S90, S99
+- design refs: provider/mirror non-negotiable constraint
+- target files:
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/phase_plan_issue.md`
+  - `spec-dock/docs/authoring/issue-plan.md`
+  - `spec-dock/templates/issue/plan.md`
+  - `spec-dock/templates/issue/report.md`
+  - `.agents/skills/spec-dock-issue-execution/SKILL.md`
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: changed provider sources from S10-S40, current dogfooding mirror files, active requirement/design
+- allowed paths: the six S50 target files only
+- forbidden changes: provider sources, tests, Python runtime source, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: dogfooding mirror files contain the same structural sections/fields as provider sources; any intentional mirror difference is recorded with reason.
+- required tests or docs-only verification: provider/mirror structural parity inspection; automated generation assertions added in S60.
+- reviewer focus: synchronization without broad unrelated formatting churn.
+- stop conditions: mirror path cannot be matched to provider source; synchronization requires a generator that changes paths outside S50 allowed paths.
+- output required: parity summary and closure evidence for C14.
+
+#### 具体テストケース一覧
+
+- `tc-s50-001` docs-only: workflow and plan docs mirror provider structure
+  - 前提: S10 and S20 provider docs are complete.
+  - 操作: Compare provider docs to dogfooding `spec-dock/docs/...` mirrors for required headings/fields.
+  - 期待結果: Mirror docs include the same source-of-truth role split, delegation contract fields, and plan authoring requirements.
+  - 失敗検出: Dogfooding docs are stale or conflict with provider docs.
+  - 検証方法: docs-only parity inspection.
+  - 関連 closure id: C14
+- `tc-s50-002` docs-only: templates and skill mirror provider structure
+  - 前提: S30 and S40 provider template/skill changes are complete.
+  - 操作: Compare provider plan/report templates and skill to dogfooding mirrors for required structural content.
+  - 期待結果: Mirror plan/report/skill contain required sections and fields.
+  - 失敗検出: New scaffold behavior differs from dogfooding behavior.
+  - 検証方法: docs-only parity inspection.
+  - 関連 closure id: C14
+
+#### step closure contract
+
+- closure ids: C14
+- close when: all six mirror files are synchronized structurally, parity verification passes, and `spec-reviewer` passes.
+- test bundle: docs-only cases `tc-s50-001` and `tc-s50-002`.
+- pre-implementation evidence: characterization pass by listing provider/mirror target pairs.
+- verification evidence: parity notes and spec-reviewer verdict.
+- report evidence: Step Contract Closure row for C14.
+- residual risk: exact provider/mirror byte-for-byte equality may not be required if existing mirror conventions differ; structural parity is required.
+
+#### behavior slice execution
+
+1. List provider-to-mirror pairs.
+2. Apply provider structural changes to dogfooding mirrors.
+3. Inspect each pair for required headings/fields.
+4. Request `spec-reviewer`.
+5. Close on pass.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass.
+- commit gate: one S50 commit after pass.
+- no-op gate: allowed only if all mirror files already match required structure.
+- report update: record mirror paths and parity evidence.
+
+### S60 - Init/update structural assertions
+
+- depends on: S10, S20, S30, S40, S50
+- unblocks: S90, S99
+- design refs: test strategy
+- target files:
+  - `tests/test_init_update.py`
+
+#### delegation contract
+
+- delegated role: `dev-coder`
+- input docs: active requirement/design, changed provider and mirror files from S10-S50, `tests/test_init_update.py`
+- allowed paths: `tests/test_init_update.py`
+- forbidden changes: docs, templates, skills, Python runtime source, generated artifacts, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: targeted assertions cover workflow policy fields, plan template required sections/fields, report evidence/exception fields, concise skill reminder, and provider/mirror generated structural content.
+- required tests or docs-only verification: `uv run pytest tests/test_init_update.py`
+- reviewer focus: assertions should check stable structural contract, not incidental long prose.
+- stop conditions: tests require runtime changes outside approved scope; fixtures reveal generated output path drift not covered by design.
+- output required: test names added/changed, pytest result, closure evidence for C15.
+
+#### 具体テストケース一覧
+
+- `tc-s60-001` regression: plan template structural contract is asserted
+  - 前提: S20 provider plan template and S50 mirror are updated.
+  - 操作: Run targeted init/update tests.
+  - 期待結果: Tests assert `Spec-Locked Closure Index`, `具体テストケース一覧`, step closure contract, behavior slice execution, step gate, and all delegation contract fields.
+  - 失敗検出: Future scaffold drops a required plan section or field.
+  - 検証方法: `uv run pytest tests/test_init_update.py`
+  - 関連 closure id: C06, C15
+- `tc-s60-002` regression: report evidence and exception contract is asserted
+  - 前提: S30 provider report template and S50 mirror are updated.
+  - 操作: Run targeted init/update tests.
+  - 期待結果: Tests assert delegation evidence fields and Parent Implementation Exception fields.
+  - 失敗検出: Future report scaffold cannot record AC-005 or AC-006 evidence.
+  - 検証方法: `uv run pytest tests/test_init_update.py`
+  - 関連 closure id: C09, C10, C15
+- `tc-s60-003` regression: workflow/skill source-of-truth roles are asserted
+  - 前提: S10 provider workflow doc and S40 provider skill are updated.
+  - 操作: Run targeted init/update tests.
+  - 期待結果: Tests assert workflow source-of-truth role markers and concise skill reminder markers.
+  - 失敗検出: Skill becomes policy fork or workflow policy fields disappear.
+  - 検証方法: `uv run pytest tests/test_init_update.py`
+  - 関連 closure id: C01, C12, C15
+
+#### step closure contract
+
+- closure ids: C15
+- close when: `tests/test_init_update.py` contains structural assertions and targeted pytest passes.
+- test bundle: regression cases `tc-s60-001` through `tc-s60-003`.
+- pre-implementation evidence: characterization pass by running or inspecting existing tests before changes, or documenting why red-first is not applicable for docs/template asset tests.
+- verification evidence: `uv run pytest tests/test_init_update.py` output.
+- report evidence: Test Contract Closure and Closure Coverage rows for C15 and linked closure ids.
+- residual risk: assertions cannot prove every prose nuance; they lock required structural content.
+
+#### behavior slice execution
+
+1. Inspect existing test helper style in `tests/test_init_update.py`.
+2. Add minimal structural assertions for changed assets.
+3. Run targeted pytest.
+4. Fix assertion overfitting if tests are brittle.
+5. Request `code-reviewer` for test diff.
+
+#### step gate
+
+- `code-reviewer gate`: required pass because this step changes tests.
+- commit gate: one S60 commit after pass.
+- no-op gate: allowed only if existing tests already assert all C15 content.
+- report update: record pytest output and reviewer verdict.
+
+### S90 - Docs impact resolution / docs refresh
+
+- depends on: S10-S60
+- unblocks: S99
+- design refs: S90 standard docs impact gate
+- target files:
+  - No edits by default.
+  - If changed docs introduce a broken or missing reference, only the directly impacted docs index/cross-reference file may be edited after recording the reason.
+
+#### delegation contract
+
+- delegated role: `doc-writer`
+- input docs: all changed files from S10-S60, `spec-dock/docs/workflow_spec_authoring.md`, `spec-dock/docs/phase_plan_issue.md`, active requirement/design/plan
+- allowed paths: no edits by default; directly impacted docs index/cross-reference files only if required
+- forbidden changes: Python runtime source, tests, templates, skills, unrelated docs, active issue `requirement.md` / `design.md` / `report.md`
+- acceptance criteria: docs impact is resolved; no stale links, role-split conflicts, or policy/source-of-truth drift remain.
+- required tests or docs-only verification: docs-only link/path/reference inspection; `spec-reviewer` docs/spec alignment pass.
+- reviewer focus: changed surfaces remain consistent with approved requirement/design/plan and `workflow_spec_authoring.md`.
+- stop conditions: resolving docs impact requires broad docs restructuring or edits outside allowed paths.
+- output required: impacted-docs list, no-op or changed-path summary, closure evidence for C16.
+
+#### 具体テストケース一覧
+
+- `tc-s90-001` docs-only: changed references are consistent
+  - 前提: S10-S60 changes are complete.
+  - 操作: Inspect changed docs/templates/skill for references to canonical docs, provider/mirror roles, reviewer gates, and report evidence.
+  - 期待結果: References are valid and no changed surface contradicts another.
+  - 失敗検出: Broken link, stale role description, or duplicated policy source.
+  - 検証方法: docs-only inspection plus `spec-reviewer` pass.
+  - 関連 closure id: C16
+- `tc-s90-002` docs-only: docs impact no-op is justified when no edit is needed
+  - 前提: No broken references or drift are found.
+  - 操作: Record inspected paths and no-op reason.
+  - 期待結果: Report explains why no additional docs edit is needed.
+  - 失敗検出: Docs impact is skipped without inspected-path evidence.
+  - 検証方法: report evidence and `spec-reviewer` pass.
+  - 関連 closure id: C16
+
+#### step closure contract
+
+- closure ids: C16
+- close when: docs impact list is complete, required docs fixes are done or no-op is justified, and `spec-reviewer` passes.
+- test bundle: docs-only cases `tc-s90-001` and `tc-s90-002`.
+- pre-implementation evidence: inspect changed paths from S10-S60.
+- verification evidence: docs impact notes and spec-reviewer verdict.
+- report evidence: S90 docs impact section in report.
+- residual risk: none expected; broad docs restructuring is out of scope and must stop.
+
+#### behavior slice execution
+
+1. Review changed files and references.
+2. Decide whether docs impact is no-op or requires a narrow cross-reference edit.
+3. If edit is required, edit only allowed docs reference path.
+4. Request `spec-reviewer`.
+5. Close on pass.
+
+#### step gate
+
+- `spec-reviewer gate`: required pass.
+- commit gate: one S90 commit if edits are made; otherwise approved-no-op evidence.
+- no-op gate: allowed with inspected-path evidence.
+- report update: record impacted docs and reviewer verdict.
+
+### S99 - Final quality gate
+
+- depends on: S90
+- unblocks: issue completion report and final handoff
+- design refs: S99 standard final quality gate
+- target files:
+  - No edits by default.
+  - `spec-dock/active/issue/report.md` may be updated by the parent orchestrator as run-local orchestration metadata during execution.
+
+#### delegation contract
+
+- delegated role: parent orchestrator for integration; reviewer roles are `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`
+- input docs: active requirement/design/plan/report, all changed files, S60 test output, S90 docs impact evidence
+- allowed paths: no product/doc/template/skill/test edits in this step; report metadata only during actual execution
+- forbidden changes: provider sources, mirrors, tests, runtime source, active issue `requirement.md` / `design.md` / `plan.md`
+- acceptance criteria: all closure IDs C01-C17 have evidence, `uv run pytest tests/test_init_update.py` passes, `git diff --check` passes, final `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer` pass.
+- required tests or docs-only verification: `git diff --check`; `uv run pytest tests/test_init_update.py`; final reviewer gates.
+- reviewer focus: issue-wide integration, test sufficiency, source-of-truth role split, provider/mirror parity, complete report evidence.
+- stop conditions: any closure ID lacks evidence; any required reviewer is unavailable/denied/failed without explicit blocked/incomplete handling; tests fail.
+- output required: final changed-file list, commands/results, reviewer verdicts, closure index status, remaining risks.
+
+#### 具体テストケース一覧
+
+- `tc-s99-001` quality: targeted tests and diff hygiene pass
+  - 前提: S10-S90 are closed.
+  - 操作: Run `git diff --check` and `uv run pytest tests/test_init_update.py`.
+  - 期待結果: Both commands pass.
+  - 失敗検出: Whitespace errors or structural asset regression remain.
+  - 検証方法: command output recorded in report/final response.
+  - 関連 closure id: C15, C17
+- `tc-s99-002` quality: final reviewer gates pass
+  - 前提: All implementation step reviews have passed or valid no-op evidence exists.
+  - 操作: Run final `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`.
+  - 期待結果: All three final reviewers pass fresh.
+  - 失敗検出: Step-local review missed test insufficiency, integration risk, or spec mismatch.
+  - 検証方法: reviewer verdicts recorded in report.
+  - 関連 closure id: C17
+- `tc-s99-003` quality: closure ledger is complete
+  - 前提: S10-S90 report evidence exists.
+  - 操作: Inspect closure index C01-C17 against report evidence.
+  - 期待結果: Every required closure has evidence and no unresolved question remains.
+  - 失敗検出: Issue is reported complete with missing closure evidence.
+  - 検証方法: final report closure review.
+  - 関連 closure id: C17
+
+#### step closure contract
+
+- closure ids: C17 plus final confirmation of C01-C16
+- close when: tests pass, diff hygiene passes, all final reviewers pass, closure ledger is complete, and unexpected modified files are absent.
+- test bundle: quality cases `tc-s99-001` through `tc-s99-003`.
+- pre-implementation evidence: all previous step closure evidence exists.
+- verification evidence: command outputs and reviewer verdicts.
+- report evidence: final quality gate and final exit contract.
+- residual risk: none accepted without explicit blocked/incomplete report.
+
+#### behavior slice execution
+
+1. Confirm S10-S90 closure evidence.
+2. Run final commands.
+3. Run final reviewer gates.
+4. Resolve any reviewer failure by returning to the appropriate delegated step, not by direct unrecorded fix.
+5. Close only after all final gates pass.
+
+#### step gate
+
+- `qa-reviewer gate`: required pass for test sufficiency and integration test need.
+- issue-wide `code-reviewer gate`: required pass for integrated diff.
+- `spec-reviewer gate`: required pass for requirement/design/plan/report/docs alignment.
+- commit gate: final report/final commit handled by execution workflow after pass.
+- no-op gate: not applicable for final quality gate.
+- report update: record final commands, reviewer verdicts, closure ledger, and remaining risks.
+
+## Review / QA Gate 方針
+
+- Docs-only, template-only, and skill-text-only steps use `spec-reviewer` as the step reviewer.
+- Test changes use `code-reviewer` as the step reviewer.
+- S99 always runs `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`; final reviews do not replace step reviews.
+- Required reviewer gate success means fresh `passed` only. `waived`, `provisional`, `unavailable`, `denied`, and `failed` are not pass states.
+- Reviewer failure is handled by bounded follow-up delegation to the appropriate worker unless a recorded Parent Implementation Exception is approved.
+
+## Final Exit Contract
+
+The issue can proceed from plan to implementation when:
+
+- This plan has fresh `spec-reviewer` pass.
+- Every implementation step has concrete target files, delegation contract, concrete test cases, closure contract, behavior slice execution, and step gate.
+- Provider source and dogfooding mirror updates are both planned.
+- S90 and S99 are present and decision-complete.
+- No unresolved questions or placeholders remain.
+
+The implementation can be reported complete only when:
+
+- Closure IDs C01-C17 have evidence.
+- S10-S60 step reviews pass and each step is committed or valid approved-no-op.
+- S90 docs impact is resolved.
+- S99 final quality gate passes.
+- `report.md` records command evidence, reviewer evidence, delegation evidence, parent integration decisions, and any residual risks.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/report.md
@@ -1,0 +1,240 @@
+---
+種別: 実装報告書（Issue）
+ID: "iss-00098"
+タイトル: "Delegated Implementation Orchestration Contract"
+関連GitHub: ["#98"]
+状態: "draft | approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-15"
+依存: ["requirement.md", "design.md", "plan.md"]
+親: ["epic-00067", "init-local-00003"]
+---
+
+# iss-00098 Delegated Implementation Orchestration Contract — 実装報告（LOG）
+
+## 実装サマリー (任意)
+- [実装した内容の概要を2-3文で記載]
+
+## 実装記録（セッションログ） (必須)
+
+### 2026-05-15 初期セットアップ
+
+#### 対象
+- Step: requirement authoring setup
+- AC/EC: AC-001..AC-006, EC-001..EC-004
+
+#### 実施内容
+- `epic-00067` 配下に `Delegated Implementation Orchestration Contract` の Issue を作成した。
+- GitHub Issue `#98` と spec-dock Issue `iss-00098` の linkage を作成した。
+- `issue start iss-00098` は、新規 Issue node が未追跡で working tree が clean ではないため checkout safety guard で停止した。
+- 作成済み Issue node を保持するため、専用ブランチを手動作成し、manual / recovery path として `active set --id iss-00098` で active issue を固定した。
+- ユーザー補足により、この Issue workflow 内で `spec-reviewer`、`dev-coder`、`code-reviewer`、`qa-reviewer` など適切な named sub-agent を活用する workflow-scoped delegation consent を得た。
+
+#### 実行コマンド / 結果
+```bash
+./spec-dock/scripts/spec-dock new issue --create-github-issue --epic epic-00067 --title "Delegated Implementation Orchestration Contract"
+
+spec-dock: ok (new issue) id=iss-00098 epic=epic-00067 initiative=init-local-00003 ... github=#98
+spec-dock: ok (new issue auto-sync)
+
+./spec-dock/scripts/spec-dock issue start iss-00098
+
+error: Working tree is not clean; aborting checkout for safety.
+?? spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/
+
+git checkout -b codex/iss-00098-delegated-implementation-orchestration-contract
+
+Switched to a new branch 'codex/iss-00098-delegated-implementation-orchestration-contract'
+
+./spec-dock/scripts/spec-dock active set --id iss-00098
+
+spec-dock: ok (active set) target=iss-00098 initiative=init-local-00003 epic=epic-00067 issue=iss-00098
+
+./spec-dock/scripts/spec-dock validate
+
+spec-dock: ok (validate) nodes=42
+```
+
+#### Workflow Delegation Consent
+| consent source | repo/worktree | active issue | session | named roles | boundary | expires / invalidation | result |
+|---|---|---|---|---|---|---|---|
+| user instruction on 2026-05-15 | `/Users/iwasawayuuta/workspace/tools/spec-dock` | `iss-00098` | current Codex session | `spec-reviewer`, `code-reviewer`, `qa-reviewer`, read-only specialist agents | Reviewer/read-only specialist workflow-scoped consent for this Issue's spec authoring, reviews, and final gates. Write-capable delegation such as `doc-writer` and `dev-coder` is recorded per step in Step Execution Ledger / Implementation Delegation Gate evidence, not treated as generic consent. Separate confirmation remains required for destructive operations, credentialed external access outside GitHub issue creation already requested, publishing, or scope expansion. | Ends when active issue/session scope changes or user revokes consent. | granted |
+
+#### Step Contract Closure
+| step | closure ids | close condition | evidence | result | notes |
+|---|---|---|---|---|---|
+| requirement authoring setup | AC-001..AC-006 | Issue exists, active issue is fixed, requirement draft is authored, validate passes | `new issue`, manual branch checkout, `active set --id iss-00098`, `validate` | pass | `issue start` blocked by clean-worktree guard after node creation; manual recovery path recorded |
+
+#### Test Contract Closure
+| closure id / test id | step | required | evidence level | pre-implementation evidence | verification command | result | notes |
+|---|---|---|---|---|---|---|---|
+| AC-001..AC-006 | requirement authoring setup | yes | evidence-required | requirement draft created from approved plan | `./spec-dock/scripts/spec-dock validate` | pass | spec-reviewer gate pending |
+
+- `closure id / test id` は Central index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
+
+#### Closure Coverage
+| closure id | step | verification evidence | result | notes |
+|---|---|---|---|---|
+| AC-001..AC-006 | requirement authoring setup | `validate` -> `spec-dock: ok (validate) nodes=42` | pass | fresh spec-reviewer review is next |
+
+#### Closure Delta
+| change | closure id | test id alias | resolves to closure id | reason | re-review required |
+|---|---|---|---|---|---|
+| none | AC-001..AC-006 | N/A | AC-001..AC-006 | Initial requirement authoring from user-approved plan | yes |
+
+#### Implementation Delegation Gate
+| step | decision | required reason | agent role | delegated scope | result | local-execution rationale |
+|---|---|---|---|---|---|---|
+| requirement authoring setup | approved-local-execution | orchestration metadata / initial requirement draft from user-provided approved plan | N/A | requirement/report authoring only; no product implementation | pass | User requested immediate Issue creation and requirement authoring; implementation work remains subject to delegated workflow and reviewer gates |
+
+#### Code Review Gate
+| step | reviewer | review scope | review_status | findings / fixes | re-review count | result |
+|---|---|---|---|---|---|---|
+| requirement authoring setup | spec-reviewer | requirement.md vs user-approved plan / workflow alignment | pending | Fresh spec-reviewer review will run next | 0 | pending |
+
+#### Step Commit Gate
+| step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
+|---|---|---|---|---|---|---|---|---|
+| requirement authoring setup | pending | Issue node + requirement/report initial evidence | pending | pending | N/A | N/A | N/A | N/A |
+
+#### 変更したファイル
+- `spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/requirement.md` - 初期要件定義を作成
+- `spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/report.md` - 初期セットアップ、委任同意、validate 証跡を記録
+
+#### コミット
+- 未実施
+
+#### メモ
+- `issue start` の primary path は clean-worktree guard により未完了。manual branch checkout + `active set --id` の recovery path を使用した。
+- Requirement phase promotion は fresh `spec-reviewer` の `review_status: pass` が必要。
+
+---
+
+### 2026-05-15 HH:MM - HH:MM
+
+#### 対象
+- Step: ...
+- AC/EC: ...
+
+#### 実施内容
+- Fresh `spec-reviewer` に requirement phase review を依頼した。
+- 初回 reviewer はローカル artifact を読めず `review_status: fail` としたため、要件本文と review 基準を明示的に渡して fresh review を再実行した。
+- 2 回目の `spec-reviewer` は、role boundary、waiver semantics、acceptance criteria の観測可能性を blocking finding として `review_status: fail` を返した。
+- 指摘に対応し、`requirement.md` の `境界`、`受け入れ条件`、`例外・エッジケース`、`決定済み方針` を更新した。
+
+---
+
+## Spec Authoring Gate
+
+| phase | reviewer | review_status | findings / fixes | re-review count | promotion |
+|---|---|---|---|---|---|
+| requirement | spec-reviewer | fail | Initial reviewer could not inspect artifacts; no substantive findings. | 0 | blocked pending fresh review |
+| requirement | spec-reviewer | fail | P1 role boundary unresolved; P1 unavailable delegation waiver semantics undefined; P2 ACs not externally verifiable. Fixed by defining direct parent metadata boundary, `doc-writer` vs `dev-coder` ownership, waiver semantics, `Parent Implementation Exception`, and concrete AC evidence fields. | 1 | blocked pending fresh re-review |
+| requirement | spec-reviewer | fail | P1 evidence fields still assumed `dev-coder` even for `doc-writer` owned steps. Fixed by changing AC-004 / AC-006 to role-neutral delegated worker evidence and adding `delegated worker` terminology. | 2 | blocked pending fresh re-review |
+| requirement | spec-reviewer | fail | P1 boundary section still required `dev-coder` report for every implementation step. Fixed by requiring delegated worker report plus step-appropriate reviewer gate: `code-reviewer` for code/runtime/tests/scaffold behavior and `spec-reviewer` docs/spec alignment for docs-only/template-only/skill-text-only steps. | 3 | blocked pending fresh re-review |
+| requirement | spec-reviewer | fail | P1 AC language still preserved dev-coder/code-reviewer-only assumptions. Fixed by changing purpose/scope/AC-001 to delegated worker language and AC-004 to step-appropriate reviewer gates. | 4 | blocked pending fresh re-review |
+| requirement | spec-reviewer | fail | P1 AC-003 still encoded a dev-coder-only handoff gate. Fixed by generalizing AC-003 to step-appropriate delegated worker handoff with delegated role, scope, source of truth, allowed/forbidden changes, verification, stop conditions, and output requirements. | 5 | blocked pending fresh re-review |
+| requirement | spec-reviewer | pass | No findings. Requirement consistently frames implementation as delegated to step-appropriate delegated workers and AC-003 lists the necessary handoff contract fields. | 6 | promoted to design |
+| design | spec-reviewer | pass | No findings. Design traces approved AC/EC to explicit design surfaces and verification points, preserves source-of-truth boundaries, and defines delegated worker / reviewer gate mapping for plan authoring. | 0 | promoted to plan |
+| plan | spec-reviewer | pass | P2 C15 evidence-level ambiguity was reported. Fixed by changing C15 to covered-existing with characterization pre-evidence and targeted pytest closure. Added missing plan frontmatter with approved status. | 0 | promoted to implementation |
+
+## Step Execution Ledger
+
+| step | delegated role | scope | reviewer gate | result | notes |
+|---|---|---|---|---|---|
+| S10 | doc-writer | `src/spec_dock/assets/spec_dock/docs/workflow_issue.md` | spec-reviewer | pass | Added Parent Agent Invariant, delegated worker handoff fields, Parent Implementation Exception, waiver/unavailable semantics, reviewer gate mapping, metadata boundary, and reviewer-fail bounded follow-up. |
+| S20 | doc-writer | provider plan authoring docs and plan template | spec-reviewer | pass | Initial fail found generic code-reviewer-only wording in plan surfaces and upstream workflow. Fixed to generic step reviewer gate wording; combined S10/S20 re-review passed. |
+| S30 | doc-writer | provider report template | spec-reviewer | pass | Initial fail found Workflow Delegation Consent mixed write-capable roles into reviewer/read-only consent. Fixed by limiting consent example to reviewer/read-only roles and recording write-capable work in Implementation Delegation Gate / Delegated Worker Evidence. Re-review passed. |
+| S40 | doc-writer | provider issue-execution skill | spec-reviewer | pass | Replaced long policy duplication with a concise reminder that points to `workflow_issue.md`, preserves parent orchestration responsibility, routes runtime/tests/scaffold behavior to `dev-coder`, routes shipped docs/templates/skills/workflow text to `doc-writer`, and treats unavailable tooling / failed review as stop or re-delegation conditions. |
+| S50 | doc-writer | dogfooding mirror synchronization for docs/templates/skill | spec-reviewer | pass | Copied all six provider/mirror pairs byte-for-byte. Parent reran `cmp -s` for all pairs; all exit 0. `spec-reviewer` found no issues and confirmed C14 can close. |
+| S60 | dev-coder | `tests/test_init_update.py` structural assertions | code-reviewer | pass | Added regression assertions for workflow policy markers, plan delegation contract fields, report evidence/exception fields, concise skill routing, and generated scaffold content. Targeted unittest passed; `uv run pytest` was unavailable because `pytest` is not installed. |
+
+## Step Contract Closure
+
+| step | closure ids | close condition | evidence | result | notes |
+|---|---|---|---|---|---|
+| S10 | C01, C02, C03, C07, C08 | Provider `workflow_issue.md` contains required upstream execution policy sections and S10 spec-reviewer passes | `doc-writer` summary; `spec-reviewer` S10 review_status `pass` | pass | First reviewer attempt failed due artifact-read unavailability; fresh embedded-diff review passed |
+| S40 | C12, C13 | Provider issue-execution skill contains concise source-of-truth reminder and stop-condition reminders, and S40 spec-reviewer passes | `doc-writer` summary; `spec-reviewer` S40 review_status `pass`; `git diff -- src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md` | pass | Skill now avoids full workflow duplication and defers execution policy to `workflow_issue.md` |
+| S50 | C14 | Six dogfooding mirror files are synchronized structurally with provider sources and S50 spec-reviewer passes | `doc-writer` S50 report; six `cmp -s` checks; `spec-reviewer` S50 review_status `pass` | pass | All provider/mirror pairs are exact parity; no intentional differences |
+| S60 | C15 | Structural assertions exist and targeted verification passes | `dev-coder` summary; `.venv/bin/python3 -m unittest ...` ran 3 tests OK; `git diff --check -- tests/test_init_update.py` OK; `code-reviewer` S60 review_status `pass` | pass | `uv run pytest tests/test_init_update.py` failed to spawn `pytest` because it is not installed in the current environment |
+
+## Test Contract Closure
+
+| closure id / test id | step | required | evidence level | pre-implementation evidence | verification command | result | notes |
+|---|---|---|---|---|---|---|---|
+| C01 | S10 | yes | inspect-only | Current workflow had delegation gate but no Parent Agent Invariant | docs-only inspection + S10 spec-reviewer | pass | Parent orchestration ownership and non-implementation explicit |
+| C02 | S10 | yes | inspect-only | Current workflow did not list all delegated worker handoff fields | docs-only inspection + S10 spec-reviewer | pass | Handoff fields defined |
+| C03 | S10 | yes | inspect-only | Current workflow had waiver/degraded states but not parent exception semantics | docs-only inspection + S10 spec-reviewer | pass | Exception and unavailable/denied semantics bounded |
+| C07 | S10 | yes | inspect-only | Current workflow used per-step code-reviewer broadly | docs-only inspection + S10 spec-reviewer | pass | Step-type reviewer mapping defined |
+| C08 | S10 | yes | inspect-only | Metadata vs shipped asset direct-edit boundary was not explicit | docs-only inspection + S10 spec-reviewer | pass | Metadata boundary defined |
+| C12 | S40 | yes | covered-existing | Previous skill duplicated the full workflow and risked becoming a stale policy fork | docs-only inspection + S40 spec-reviewer | pass | Skill is concise and canonical-doc driven |
+| C13 | S40 | yes | inspect-only | Previous skill had workflow stop conditions embedded in long policy text rather than concise execution reminders | docs-only inspection + S40 spec-reviewer | pass | Unavailable/denied tooling and review failure are stop/re-delegation conditions |
+| C14 / tc-s50-001 | S50 | yes | inspect-only | Provider/mirror target pairs listed from plan | `cmp -s` for workflow/plan docs pairs + S50 spec-reviewer | pass | Workflow and plan docs mirrors are byte-identical to provider sources |
+| C14 / tc-s50-002 | S50 | yes | inspect-only | Provider/mirror target pairs listed from plan | `cmp -s` for plan/report template and skill pairs + S50 spec-reviewer | pass | Templates and skill mirrors are byte-identical to provider sources |
+| C15 / tc-s60-001 | S60 | yes | covered-existing | Existing tests covered scaffold/template structure but not iss-00098 delegation contract markers | `.venv/bin/python3 -m unittest tests.test_init_update.TestInitUpdate.test_bundled_skill_routing_contract tests.test_init_update.TestInitUpdate.test_spec_document_templates_keep_policy_out_of_scaffold tests.test_init_update.TestInitUpdate.test_init_creates_expected_structure` | pass | Plan template structural contract assertions added |
+| C15 / tc-s60-002 | S60 | yes | covered-existing | Existing tests did not assert new report delegation/exception evidence tables | targeted unittest above | pass | Report evidence and exception contract assertions added |
+| C15 / tc-s60-003 | S60 | yes | covered-existing | Existing tests expected long issue-execution skill policy text | targeted unittest above + `git diff --check -- tests/test_init_update.py` | pass | Assertions now lock concise skill reminder and workflow source-of-truth markers |
+
+## Closure Coverage
+
+| closure id | step | verification evidence | result | notes |
+|---|---|---|---|---|
+| C01 | S10 | S10 spec-reviewer pass | pass |  |
+| C02 | S10 | S10 spec-reviewer pass | pass |  |
+| C03 | S10 | S10 spec-reviewer pass | pass |  |
+| C07 | S10 | S10 spec-reviewer pass | pass |  |
+| C08 | S10 | S10 spec-reviewer pass | pass |  |
+| C04 | S20 | Combined S10/S20 spec-reviewer pass | pass | Plan authoring docs consume workflow policy without redefining it |
+| C05 | S20 | Combined S10/S20 spec-reviewer pass | pass | Authoring entrypoint includes delegation contract field list |
+| C06 | S20 | Combined S10/S20 spec-reviewer pass | pass | Plan template contains required scaffold sections and delegation contract |
+| C09 | S30 | S30 spec-reviewer pass | pass | Delegated Worker Evidence fields are recordable |
+| C10 | S30 | S30 spec-reviewer pass | pass | Parent Implementation Exception fields are recordable |
+| C11 | S30 | S30 spec-reviewer pass | pass | Report remains evidence surface and preserves workflow consent boundary |
+| C12 | S40 | S40 spec-reviewer pass | pass | Skill remains concise and points to canonical workflow docs |
+| C13 | S40 | S40 spec-reviewer pass | pass | Skill records stop/re-delegation reminders for unavailable tooling and failed review |
+| C14 | S50 | S50 `doc-writer` report, six successful `cmp -s` checks, S50 `spec-reviewer` pass | pass | Dogfooding mirrors are exact provider parity |
+| C15 | S60 | Targeted unittest pass, `git diff --check -- tests/test_init_update.py` pass, S60 `code-reviewer` pass | pass | `uv run pytest tests/test_init_update.py` is blocked by missing `pytest`; equivalent targeted unittest command passed |
+| C16 | S90 | S90 `doc-writer` no-op inspection and S90 `spec-reviewer` re-review pass | pass | No current-change docs impact remains; pre-existing README legacy migration note is scope-out |
+| C17 | S99 | `git diff --check`, `./spec-dock/scripts/spec-dock validate`, targeted unittest, final QA pass, final issue-wide code-reviewer re-review pass, final spec-reviewer re-review pass | pass | Final spec-reviewer initial review failed on missing report evidence and consent-boundary cleanup; both were fixed and re-review passed |
+
+## Final Quality Gate (必須)
+
+### S90 Docs Impact Resolution
+| target | update required | owner | evidence | spec-reviewer result |
+|---|---|---|---|---|
+| provider docs/templates/skill, dogfooding mirrors, `tests/test_init_update.py`, `README.md`, `src/spec_dock/assets/spec_dock/docs/README.md`, `src/spec_dock/assets/spec_dock/docs/guide.md` | no | doc-writer inspection; no edit | S90 doc-writer inspected active docs, changed provider/mirror surfaces, README/docs index surfaces, provider/mirror parity, role split, source-of-truth ownership, and report/template evidence. No changed-surface docs impact remains. Pre-existing root `README.md` legacy migration note is scope-out because it was not introduced by this issue and is not directly impacted by delegated-orchestration changes. | pass after re-review; prior fail resolved by recording this evidence |
+
+### Final QA Gate
+| reviewer | scope | integration test decision | evidence | result |
+|---|---|---|---|---|
+| qa-reviewer | whole issue test adequacy | already sufficient; no additional integration test required | `git diff --check` OK; `./spec-dock/scripts/spec-dock validate` OK `nodes=42`; targeted unittest commands OK; `uv run pytest tests/test_init_update.py` unavailable because `pytest` is not installed; QA accepted unittest because this repo uses `unittest` and the change is docs/template/skill structural contract | pass |
+
+### Final Code Review Gate
+| reviewer | scope | findings / fixes | re-review count | result |
+|---|---|---|---|---|
+| code-reviewer | issue-wide integrated diff | Initial issue-wide review passed with P2 lifecycle reminder finding. Follow-up restored concise `Runtime Command Reminders` to provider and mirror skill, then `dev-coder` updated tests to assert the concise reminders. Re-review found no remaining findings. | 1 | pass |
+
+### Final Spec Review Gate
+| reviewer | scope | findings / fixes | re-review count | result |
+|---|---|---|---|---|
+| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | Initial final review failed: P1 missing S99/C17 final gate evidence; P2 Workflow Delegation Consent mixed write-capable roles into generic consent. Fixed by recording final QA/code/spec/command evidence, adding C17 closure evidence, and limiting Workflow Delegation Consent to reviewer/read-only specialist consent while keeping write-capable work in step evidence. Fresh re-review found no findings and confirmed C17 can close. | 1 | pass |
+
+### Final Commit
+| final report ledger | final commit scope | post-commit external evidence destination | result |
+|---|---|---|---|
+| C01-C17 closed | provider docs/templates/skill, dogfooding mirrors, `tests/test_init_update.py`, active issue docs/report | final response before commit; commit hash after commit | ready |
+
+## 遭遇した問題と解決 (任意)
+- 問題: ...
+  - 解決: ...
+
+## 学んだこと (任意)
+- ...
+- ...
+
+## 今後の推奨事項 (任意)
+- ...
+- ...
+
+## 省略/例外メモ (必須)
+- 該当なし

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/requirement.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/requirement.md
@@ -1,0 +1,179 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00098"
+タイトル: "Delegated Implementation Orchestration Contract"
+関連GitHub: ["#98"]
+状態: "approved"
+作成者: "Codex CLI"
+最終更新: "2026-05-15"
+親: ["epic-00067", "init-local-00003"]
+---
+
+# iss-00098 Delegated Implementation Orchestration Contract — 要件定義（WHAT / WHY）
+
+## 目的
+- spec-dock の Issue 実行 workflow に、親 Codex を実装者ではなく orchestration owner として扱う delegated-by-default 原則を組み込む。
+- 実作業は plan step 単位で適切な delegated worker に委任し、runtime / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を主担当にして、`code-reviewer` / `qa-reviewer` / `spec-reviewer` の gate で検証する運用契約を明文化する。
+- 親 Codex の context 汚染と過剰な低レベル実装推論を抑えつつ、delivery の最終責任と統合判断は親 Codex に残す。
+
+## 背景・現状
+- 現状の workflow には `Implementation Delegation Gate` と `dev-coder` の role selection があるが、親 Codex が直接実装する `approved-local-execution` も広く許容されている。
+- その結果、親 Codex が実装詳細、探索ログ、テスト失敗、修正試行を抱え込み、要件・設計・計画・統合判断の文脈を圧迫しやすい。
+- reviewer 系 sub-agent は gate として使われやすい一方、`dev-coder` は任意の実装手段に見えやすく、親 Codex が直接実装する傾向が残る。
+- spec-dock の dogfooding workflow では、親 Codex が workflow 全体を統合し、実装推論とファイル変更は bounded worker に委任する形を標準にしたい。
+
+## 対象ユーザー / 利用シナリオ
+- 主な利用者:
+  - spec-dock を dogfooding する Codex CLI / コーディングエージェント
+  - spec-dock の workflow / skill / shipped agent assets を保守する開発者
+- 代表シナリオ:
+  - ユーザーが active Issue の要件定義から実装完了までを Codex に依頼する。
+  - 親 Codex は active docs を読み、step contract を整え、`dev-coder` に実装を委任する。
+  - `dev-coder` は指定 step のファイル変更と検証を行い、implementation report を返す。
+  - 親 Codex は結果を統合判断し、reviewer gate を通してから step を完了扱いする。
+
+## スコープ
+- 必須:
+  - 親 Codex の delegated-by-default 原則を workflow / skill / template に明文化する。
+  - delegated worker 委任時の必須入力、許可範囲、禁止範囲、停止条件、戻り値を定義する。
+  - plan step に delegation contract を持たせる。
+  - report に delegation evidence / reviewer verdict / parent integration decision を残せるようにする。
+  - 親 Codex が直接実装できる例外条件と exception record を定義する。
+- 禁止:
+  - 「小さい変更」「機械的変更」「親が知っている修正」を理由に、実装ファイル変更を無記録で親 Codex が行える扱いにすること。
+  - `dev-coder` 委任を reviewer gate の代替にすること。
+  - 親 Codex の delivery 責任を `dev-coder` や reviewer に移すこと。
+- 対象外:
+  - sub-agent runtime 自体の新規実装。
+  - transcript/tool-call 監査の完全自動 enforcement。
+  - `spec-dock issue delegate` などの新 CLI command 追加。
+  - Codex 以外の host 向け専用 workflow 実装。
+
+## 境界
+- 常に行う:
+  - 親 Codex は調査、計画、委任、検証、統合判断、報告を担当する。
+  - 実装ファイル、テスト、scaffold、template、runtime、shipped asset の変更は原則 `dev-coder` または適切な write-capable role に委任する。
+  - 各 implementation step は delegated worker report と、step の性質に対応する reviewer gate を経てから完了扱いする。code / runtime / tests / scaffold behavior を含む step は `code-reviewer` pass、docs-only / template-only / skill-text-only step は `spec-reviewer` による docs/spec alignment pass を必須にする。
+- 判断が必要:
+  - 実装前の design / plan で、各 step の allowed paths、forbidden changes、reviewer focus、required tests を具体化する。
+  - docs / templates / skill / workflow 文書の更新をどの implementation step に分けるかを、変更対象の source-of-truth と review scope に合わせて設計する。
+- 行わない:
+  - 親 Codex の direct write を技術的に完全禁止する runtime gate はこの Issue では実装しない。
+  - すべての軽微な文書更新まで必ず `dev-coder` に委任する hard rule にはしない。
+
+## 非交渉制約
+- `src/spec_dock/assets/install_root/` は installed agent-tooling assets の provider-side source of truth として扱う。
+- `src/spec_dock/assets/spec_dock/` は consumer workspace に生成される `spec-dock/` scaffold の provider-side source of truth として扱う。
+- dogfooding 側 `spec-dock/` だけを正本として編集してはならない。
+- workflow 説明は docs を正本とし、skills は concise routing / execution reminders に留める。
+- Issue execution は `workflow_issue.md` と `.agents/skills/spec-dock-issue-execution/SKILL.md` の整合を保つ。
+- requirement / design / plan の phase promotion は fresh `spec-reviewer` の `review_status: pass` を必要とする。
+
+## 前提
+- `dev-coder` は bounded implementation step を直接編集できる write-capable sub-agent として利用可能である。
+- `code-reviewer`、`qa-reviewer`、`spec-reviewer` は reviewer gate として利用可能である。
+- 現行 workflow にはすでに `Implementation Delegation Gate`、`Role selection matrix`、`delegated / approved-local-execution` の記録欄がある。
+- 本 Issue はその既存 contract を、親 Codex orchestration model に合わせて強化する。
+
+## 受け入れ条件
+- AC-001:
+  - アクター: 親 Codex
+  - 前提: active Issue の implementation step を開始する
+  - 操作: issue execution workflow / skill を読む
+  - 期待結果: `Parent Agent Invariant` または同等の節が存在し、親 Codex の許可行為が inspect / plan / delegate / verify / integrate / report に限定され、code / test / scaffold / template / runtime / shipped asset の直接変更禁止と delegated worker 委任原則が明記されている
+  - 観測点: `workflow_issue.md`、`spec-dock-issue-execution/SKILL.md` の該当節
+- AC-002:
+  - アクター: plan author
+  - 前提: Issue plan の implementation step を作成する
+  - 操作: plan template / authoring docs に従って step を記述する
+  - 期待結果: 各 step に `delegation contract` 欄があり、`delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests`、`reviewer focus`、`stop conditions`、`output required` を記録できる
+  - 観測点: issue plan template、issue plan authoring docs の step contract
+- AC-003:
+  - アクター: 親 Codex
+  - 前提: `dev-coder`、`doc-writer`、またはその他の step-appropriate delegated worker に実作業を委任する
+  - 操作: handoff contract に従って依頼する
+  - 期待結果: delegated worker handoff に `delegated role`、`scope`、`source of truth`、`allowed changes`、`forbidden changes`、`required verification`、`stop conditions`、`output required` が必須項目として存在する
+  - 観測点: workflow docs、skill guidance、template text の handoff contract
+- AC-004:
+  - アクター: reviewer
+  - 前提: `dev-coder` または `doc-writer` などの delegated worker による step diff がある
+  - 操作: step の性質に対応する reviewer gate を実行する
+  - 期待結果: reviewer fail 条件として、step contract 外変更、provider/dogfooding source-of-truth 逸脱、required tests または docs-only verification の未実行・未記録、delegated worker report 不足、親 Codex の無記録 direct implementation が列挙されている。code / runtime / tests / scaffold behavior を含む step は `code-reviewer`、docs-only / template-only / skill-text-only step は `spec-reviewer` docs/spec alignment が対応 gate として明記されている
+  - 観測点: workflow docs、report template、review gate guidance の fail condition
+- AC-005:
+  - アクター: 親 Codex
+  - 前提: 親 Codex が例外的に直接実装する必要がある
+  - 操作: exception gate を記録する
+  - 期待結果: `Parent Implementation Exception` 欄に delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate が必須項目として存在する
+  - 観測点: report template、workflow docs の exception record
+- AC-006:
+  - アクター: future agent / maintainer
+  - 前提: 完了済み Issue の report を読む
+  - 操作: delegation evidence を確認する
+  - 期待結果: report の delegation evidence に step id、delegated role、delegated worker summary、changed files、tests run または docs-only verification、reviewer verdict、unresolved risks、parent integration decision が必須列または必須項目として存在する
+  - 観測点: issue report template、completed report example or template rows
+
+## 例外・エッジケース
+- EC-001:
+  - 条件: `dev-coder` が host policy、環境、権限、またはツール制約で利用できない
+  - 期待: required implementation delegation は degraded success ではなく `blocked` または `incomplete` として扱う。ユーザーが明示的に risk acceptance を与えた場合のみ `waived` を記録できるが、`waived` は reviewer pass ではなく、親 Codex の直接実装を自動許可しない。親 Codex が直接実装するには、別途 `Parent Implementation Exception` の user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate を記録する
+  - 観測点: workflow docs、report evidence
+- EC-002:
+  - 条件: 変更が docs / report / handoff note など orchestration metadata のみである
+  - 期待: `report.md`、handoff note、phase evidence のような run-local orchestration metadata は親 Codex が直接更新できる。shipped docs、templates、skills、workflow text、runtime-facing scaffold は `doc-writer` または `dev-coder` に委任し、reviewer gate を通す
+  - 観測点: exception policy
+- EC-003:
+  - 条件: step が複数 layer / package / shipped asset にまたがる
+  - 期待: 親 Codex は direct implementation せず、allowed paths と dependencies を明記して `dev-coder` に委任する
+  - 観測点: plan step delegation contract
+- EC-004:
+  - 条件: reviewer が `dev-coder` 実装に fail を返す
+  - 期待: 親 Codex は原則として自分で修正せず、指摘を bounded follow-up として `dev-coder` に再委任する
+  - 観測点: workflow docs、report evidence
+
+## 入力→出力例
+- EX-001:
+  - 入力: 「active Issue の S01 を実装して」
+  - 出力: 親 Codex が S01 の source docs、allowed paths、forbidden changes、acceptance criteria、required tests、stop conditions をまとめた `dev-coder` handoff を作成する
+- EX-002:
+  - 入力: `dev-coder` implementation report
+  - 出力: 親 Codex が changed files / tests / risks を確認し、`code-reviewer` に step diff review を委任する
+
+## 用語
+- TERM-001:
+  - `parent Codex`: ユーザーと対話し、workflow 全体、委任、統合判断、最終報告を担当する orchestration owner。
+- TERM-002:
+  - `dev-coder`: bounded implementation step のファイル変更、テスト追加、検証実行を担当する write-capable sub-agent。
+- TERM-003:
+  - `delegated worker`: plan step の実作業を担当する sub-agent。runtime / tests / scaffold behavior は主に `dev-coder`、shipped docs / templates / skills / workflow text は主に `doc-writer` が担当する。
+- TERM-004:
+  - `delegation contract`: plan step ごとに、委任先、入力、許可範囲、禁止範囲、完了条件、検証、停止条件を固定する契約。
+- TERM-005:
+  - `parent implementation exception`: 親 Codex が例外的に直接ファイル変更する場合に必要な理由・範囲・承認・検証の記録。
+- TERM-006:
+  - `reviewer gate`: `code-reviewer`、`qa-reviewer`、`spec-reviewer` が fresh `review_status: pass` を返すまで完了扱いしない品質ゲート。
+
+## 決定済み方針
+- DEC-001:
+  - 論点: 親 Codex が直接更新してよい orchestration metadata の範囲
+  - 採用: `report.md` / handoff note / phase evidence のような orchestration metadata に限定する。
+  - 理由: docs / templates は shipped behavior に影響するため、`doc-writer` または `dev-coder` 委任を原則にする。
+  - 影響範囲: workflow docs、report template、exception policy
+- DEC-002:
+  - 論点: 親 Codex の direct write を runtime validator で検出するか
+  - 採用: 今回は docs / skill / template contract までを対象にし、runtime validator は追加しない。
+  - 理由: 運用 contract を先に dogfood し、audit automation は後続 Issue に分離する。
+  - 影響範囲: runtime command、tests、agent logs
+- DEC-003:
+  - 論点: `doc-writer` と `dev-coder` の使い分け
+  - 採用: shipped docs / templates / skills / workflow text の文言・構造更新は `doc-writer`、runtime / tests / scaffold behavior を伴う変更は `dev-coder` が担当する。両方をまたぐ step は plan で分割するか、親 Codex が allowed paths と reviewer focus を分けて委任する。
+  - 理由: 文書整合と実装変更の責務を混ぜると review scope と commit scope が曖昧になるため。
+  - 影響範囲: workflow docs、issue plan template、report template、review gate guidance
+- DEC-004:
+  - 論点: sub-agent unavailable 時の waiver semantics
+  - 採用: `waived` はユーザーの明示的 risk acceptance を記録する状態であり、required reviewer / delegation gate の pass ではない。waiver 後も completion には代替検証と該当 reviewer gate の扱いを report に残し、親 Codex の直接実装は `Parent Implementation Exception` を別途必要とする。
+  - 理由: unavailable / denied を degraded success と扱うと、workflow の品質ゲートが空洞化するため。
+  - 影響範囲: workflow docs、report template、exception policy、final completion judgment
+
+## 未確定事項
+- 現時点で design promotion を妨げる未確定事項はない。

--- a/spec-dock/templates/issue/plan.md
+++ b/spec-dock/templates/issue/plan.md
@@ -89,7 +89,7 @@ ID: "<ISS_ID>"
 ## レビュー / QA ゲート方針
 - RG1 implementation review:
   - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer
+  - reviewer: code-reviewer for code / runtime / tests / scaffold behavior; spec-reviewer docs/spec alignment for docs-only / template-only / skill-text-only
   - pass 条件: review_status: pass
   - 範囲: 現在 step の diff、tests、docs/report 更新、spec 影響
 - QG1 QA review:
@@ -105,9 +105,10 @@ ID: "<ISS_ID>"
 - 実行 policy、approval cadence、completion contract は `workflow_issue.md` を正本にする。
 - step / block / behavior slice の書き方は `phase_plan_issue.md` を正本にする。
 - plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
-- 各 implementation step は commit 単位として設計し、`code-reviewer gate` を pass してから `commit gate` で閉じる。
+- 各 implementation step は `workflow_issue.md` の policy を再定義せず、step-local な `delegation contract` に worker handoff の入力、許可範囲、禁止範囲、検証、reviewer focus、停止条件、出力を書く。
+- 各 implementation step は commit 単位として設計し、`workflow_issue.md` の reviewer gate mapping に従う `step reviewer gate` を pass してから `commit gate` で閉じる。
 - `approved-no-op` は差分なしの場合だけ許可し、理由、確認対象、差分なし確認コマンドを report に残す。
-- implementation step を追加する場合は S01 の subsections を複製し、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
+- implementation step を追加する場合は S01 の subsections を複製し、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
 
 ## 実装ステップ
 
@@ -136,6 +137,34 @@ ID: "<ISS_ID>"
   - negative:
 - pre-implementation evidence:
   - expected red / characterization pass / test sensitivity evidence:
+
+#### delegation contract
+- delegated role:
+  - dev-coder / doc-writer / other named worker:
+- input docs:
+  - `requirement.md`:
+  - `design.md`:
+  - `plan.md`:
+  - workflow / authoring docs:
+  - current target files:
+- allowed paths:
+  - ...
+- forbidden changes:
+  - ...
+- acceptance criteria:
+  - ...
+- required tests or docs-only verification:
+  - targeted command / manual evidence / inspection / docs diff:
+- reviewer focus:
+  - code-reviewer for code / runtime / tests / scaffold behavior, or spec-reviewer docs/spec alignment for docs-only / template-only / skill-text-only:
+- stop conditions:
+  - input docs conflict / path outside allowed scope / verification cannot run / delegated role mismatch / host policy conflict / acceptance cannot be met:
+- output required:
+  - changed files:
+  - worker summary:
+  - verification result:
+  - unresolved risks:
+  - report evidence to update:
 
 #### 具体テストケース一覧
 
@@ -192,10 +221,17 @@ ID: "<ISS_ID>"
 - delegation 判断:
   - delegated / approved-local-execution / degraded mode:
   - 必須理由 / no delegation rationale:
+- delegation contract evidence:
+  - delegated role:
+  - allowed paths:
+  - forbidden changes:
+  - required tests or docs-only verification:
+  - stop conditions:
+  - output required:
 - report draft update:
-  - update before code-reviewer so the evidence is reviewed and committed with the step:
-- code-reviewer gate:
-  - reviewer: code-reviewer
+  - update before the step reviewer gate so the evidence is reviewed and committed with the step:
+- step reviewer gate:
+  - reviewer: code-reviewer / spec-reviewer docs/spec alignment, according to `workflow_issue.md` reviewer gate mapping
   - review 範囲:
   - pass 条件: review_status: pass
   - re-review rule: 指摘を修正し pass まで再実行
@@ -218,7 +254,7 @@ ID: "<ISS_ID>"
 
 ### Sxx — <next observable behavior>
 - S01 の subsections を複製して記入する。
-- `具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
+- `delegation contract`、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
 
 ### S90 — docs impact resolution / docs refresh
 - 対象:

--- a/spec-dock/templates/issue/report.md
+++ b/spec-dock/templates/issue/report.md
@@ -56,9 +56,33 @@ ID: "<ISS_ID>"
 | none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no |
 
 #### Implementation Delegation Gate
-| step | decision | required reason | agent role | delegated scope | result | local-execution rationale |
-|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | pass / fail / blocked | no delegation rationale / degraded reason |
+`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records evidence only.
+
+| step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | result |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
+
+#### Delegated Worker Evidence
+| step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
+|---|---|---|---|---|---|---|---|
+| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
+
+#### Parent Implementation Exception
+| step | delegation unavailable/impossible reason | user approval / risk acceptance | allowed files | allowed operation | rollback plan | post-change verification | reviewer gate | unavailable / denied / host conflict / waiver handling |
+|---|---|---|---|---|---|---|---|---|
+| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
+
+#### Workflow Delegation Consent
+This table is for reviewer / read-only specialist workflow-scoped consent. Write-capable delegation such as `dev-coder` or `doc-writer` is recorded in `Implementation Delegation Gate` and `Delegated Worker Evidence`, not as generic workflow-scoped consent.
+
+| consent source | repo / worktree | active issue | session | named roles | boundary | expires / invalidation condition | denied / unavailable reason | next action |
+|---|---|---|---|---|---|---|---|---|
+| user message / policy / N/A | ... | iss-_____ | ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | reviewer / read-only specialist scope only | ... | none / ... | ... |
+
+#### Reviewer Gate Status
+| step | gate name | reviewer role | freshness | state | risk acceptance | promotion / completion decision | notes |
+|---|---|---|---|---|---|---|---|
+| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
 
 #### Code Review Gate
 | step | reviewer | review scope | review_status | findings / fixes | re-review count | result |

--- a/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
+++ b/src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md
@@ -1,93 +1,27 @@
 ---
 name: spec-dock-issue-execution
-description: Leaf skill for issue execution tasks in spec-dock.
+description: Execute an active spec-dock issue while keeping spec-dock/docs/workflow_issue.md as the source of truth.
 ---
 
-# Spec-dock Issue Execution
+# Spec-Dock Issue Execution
 
-- Use this skill for issue execution work.
-- Typical fit: implement the active issue through approved behavior-slice execution and update `report.md`.
-- Start from `spec-dock/active/context-pack.md`, then follow the issue workflow.
-- `spec-dock/docs/workflow_issue.md` is the source of truth for issue execution and completion.
-- `spec-dock/docs/workflow_spec_authoring.md` is the source of truth for issue requirement / design / plan phase promotion before execution.
-- Normal lifecycle path: start with `./spec-dock/scripts/spec-dock issue start <target>` and finish with `./spec-dock/scripts/spec-dock issue finish`.
-`issue finish` is lifecycle closure only: it closes or confirms the linked GitHub issue and clears active state, but it does not guarantee commit, push, PR, merge, validate, test, or review completion; delivery completion still requires separate evidence in tests, reviews, reports, and PR/merge workflow.
-- Treat direct `./spec-dock/scripts/spec-dock active set ...` as a manual / recovery command, not the primary issue execution path.
-- For shared phase authoring method, use:
-  - `spec-dock/docs/workflow_spec_authoring.md`
-  - `spec-dock/docs/phase_requirement.md`
-  - `spec-dock/docs/phase_design.md`
-  - `spec-dock/docs/phase_plan.md`
-  - `spec-dock/docs/phase_plan_issue.md`
-  - `spec-dock/docs/authoring/issue-plan.md`
-- Keep templates as scaffolds. Use the docs above for authoring guidance, including Issue dependency analysis, `Module Dependency Diagram`, Linux `tree` style file-change planning, and step ordering.
-- Spec authoring mode: shape `requirement.md`, `design.md`, and `plan.md` for the project. Add, remove, merge, reorder, or rewrite template sections when it improves correctness, human understanding, or agent executability. Remove irrelevant placeholders.
-- In spec authoring mode, Issue `plan.md` must satisfy `spec-dock/docs/authoring/issue-plan.md`. Each implementation step needs a `具体テストケース一覧` that uses card-style nested list test cases, not a wide table, with each concrete test case id at the start of the top-level bullet.
-- In spec authoring mode, do not move from requirement to design, design to plan, or plan to implementation until a fresh `spec-reviewer` returns `review_status: pass`; fix findings and re-run a fresh reviewer until pass.
-- Record each `Spec Authoring Gate` in `spec-dock/active/issue/report.md`, including investigation, user questions/answers, reviewer verdict, fixes, and promotion decision.
-- Before invoking reviewer or specialist sub-agents for an active issue, confirm workflow-scoped delegation consent for the current repo/worktree, active issue, session, and named roles. A current user request may grant that scope; record the consent scope and boundary in `spec-dock/active/issue/report.md`.
-- With workflow-scoped delegation consent, invoke required named reviewer / read-only specialist roles autonomously within the active issue scope. Do not ask for per-phase confirmation; do re-confirm before scope expansion, non-named roles, write-capable delegation, destructive operations, external publishing, credentialed access, or browser/private external systems.
-- Reviewer gate states are `passed`, `failed`, `unavailable`, `denied`, `waived`, and `provisional`. Only a fresh `passed` result satisfies a required reviewer gate. `waived` requires explicit user risk acceptance in `report.md`. `provisional` is orchestrator self-check evidence, not a replacement for `spec-reviewer`, `code-reviewer`, or `qa-reviewer`.
-- Degraded mode may support status gathering, local self-check, or alternate verification evidence, but it never satisfies a required reviewer gate, implementation readiness gate, or final quality gate. Reviewer `unavailable`, `denied`, `failed`, stale, missing, waived, or provisional is blocked / incomplete unless an explicit user waiver is recorded where the workflow allows it.
-- In spec authoring mode, use the optional diagram catalog in `spec-dock/docs/phase_design.md` as the authoritative source for diagram choices. Add catalog-listed or project-specific sections only when they clarify the issue.
-- Execution mode: follow the approved issue docs. If the docs are missing required detail or contradict the implementation path, update/review the docs before implementation continues.
-- Record report-scoped delivery completion evidence in `spec-dock/active/issue/report.md` before running `./spec-dock/scripts/spec-dock issue finish`, because `issue finish` clears active state after lifecycle closure. Final commit hash and post-commit clean evidence are recorded after the final commit as external delivery evidence.
-- Treat `Spec-Locked Closure Index` as the issue-wide coverage ledger, not as a single test-case catalog. Execute and close work through each step's `step closure contract`.
-- Treat each implementation step as a commit unit: `1 implementation step = 1 code-reviewer scope = 1 commit`.
-- Before each implementation step starts, run an `Implementation Delegation Gate` decision and record it in `spec-dock/active/issue/report.md`.
-- Delegation is conditionally mandatory when a step crosses multiple layers, modules, or packages; affects runtime / CLI / infra / templates / shipped scaffold / shared docs; needs existing-pattern or impact analysis; touches integration tests, migration, backward compatibility, filesystem, GitHub, or active state; or is large enough to split into an independent worker scope.
-- Use `delegated` when a sub-agent is used, and record role, scope, request, returned result, and integration outcome. Use `approved-local-execution` only for small single-file changes, mechanical wording changes, clear localized changes, or immediate blocking / tightly coupled work that the main orchestrator should handle; record the no delegation rationale.
-- If sub-agents are unavailable, denied, or blocked by host policy for a required gate, do not continue as degraded success. Record the environment reason, gate state, alternate verification, and next action; classify the issue as blocked / incomplete unless an explicit user waiver is recorded where the workflow allows it.
-- Role selection matrix: `repo-analyst` maps code paths, impact, dependencies, and existing patterns before implementation; `dev-coder` handles bounded implementation steps with a clear write scope; `doc-writer` updates docs / templates / workflow / skill text; `qa-reviewer` owns final test adequacy and integration-test need; `code-reviewer` owns per-step diffs and the issue-wide integrated diff; `spec-reviewer` owns requirement / design / plan / report / implementation / docs alignment.
-- Before implementation starts, stop if any required closure id in `plan.md` is not referenced from a behavior slice `closure ids` / `test ids` list, or if a required closure row has no step-local close condition, verification command, or evidence path.
-- Before implementation starts, stop if any implementation step is missing `具体テストケース一覧`, if concrete test cases are only global / table-only / abstract, or if a test case lacks the standard `前提`, `操作`, `期待結果`, `失敗検出`, and `検証方法` fields. Docs-only or approved-no-op steps must state the test-not-needed reason and alternate verification.
-- Do not change a required closure row, `locked expectation`, `required`, or meaning-bearing `spec link` during implementation without first updating the plan/design and getting re-review.
-- Do not report complete unless every required closure id is closed in `spec-dock/active/issue/report.md` through `Step Contract Closure`, `Test Contract Closure`, and `Closure Coverage`.
-- Record additions, removals, changed rows, intentionally unimplemented rows, and re-review decisions in `Closure Delta`.
-- For every implementation step with changes, run the `code-reviewer` sub-agent on that step diff and iterate fixes / re-review until `review_status: pass`.
-- Implementation delegation does not replace review gates. Even if `dev-coder` or another worker implemented the step, the resulting step diff still requires per-step `code-reviewer` pass.
-- After the step `code-reviewer` pass, commit the step scope before moving to the next implementation step. Prefer `$git-commit-conventional-ja` or an equivalent Japanese multi-line Conventional Commit flow grounded in the staged diff.
-- Do not mix multiple implementation steps in one commit. If the step is too large for one reviewable commit, split the plan step before implementation continues.
-- Use `approved-no-op` only when the step has no diff. Record the no-op reason, checked contracts/files, diff-clean command, and review or read-only confirmation evidence in `spec-dock/active/issue/report.md`.
-- Do not skip the docs impact resolution step or the final quality gate.
-- In `S90 docs impact resolution`, inspect docs / templates / README / workflow / skill / migration notes impact. If docs updates are required, use `doc-writer` for the update and `spec-reviewer` for docs/spec alignment review.
-- In `S99 final quality gate`, run `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`. Iterate fixes and re-run the failing reviewer until all three pass.
-- `qa-reviewer` owns test adequacy and whether an issue-wide integration test must be added before pass.
-- The final `code-reviewer` owns the integrated issue diff, structure, responsibility boundaries, regression risk, and maintainability. It does not replace per-step code review.
-- `spec-reviewer` owns requirement fulfillment and consistency across requirement, design, plan, report, implementation, tests, and docs.
-- After all final reviewers pass, update the final report ledger with each step closure, final review results, final commit scope, and the post-commit external evidence destination. Then create the final commit and confirm no unintended staged or unstaged changes remain.
-- Delivery completion must be confirmed before `issue finish` while the active issue is still set and confirmable, and `spec-dock/active/issue/requirement.md`, `design.md`, `plan.md`, and `report.md` contain issue-specific content rather than template, placeholder, or effectively blank content.
-- `spec-dock/active/issue/report.md` must record command evidence for required `sync`, `validate`, implementation delegation decisions, per-step code review, step commit / approved-no-op, final QA review, final issue-wide code review, final spec review, and final report ledger / final commit scope before the final commit, including whether each required step succeeded, passed, reached approval, reached `delegated` / `approved-local-execution`, or reached `committed` / `approved-no-op`.
-- Do not run `issue finish` until every required step has been executed, every required `sync` / `validate` step has succeeded or passed, every required review step has reached approval or pass, every implementation step has delegation evidence as `delegated`, `approved-local-execution`, or degraded mode for delegation availability only, every implementation step is `committed` or valid `approved-no-op`, the final report ledger and final commit scope are recorded in `spec-dock/active/issue/report.md`, the final commit is complete, no unintended staged / unstaged changes remain, and the final commit hash plus post-commit clean evidence are recorded in external delivery evidence such as the final response, PR, or issue comment.
-- After `issue finish`, do not require the active issue to remain set. Treat `issue finish` as lifecycle closure / GitHub close / active clear only.
-- If any required step is skipped, or executed without a successful, pass, approved, `committed`, or valid `approved-no-op` outcome, classify the issue as `blocked` or `incomplete`, record the reason and next action in `spec-dock/active/issue/report.md`, and do not report the issue as complete.
-- Treat the issue as `blocked` only when an external dependency, missing permission, unavailable service, or other environment condition prevents the next required action.
-- When blocked, record the reason and next action in `spec-dock/active/issue/report.md`. Include blocker type and impact when applicable.
-- Keep environment blockers separate from product gaps; missing implementation, missing docs updates, or missing evidence are incomplete unless an environment blocker prevents progress.
-- When incomplete, record the reason and next action in `spec-dock/active/issue/report.md`.
-- Do not report the issue as complete while it is incomplete or blocked.
-- Primary workflow: `spec-dock/docs/workflow_issue.md`.
-- `spec-dock/docs/reference_deps.md`
-- `spec-dock/docs/reference_sync.md`
-- `spec-dock/docs/reference_github.md`
-- `spec-dock/docs/reference_naming.md`
-- `spec-dock/docs/workflow_spec_authoring.md`
+Use `spec-dock/docs/workflow_issue.md` as the source of truth. This skill is only a concise reminder for issue execution.
 
-## Runtime command reminders
+- Keep the parent agent responsible for orchestration, context, acceptance evidence, and final closure. Delegates may implement bounded tasks, but they do not own the issue.
+- Preserve parent invariants before, during, and after delegated work: active issue context, allowed paths, acceptance criteria, reviewer requirements, and stop conditions remain the parent agent's responsibility.
+- Route runtime, tests, and scaffold behavior to `dev-coder`.
+- Route shipped docs, templates, skills, and workflow text to `doc-writer`.
+- Treat unavailable tooling, denied access, host conflicts, waiver requests, and similar blockers as stop/incomplete unless explicit workflow policy evidence says they count as success.
+- When review fails, perform bounded delegated follow-up and rerun review. Parent direct fixes require a documented Parent Implementation Exception.
 
-- Use runtime command path only: `./spec-dock/scripts/spec-dock ...`
-- Normal issue execution lifecycle:
-  - `./spec-dock/scripts/spec-dock issue start <target>`
-  - `./spec-dock/scripts/spec-dock issue finish`
-- `issue start -f` / `--force` bypasses only the unfinished active issue guard for switching away from another unfinished issue branch. It does not bypass dependency readiness, target validation, or checkout safety.
-- `issue start` from `main` / `master` / `develop` / `staging` or another non-issue branch is allowed; the unfinished guard is for another unfinished active issue branch only.
-- Use direct `active set` only for manual / recovery work. It remains outside the unfinished issue guard.
-- After `issue finish`, avoid running `sync` on the just-finished issue branch when you need active clear to remain clear. `sync` can restore active from branch-derived issue context; move to `main` or another non-issue branch before final sync, or skip post-finish sync.
-- Dependency mutation is command-first:
-  - `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`
-  - `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`
-  - `./spec-dock/scripts/spec-dock deps check <target>`
-- Keep report evidence aligned with workflow checks:
-  - `./spec-dock/scripts/spec-dock validate`
-  - `./spec-dock/scripts/spec-dock sync`
-- Use `--no-github` only for explicit cache/local verification with no GitHub calls.
+## Runtime Command Reminders
+
+- Use the shipped runtime path: `./spec-dock/scripts/spec-dock ...`.
+- Normal lifecycle is `issue start <target>` before execution and `issue finish` only after the workflow completion gates pass.
+- `issue start -f` / `issue start --force` bypasses only the unfinished-active-issue guard; it does not bypass readiness, target validation, or checkout safety.
+- After `issue finish`, avoid `sync` on the just-finished issue branch when active clear must remain clear.
+- Mutate dependencies command-first with `deps add`, `deps remove`, and `deps check`: `./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>`, `./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>`, and `./spec-dock/scripts/spec-dock deps check <target>`.
+- Evidence commands include `validate` and `sync`: `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync`.
+- Use `--no-github` only for explicit cache/local verification without GitHub calls.
+
+Do not copy the full workflow here; update `workflow_issue.md` when execution policy changes.

--- a/src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md
+++ b/src/spec_dock/assets/spec_dock/docs/authoring/issue-plan.md
@@ -18,6 +18,7 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - reviewer-pass 済みの `requirement.md` と `design.md` を、実装可能な step、検証、review gate、commit gate、final quality gate へ変換する。
 - `Spec-Locked Closure Index` で仕様 coverage を固定し、各 implementation step の `具体テストケース一覧` で TDD 実行入力を固定する。
 - step 順、依存、対象ファイル、検証方法、report evidence を実装者が判断せずに実行できる粒度へ落とす。
+- `workflow_issue.md` の delegated-by-default policy を再定義せず、各 implementation step の `delegation contract` として委任先、入力、許可範囲、検証、reviewer focus、停止条件、出力を具体化する。
 
 ## 必須項目
 
@@ -26,6 +27,7 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - `ステップ一覧`
 - `要件 ↔ ステップ対応`
 - `Spec-Locked Closure Index`
+- 各 implementation step の `delegation contract`
 - 各 implementation step の `具体テストケース一覧`
 - 各 implementation step の `step closure contract`
 - 各 implementation step の `behavior slice execution`
@@ -33,6 +35,34 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 - `S90 docs impact resolution / docs refresh`
 - `S99 final quality gate`
 - `Final Exit Contract`
+
+## delegation contract
+
+各 implementation step は、`workflow_issue.md` の `Parent Agent Invariant`、`Implementation Delegation Gate`、delegated worker handoff、reviewer gate mapping を参照し、その step 固有の handoff contract を持つ。
+この欄は execution policy の再定義ではない。plan author は、worker が追加判断なしに作業でき、reviewer が scope / verification / report evidence を確認できるように、次の項目を step-local に埋める。
+
+標準項目:
+
+- `delegated role`:
+  - runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary worker とする。
+- `input docs`:
+  - `requirement.md`、`design.md`、`plan.md`、該当 workflow / authoring docs、target files などの source of truth。
+- `allowed paths`:
+  - `design.md` の `ディレクトリ / ファイル変更計画` から、その step が触る subset。
+- `forbidden changes`:
+  - scope 外ファイル、別 step の変更、source-of-truth 逸脱、runtime と docs の不用意な混在など。
+- `acceptance criteria`:
+  - closure index と step closure contract へ追跡できる、観測可能な完了条件。
+- `required tests or docs-only verification`:
+  - targeted command、manual evidence、inspection、docs diff など、その step の検証方法。
+- `reviewer focus`:
+  - `workflow_issue.md` の mapping に従い、code / runtime / tests / scaffold behavior は `code-reviewer`、docs-only / template-only / skill-text-only は `spec-reviewer` docs/spec alignment を基本にする。
+- `stop conditions`:
+  - 入力 docs の矛盾、許可パス外変更が必要、検証不能、delegated role 不適合、host policy / tool 制約、acceptance 未達など。
+- `output required`:
+  - changed files、worker summary、verification result、unresolved risks、report へ転記する delegation evidence。
+
+複数 layer / package / shipped asset にまたがる step は、親 Codex が直接実装せず、allowed paths と dependency boundary を明記して委任する。docs-only / template-only / skill-text-only step であっても、shipped artifact を変更する場合は `doc-writer` 委任と docs/spec alignment review を plan に残す。
 
 ## 具体テストケース一覧
 
@@ -64,6 +94,9 @@ Issue の `plan.md` を作成・更新するときの agent-facing entrypoint �
 ## reviewer fail 条件
 
 - implementation step に `具体テストケース一覧` がない。
+- implementation step に `delegation contract` がない、または `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` のいずれかが欠けている。
+- `delegation contract` が `workflow_issue.md` と矛盾する execution policy を再定義している。
+- delegated worker work を reviewer gate の代替として扱っている、または step の変更種別と reviewer focus が矛盾している。
 - concrete test case が step-local ではなく、global test plan だけに置かれている。
 - `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` のいずれかが欠けている。
 - 「テストを追加する」「動作確認する」など、実装者が fixture / command / expected observation を判断する必要がある抽象表現だけになっている。

--- a/src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/phase_plan_issue.md
@@ -16,6 +16,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
   - review / QA / spec gate 方針
   - 依存関係から導いた step 順
   - nested execution structure
+  - per-step delegation contract
   - docs impact gate
   - final quality gate with `qa-reviewer` / issue-wide `code-reviewer` / `spec-reviewer`
   - final exit contract
@@ -35,6 +36,15 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - 各 behavior slice には closure index の `id` に対応する `step closure contract`、`test bundle`、`pre-implementation evidence`、`bounded implementation batch`、`verification`、`refactor / tidy` を置く
 - Central index は仕様由来の `spec link`、`locked expectation`、`observable input/state`、`bug class guarded`、`required`、`evidence level`、closure owner step を所有する
 - `step closure contract` はその step で満たす closure `id`、close condition、test bundle、pre-implementation evidence、verification command / evidence path、report evidence を所有する
+- 各 implementation step には `delegation contract` を置く。これは `workflow_issue.md` の `Parent Agent Invariant`、`Implementation Delegation Gate`、delegated worker handoff、reviewer gate mapping を plan step へ埋め込むための欄であり、実行 policy を再定義しない
+- `delegation contract` は `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` を持つ
+- `delegated role` は step の変更種別に合わせる。runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary worker とし、混在する場合は step を分割するか reviewer focus と gate を明記する
+- `input docs` は `requirement.md`、`design.md`、`plan.md`、該当 workflow / authoring docs、target files など、worker が判断を補わずに読める正本を列挙する
+- `allowed paths` は `design.md` の `ディレクトリ / ファイル変更計画` から該当 step の subset として書き、`forbidden changes` には source-of-truth 逸脱、scope 外ファイル、別 step の変更、runtime / docs の混在などを明記する
+- `acceptance criteria` は closure index と step closure contract へ追跡できる観測可能な完了条件にし、`required tests or docs-only verification` は targeted command、manual evidence、inspection、docs diff など step に必要な検証を具体化する
+- `reviewer focus` は `workflow_issue.md` の reviewer gate mapping を参照して、code / runtime / tests / scaffold behavior なら `code-reviewer`、docs-only / template-only / skill-text-only なら `spec-reviewer` docs/spec alignment を基本にする。委任は reviewer gate の代替ではない
+- `stop conditions` は許可パス外変更、入力 docs の矛盾、検証不能、delegated role 不適合、host policy / tool 制約、acceptance 未達など、worker が親 Codex へ戻す条件を書く
+- `output required` は changed files、worker summary、verification result、unresolved risks、reviewer が確認すべき evidence、report へ転記する delegation evidence を指定する
 - `test bundle` は step closure contract の一部として、必要な範囲で acceptance / characterization / property or invariant / regression / negative を分類する
 - `test ids` と書く場合も Central index の closure `id` の alias として扱い、別 alias を使う場合は report の `Closure Delta` に `test id alias` と `resolves to closure id` を記録する
 - `test bundle` は Central index の `locked expectation` / `observable input/state` を再記述しない
@@ -52,7 +62,7 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - 各 step の close 判定は Issue 全体の一覧表ではなく、その step の `step closure contract` を正本にする
 - `step closure contract` は `close when`、`verification evidence`、`report evidence`、`residual risk` を持ち、step result approval の対象にする
 - 各 implementation step は commit 単位として設計し、`1 implementation step = 1 review scope = 1 commit` を標準にする。step が大きすぎる場合は commit をまとめず step を分割する
-- 各 step gate には `code-reviewer gate`、`commit gate`、`no-op gate` を置き、`code-reviewer` pass 後に step commit で閉じる。`approved-no-op` は差分なしの場合だけ許可する
+- 各 step gate には `step reviewer gate`、`commit gate`、`no-op gate` を置き、`workflow_issue.md` の reviewer gate mapping に従う reviewer pass 後に step commit で閉じる。`approved-no-op` は差分なしの場合だけ許可する
 - review / QA / docs / final quality gate は behavior slice の外に置き、step gate / milestone gate / `S90` / `S99` に配置する
 - `refactor / tidy` は bounded decision point として残し、事前に詳細な cleanup task を書き込まない
 - cleanup が最初から明確で大きい場合は、`bounded implementation batch` / design / 別 step で扱う
@@ -83,9 +93,10 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - `Spec-Locked Closure Index` を置く
 - `実装ステップ` を step / block / behavior slice で書く
 - 各 behavior slice の `step closure contract` / `test bundle` / `pre-implementation evidence` / `bounded implementation batch` / `verification` を置き、`test bundle` は closure index の `id` を参照できるようにする
+- 各 implementation step に `delegation contract` を置き、`workflow_issue.md` の execution policy を再定義せずに worker handoff へ必要な入力、許可範囲、禁止範囲、検証、reviewer focus、停止条件、出力を具体化する
 - 各 implementation step に `具体テストケース一覧` を置き、ネストリストで `前提` / `操作` / `期待結果` / `失敗検出` / `検証方法` を書く
 - `refactor / tidy` には `目的` と `guardrail` を置き、具体的な refactor 内容は `report.md` へ送る
-- 各 step gate に `code-reviewer gate`、`commit gate`、`no-op gate`、`report update` を置く
+- 各 step gate に `step reviewer gate`、`commit gate`、`no-op gate`、`report update` を置き、reviewer は `workflow_issue.md` の mapping に従って選ぶ
 - `S90 docs impact resolution / docs refresh` を必須で置く
 - `S99 final quality gate` を必須で置き、`qa-reviewer` のテスト十分性確認、issue-wide `code-reviewer` の統合 diff review、`spec-reviewer` の要件達成確認を配置する
 - `final exit contract` を置く
@@ -107,13 +118,16 @@ shared axiom は [phase_plan.md](phase_plan.md)、Issue の execution policy は
 - every required row が non-placeholder の `spec link`、`observable input/state`、`locked expectation`、`evidence level`、`closure evidence` を持つ
 - every required row に step-local close condition と planned verification evidence path がある
 - behavior slice が step closure contract、test bundle、pre-implementation evidence を持ち、bounded implementation batch として原因局所化できる
+- 各 implementation step が `delegation contract` を持ち、`delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` を埋めている
+- `delegation contract` が `workflow_issue.md` の policy を再定義せず、step 固有の handoff contract として書かれている
+- reviewer focus が step の変更種別と矛盾する場合、または delegated worker work を reviewer gate の代替として扱っている場合は fail とする
 - 各 implementation step が step-local な `具体テストケース一覧` を持ち、各 case が `前提`、`操作`、`期待結果`、`失敗検出`、`検証方法` を含む
 - concrete test case が横長 table に押し込まれて読みづらい場合、または global test plan だけで step-local case がない場合は fail とする
 - docs-only / approved-no-op step は、テスト不要理由と inspection / manual / docs diff などの代替検証方法を持つ
-- 各 implementation step が commit 単位として設計され、`code-reviewer gate`、`commit gate`、`no-op gate` を持っている
+- 各 implementation step が commit 単位として設計され、`step reviewer gate`、`commit gate`、`no-op gate` を持っている
 - step 順が design の依存関係分析、Module Dependency Diagram、directory / file change plan と矛盾しない
 - 各 step の `depends on` / `unblocks` / `target files` が、実装順と変更対象の確認に使える
-- report update が stage gate に置かれている。report-before-commit、code-reviewer pass、step commit、approved-no-op の実行順は `workflow_issue.md` の実行 contract で確認する
+- report update が stage gate に置かれている。report-before-commit、step reviewer gate pass、step commit、approved-no-op の実行順は `workflow_issue.md` の実行 contract で確認する
 - AC / EC と step の対応が取れている
 - docs impact と final quality gate が計画に埋め込まれ、`doc-writer` による必要 docs 更新、`qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` の三者 review が追跡できる
 - reviewer が「この plan で実装してよい」と判断できる

--- a/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
+++ b/src/spec_dock/assets/spec_dock/docs/workflow_issue.md
@@ -86,7 +86,9 @@ Issue は実装の最小単位です。
 
 - 実装前に `requirement.md` / `design.md` / `plan.md` の整合を確認し、特に `design.md` の依存関係分析 / module dependency diagram / directory tree と `plan.md` の step 順が一致していることを確認して、plan upfront approval を得る
 - 実装前に `workflow_spec_authoring.md` の requirement / design / plan gate がすべて pass し、`Spec Authoring Gate` evidence が `report.md` に残っていることを確認する
-- 各 implementation step は `step closure contract / test bundle / pre-implementation evidence → implementation delegation decision → bounded implementation batch → verification → refactor/tidy → report draft update → code-reviewer → fix → re-review → commit → clean確認` の順で進める
+- `Parent Agent Invariant`: normal execution における親 Codex は inspect / plan / delegate / verify / integrate / report を担当する orchestration owner であり、code / runtime / tests / scaffold behavior / templates / shipped docs / skills / workflow text の直接実装者ではない
+- 親 Codex が直接作成・更新してよいのは、`report.md`、handoff note、phase evidence など run-local orchestration metadata に限定する。shipped docs / templates / skills / workflow text、runtime-facing scaffold、コード、テスト、runtime behavior は delegated worker work として扱う
+- 各 implementation step は `step closure contract / test bundle / pre-implementation evidence → implementation delegation decision → bounded implementation batch → verification → refactor/tidy → report draft update → step reviewer gate → fix → re-review → commit → clean確認` の順で進める
 - 完成版 `plan.md` には `Spec-Locked Closure Index`（仕様固定クロージャ索引）を置き、各 behavior slice の仕様ロックと closure owner step を実装前に固定する
 - `Spec-Locked Closure Index` は Issue 全体のテストケース一覧や詳細なテスト実装指示ではなく、観測可能な入力・状態・locked expectation・防ぐ欠陥クラス・required/evidence level を固定する coverage ledger である
 - `test bundle` は step closure contract の一部として、step の観測可能な振る舞いに必要な acceptance / characterization / property or invariant / regression / negative を分類する
@@ -94,18 +96,21 @@ Issue は実装の最小単位です。
 - 実装開始前に required closure id が behavior slice の `closure ids` / `test ids` から参照され、各 required row に step-local close condition と verification command または evidence path があることを確認する
 - required closure row、`locked expectation`、`required`、`spec link` を変更する場合は plan amendment と re-review を先に通す
 - `pre-implementation evidence` は expected red / characterization pass / test sensitivity evidence のいずれかを記録し、failing-first を完全要求できない場合もテストが欠陥を検出できる根拠を残す
-- `Implementation Delegation Gate` は各 implementation step の開始前に必ず置く。step が複数 layer / module / package にまたがる、runtime / CLI / infra / templates / shipped scaffold / shared docs に影響する、既存 pattern 調査や影響範囲分析が必要、integration test / migration / backward compatibility / filesystem / GitHub / active state に関わる、または独立 worker scope に分割できる大きさの場合は、適切なサブエージェント利用を必須にする
-- `delegated` の場合は sub-agent role、scope、依頼内容、戻り値、取り込み結果を `report.md` に残す。`approved-local-execution` は小さい単一ファイル修正、機械的文言修正、明確な localized change、または即時 blocking / tightly coupled で main agent が担当すべき場合だけ許可し、条件付き必須に該当しない理由を `no delegation rationale` として残す
+- `Implementation Delegation Gate` は各 implementation step の開始前に必ず置く。runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`、shipped docs / templates / skills / workflow text は `doc-writer` を primary delegated worker とし、step が複数 layer / module / package にまたがる、runtime / CLI / infra / templates / shipped scaffold / shared docs に影響する、既存 pattern 調査や影響範囲分析が必要、integration test / migration / backward compatibility / filesystem / GitHub / active state に関わる、または独立 worker scope に分割できる大きさの場合は、適切なサブエージェント利用を必須にする
+- delegated worker handoff には、`delegated role`、`scope`、`source of truth`、`allowed changes`、`forbidden changes`、`required verification`、`stop conditions`、`output required` を必ず含める。複数 layer / package / shipped asset にまたがる step は、親 Codex が direct implementation せず、allowed paths と dependency boundary を明記して委任する
+- `delegated` の場合は delegated role、scope、source of truth、allowed changes、forbidden changes、required verification、stop conditions、output required、worker summary、changed files、verification result、unresolved risks、取り込み結果を `report.md` に残す
+- 親 Codex が例外的に直接実装する場合は `Parent Implementation Exception` として、delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate を事前に記録する。`approved-local-execution` はこの exception record を満たす場合だけ使用し、小さい変更、機械的変更、親が修正を知っていることを理由にした無記録 direct implementation として扱ってはならない
 - reviewer gate state は `passed` / `failed` / `unavailable` / `denied` / `waived` / `provisional` のいずれかで記録する。required reviewer gate を満たすのは fresh `passed` だけである
-- `waived` はユーザーの明示的 risk acceptance が `report.md` にある場合だけ許可する。`provisional` は orchestrator self-check の記録であり、`spec-reviewer` / `code-reviewer` / `qa-reviewer` の代替ではない
-- サブエージェント機能が利用できない、拒否された、または host policy と衝突する場合、required reviewer gate は `unavailable` / `denied` として blocked / 未完了に分類する。degraded mode は status/context gathering や追加 verification に限定し、reviewer gate、implementation readiness、final quality gate を満たさない
+- `waived` はユーザーの明示的 risk acceptance が `report.md` にある場合だけ許可する。waiver は reviewer pass ではなく、delegation / reviewer gate の unavailable / denied を degraded success にしない。waiver 後に親 Codex が直接実装する場合も、別途 `Parent Implementation Exception` の user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate を必要とする
+- サブエージェント機能が利用できない、拒否された、または host policy と衝突する場合、required delegation / reviewer gate は `unavailable` / `denied` として blocked / 未完了に分類する。unavailable / denied / host conflict は degraded success でも、親 Codex の direct implementation 自動承認でもない。degraded mode は status/context gathering や追加 verification に限定し、reviewer gate、implementation readiness、final quality gate を満たさない
 - `bounded implementation batch` は step の scope、allowed files、forbidden scope に収まる最小実装単位とする
 - `refactor/tidy` は verification 後の bounded decision point とし、plan では詳細 task を事前確定しない
 - step 順は `design.md` の依存関係分析、module dependency diagram、directory / file change plan を根拠に、upstream / prerequisite から downstream へ組む
 - cleanup が既知で大きい場合は `bounded implementation batch` / design / 別 step へ切り出す
 - review / QA / spec の各 stage gate は `pass` まで回す
-- 各 implementation step は、サブエージェント `code-reviewer` の `review_status: pass` を得てから、その step の実装・テスト・必要な report draft update をまとめてコミットする
-- implementation delegation は per-step `code-reviewer` の代替ではない。`dev-coder` などの worker が実装した場合でも、その step diff は必ず `code-reviewer` pass を得る
+- reviewer gate mapping は step の変更種別で決める。code / runtime / tests / scaffold behavior を含む step は per-step `code-reviewer` pass を必要とし、docs-only / template-only / skill-text-only step は `spec-reviewer` docs/spec alignment pass を必要とする。両方を含む場合は step を分割するか、両方の reviewer focus を明記して必要な gate を通す
+- implementation delegation は reviewer gate の代替ではない。`dev-coder` / `doc-writer` などの worker が実作業した場合でも、step diff は上記 mapping に従う reviewer pass を得る
+- reviewer が `fail` を返した場合、親 Codex は原則として自分で direct fix せず、指摘を bounded delegated follow-up として同じ delegated worker または適切な worker に再委任する。親 Codex が直接修正するには `Parent Implementation Exception` を別途満たす
 - `1 implementation step = 1 review scope = 1 commit` を標準とし、複数 step の変更を 1 commit に混ぜてはならない。step が大きすぎる場合は commit をまとめず step を分割する
 - step commit 後は `git status --short` などで、次 step へ持ち越す意図しない staged / unstaged 変更がないことを確認する
 - step の close state は `committed` または `approved-no-op` のどちらかにする。`approved-no-op` は差分が本当にない場合だけ許可し、小さい変更、あとでまとめる、report だけ、時間不足を理由にしてはならない
@@ -123,7 +128,7 @@ Issue は実装の最小単位です。
 - route だけ、または manual `active set` だけでは Issue work は完了しない。通常の開始/終了は `issue start` / `issue finish` を使う
 - `complete` と報告してよいのは、`issue finish` 前に active issue が set されその対象 issue を確認できる状態で、`spec-dock/active/issue/requirement.md` / `design.md` / `plan.md` / `report.md` の 4 点が issue 固有の内容になっており、`spec-dock/active/issue/report.md` に required `sync` / `validate` の成功または pass 結果、required review の approval または pass 結果を示すコマンド証跡、各 implementation step の `Implementation Delegation Gate` が `delegated` / `approved-local-execution` / degraded mode のいずれかで閉じている証跡、required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved-no-op として閉じている証跡、全 implementation step が `committed` または正当な `approved-no-op` で閉じている証跡、final docs impact resolved、final `qa-reviewer` pass、issue-wide `code-reviewer` pass、final `spec-reviewer` pass、final report ledger が記録済みであり、final commit 済みと意図しない staged / unstaged 変更なしの post-commit external delivery evidence を確認している場合のみである。ここで degraded mode は implementation delegation availability の証跡に限られ、required reviewer gate pass ではない
 - 4 点の issue docs のいずれかが untouched、template、placeholder、または実質未記入の状態で残る場合は `未完了` であり、成功報告をしてはならない
-- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step code review / step commit / final QA review / issue-wide code review / final spec review / final commit）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
+- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step reviewer gate / step commit / final QA review / issue-wide code review / final spec review / final commit）のいずれかを未実施のままにした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合、理由の記録は必須だが `complete` にはならない。`blocked` または `未完了` に分類し、`report.md` に reason と next action を残す
 - `blocked` は、外部依存、権限不足、サービス停止、その他の環境条件によって次の required action を進められない状態を指す
 - `blocked` の場合は `report.md` に reason と next action を残す。blocker type と impact は該当する場合に併記する
 - `未完了` は、product work、docs 更新、または証跡が不足している状態を指す。product gap は環境 blocker がない限り `blocked` ではなく `未完了` として扱う
@@ -137,10 +142,11 @@ Issue は実装の最小単位です。
 - `Test Contract Closure` に required closure id、step、evidence level、pre-implementation evidence、verification command、result を残す
 - `Closure Coverage` に各 required closure id と verification evidence の対応を残す
 - `Closure Delta` に追加・削除・変更・未実装 row と re-review 要否を残す
-- `Implementation Delegation Gate` に step、decision、required reason、agent role、delegated scope、result、local-execution rationale を残す。`delegated` の場合は依頼内容、戻り値、取り込み結果を追跡し、`approved-local-execution` の場合は no delegation rationale を残す
+- `Implementation Delegation Gate` に step、decision、required reason、delegated role、scope、source of truth、allowed changes、forbidden changes、required verification、stop conditions、output required、result を残す。`delegated` の場合は worker summary、changed files、verification result、unresolved risks、parent integration decision を追跡する
+- `Parent Implementation Exception` に delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate、unavailable / denied / host conflict / waiver の扱い、risk acceptance の有無を残す。exception record がない親 Codex direct implementation は required gate 未完了として扱う
 - `Workflow Delegation Consent` に consent source、repo/worktree、active issue、session、named roles、boundary、expires / invalidation condition、`denied` / `unavailable` の場合の reason と next action を残す
 - `Reviewer Gate Status` に gate name、reviewer role、freshness、state（`passed` / `failed` / `unavailable` / `denied` / `waived` / `provisional`）、risk acceptance の有無、promotion / completion decision を残す
-- `Step Commit Gate` に step、review scope、`code-reviewer` verdict、commit scope、closure state、commit evidence、post-commit clean check を残す
+- `Step Commit Gate` に step、review scope、step reviewer verdict、commit scope、closure state、commit evidence、post-commit clean check を残す。step reviewer は reviewer gate mapping に従って `code-reviewer` または `spec-reviewer` を記録する
 - `Final QA Gate` に `qa-reviewer` verdict、テスト十分性、integration test 追加要否、追加した場合の evidence を残す
 - `Final Code Review Gate` に issue-wide `code-reviewer` verdict、統合 diff scope、修正と re-review の evidence を残す
 - `Final Spec Review Gate` に `spec-reviewer` verdict、requirement / design / plan / report / docs 整合、docs 修正が必要な場合の `doc-writer` 更新 evidence を残す
@@ -149,7 +155,7 @@ Issue は実装の最小単位です。
 - `issue finish` 後は active issue が clear されていてよく、`complete` 判定は active state の残存ではなく `issue finish` 前に記録・確認した report evidence で行う
 - `complete` 判定に必要な required closure id は、report の `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で pass または approved-no-op として閉じている必要がある
 - `complete` 判定に必要な各 implementation step は、report の `Implementation Delegation Gate` で `delegated`、`approved-local-execution`、または degraded mode として閉じている必要がある。delegation evidence が不足している場合は `未完了` として扱う
-- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step code review / step commit / final QA review / issue-wide code review / final spec review / final commit）を未実施にした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
+- required step（`sync` / `validate` / `required review` / implementation delegation decision / per-step reviewer gate / step commit / final QA review / issue-wide code review / final spec review / final commit）を未実施にした場合、または実行しても成功、pass、approval、`delegated`、`approved-local-execution`、`committed`、または正当な `approved-no-op` に到達しなかった場合は reason と next action を残し、`blocked` / `未完了` に分類する
 - `blocked` / `未完了` の場合は reason と next action を残し、環境 blocker と product gap を混在させない
 - `blocked` では blocker type と impact を該当する範囲で残す
 - stage gate ごとの reviewer verdict / test結果 / 修正内容 / no-op 理由もここに残す
@@ -205,7 +211,7 @@ Issue は実装の最小単位です。
   - docs impact / docs refresh step が必要なら入っている
   - final quality gate が独立し、`qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer` の三者 review を含んでいる
   - 各 implementation step に Implementation Delegation Gate があり、条件付き必須 trigger に該当する step では適切なサブエージェント利用または degraded mode evidence がある
-  - 各 implementation step に code-reviewer gate、commit gate、no-op gate がある
+  - 各 implementation step に step reviewer gate、commit gate、no-op gate がある
 - report:
   - `complete` を報告する場合に必要な required `sync` / `validate` の成功または pass 結果と required review の approval または pass 結果を示すコマンド証跡が、`issue finish` 前に active issue を確認できる状態の report に残っている
   - required closure id が `Step Contract Closure` / `Test Contract Closure` / `Closure Coverage` で閉じている

--- a/src/spec_dock/assets/spec_dock/templates/issue/plan.md
+++ b/src/spec_dock/assets/spec_dock/templates/issue/plan.md
@@ -89,7 +89,7 @@ ID: "<ISS_ID>"
 ## レビュー / QA ゲート方針
 - RG1 implementation review:
   - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer
+  - reviewer: code-reviewer for code / runtime / tests / scaffold behavior; spec-reviewer docs/spec alignment for docs-only / template-only / skill-text-only
   - pass 条件: review_status: pass
   - 範囲: 現在 step の diff、tests、docs/report 更新、spec 影響
 - QG1 QA review:
@@ -105,9 +105,10 @@ ID: "<ISS_ID>"
 - 実行 policy、approval cadence、completion contract は `workflow_issue.md` を正本にする。
 - step / block / behavior slice の書き方は `phase_plan_issue.md` を正本にする。
 - plan 本文には、この Issue 固有の順序、依存、検証、review / QA gate だけを書く。
-- 各 implementation step は commit 単位として設計し、`code-reviewer gate` を pass してから `commit gate` で閉じる。
+- 各 implementation step は `workflow_issue.md` の policy を再定義せず、step-local な `delegation contract` に worker handoff の入力、許可範囲、禁止範囲、検証、reviewer focus、停止条件、出力を書く。
+- 各 implementation step は commit 単位として設計し、`workflow_issue.md` の reviewer gate mapping に従う `step reviewer gate` を pass してから `commit gate` で閉じる。
 - `approved-no-op` は差分なしの場合だけ許可し、理由、確認対象、差分なし確認コマンドを report に残す。
-- implementation step を追加する場合は S01 の subsections を複製し、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
+- implementation step を追加する場合は S01 の subsections を複製し、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` を各 step に必ず置く。
 
 ## 実装ステップ
 
@@ -136,6 +137,34 @@ ID: "<ISS_ID>"
   - negative:
 - pre-implementation evidence:
   - expected red / characterization pass / test sensitivity evidence:
+
+#### delegation contract
+- delegated role:
+  - dev-coder / doc-writer / other named worker:
+- input docs:
+  - `requirement.md`:
+  - `design.md`:
+  - `plan.md`:
+  - workflow / authoring docs:
+  - current target files:
+- allowed paths:
+  - ...
+- forbidden changes:
+  - ...
+- acceptance criteria:
+  - ...
+- required tests or docs-only verification:
+  - targeted command / manual evidence / inspection / docs diff:
+- reviewer focus:
+  - code-reviewer for code / runtime / tests / scaffold behavior, or spec-reviewer docs/spec alignment for docs-only / template-only / skill-text-only:
+- stop conditions:
+  - input docs conflict / path outside allowed scope / verification cannot run / delegated role mismatch / host policy conflict / acceptance cannot be met:
+- output required:
+  - changed files:
+  - worker summary:
+  - verification result:
+  - unresolved risks:
+  - report evidence to update:
 
 #### 具体テストケース一覧
 
@@ -192,10 +221,17 @@ ID: "<ISS_ID>"
 - delegation 判断:
   - delegated / approved-local-execution / degraded mode:
   - 必須理由 / no delegation rationale:
+- delegation contract evidence:
+  - delegated role:
+  - allowed paths:
+  - forbidden changes:
+  - required tests or docs-only verification:
+  - stop conditions:
+  - output required:
 - report draft update:
-  - update before code-reviewer so the evidence is reviewed and committed with the step:
-- code-reviewer gate:
-  - reviewer: code-reviewer
+  - update before the step reviewer gate so the evidence is reviewed and committed with the step:
+- step reviewer gate:
+  - reviewer: code-reviewer / spec-reviewer docs/spec alignment, according to `workflow_issue.md` reviewer gate mapping
   - review 範囲:
   - pass 条件: review_status: pass
   - re-review rule: 指摘を修正し pass まで再実行
@@ -218,7 +254,7 @@ ID: "<ISS_ID>"
 
 ### Sxx — <next observable behavior>
 - S01 の subsections を複製して記入する。
-- `具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
+- `delegation contract`、`具体テストケース一覧`、`step closure contract`、`behavior slice execution`、`step gate` がない implementation step は implementation-ready ではない。
 
 ### S90 — docs impact resolution / docs refresh
 - 対象:

--- a/src/spec_dock/assets/spec_dock/templates/issue/report.md
+++ b/src/spec_dock/assets/spec_dock/templates/issue/report.md
@@ -56,9 +56,33 @@ ID: "<ISS_ID>"
 | none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no |
 
 #### Implementation Delegation Gate
-| step | decision | required reason | agent role | delegated scope | result | local-execution rationale |
-|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | pass / fail / blocked | no delegation rationale / degraded reason |
+`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records evidence only.
+
+| step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | result |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
+
+#### Delegated Worker Evidence
+| step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
+|---|---|---|---|---|---|---|---|
+| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
+
+#### Parent Implementation Exception
+| step | delegation unavailable/impossible reason | user approval / risk acceptance | allowed files | allowed operation | rollback plan | post-change verification | reviewer gate | unavailable / denied / host conflict / waiver handling |
+|---|---|---|---|---|---|---|---|---|
+| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
+
+#### Workflow Delegation Consent
+This table is for reviewer / read-only specialist workflow-scoped consent. Write-capable delegation such as `dev-coder` or `doc-writer` is recorded in `Implementation Delegation Gate` and `Delegated Worker Evidence`, not as generic workflow-scoped consent.
+
+| consent source | repo / worktree | active issue | session | named roles | boundary | expires / invalidation condition | denied / unavailable reason | next action |
+|---|---|---|---|---|---|---|---|---|
+| user message / policy / N/A | ... | iss-_____ | ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | reviewer / read-only specialist scope only | ... | none / ... | ... |
+
+#### Reviewer Gate Status
+| step | gate name | reviewer role | freshness | state | risk acceptance | promotion / completion decision | notes |
+|---|---|---|---|---|---|---|---|
+| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
 
 #### Code Review Gate
 | step | reviewer | review scope | review_status | findings / fixes | re-review count | result |

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -706,6 +706,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00070-installer-source-discovery-and-managed-ownership/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00071-verification-dogfooding-and-update-parity/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00072-legacy-authority-retirement-and-final-spec-close/.meta.json",
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/issues/iss-00078-installer-coexistence-contract-and-migration-flow/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00090-github-default-sync-contract/.meta.json",
@@ -775,6 +776,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00072-legacy-authority-retirement-and-final-spec-close/.meta.json": [
             "iss-00071"
         ],
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00098-delegated-implementation-orchestration-contract/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/issues/iss-00078-installer-coexistence-contract-and-migration-flow/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00090-github-default-sync-contract/.meta.json": [],
@@ -967,6 +969,22 @@ class TestInitUpdate(CliRuntimeHarness):
                 asset_path.read_text(encoding="utf-8"),
                 f"checked-in dogfooding runtime mirror file diverged from provider asset: {mirror_rel_path}",
             )
+
+    def _assert_issue_execution_runtime_command_reminders(self, text: str, *, source: str) -> None:
+        for fragment in (
+            "## Runtime Command Reminders",
+            "Use the shipped runtime path: `./spec-dock/scripts/spec-dock ...`",
+            "Normal lifecycle is `issue start <target>`",
+            "`issue finish` only after the workflow completion gates pass",
+            "`issue start -f` / `issue start --force`",
+            "unfinished-active-issue guard",
+            "avoid `sync` on the just-finished issue branch",
+            "`deps add`, `deps remove`, and `deps check`",
+            "`validate` and `sync`",
+            "`--no-github`",
+            "Do not copy the full workflow here",
+        ):
+            self.assertIn(fragment, text, f"{source} missing concise runtime command reminder: {fragment}")
 
     def _assert_installed_templates_match_provider_assets(
         self,
@@ -2003,6 +2021,21 @@ class TestInitUpdate(CliRuntimeHarness):
             for fragment in ("前提", "操作", "期待結果", "失敗検出", "検証方法"):
                 self.assertIn(fragment, issue_plan_authoring)
             self.assertIn("Spec-Locked Closure Index", issue_plan_authoring)
+            self.assertIn("Parent Agent Invariant", issue_plan_authoring)
+            self.assertIn("delegated worker handoff", issue_plan_authoring)
+            self.assertIn("reviewer gate mapping", issue_plan_authoring)
+            for fragment in (
+                "`delegated role`",
+                "`input docs`",
+                "`allowed paths`",
+                "`forbidden changes`",
+                "`acceptance criteria`",
+                "`required tests or docs-only verification`",
+                "`reviewer focus`",
+                "`stop conditions`",
+                "`output required`",
+            ):
+                self.assertIn(fragment, issue_plan_authoring)
             for workflow_text in (workflow_initiative, workflow_epic, workflow_issue):
                 self.assertIn("workflow_spec_authoring.md", workflow_text)
                 self.assertIn("fresh `spec-reviewer`", workflow_text)
@@ -2024,6 +2057,13 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertIn("final quality gate", workflow_issue)
             self.assertIn("`qa-reviewer`", workflow_issue)
             self.assertIn("issue-wide `code-reviewer`", workflow_issue)
+            self.assertIn("Parent Agent Invariant", workflow_issue)
+            self.assertIn("inspect / plan / delegate / verify / integrate / report", workflow_issue)
+            self.assertIn("delegated worker handoff", workflow_issue)
+            self.assertIn("Parent Implementation Exception", workflow_issue)
+            self.assertIn("run-local orchestration metadata", workflow_issue)
+            self.assertIn("reviewer gate mapping", workflow_issue)
+            self.assertIn("docs-only / template-only / skill-text-only", workflow_issue)
             for command in (
                 "./spec-dock/scripts/spec-dock new issue --epic <epic-id> --title",
                 "./spec-dock/scripts/spec-dock import issue <num|#num|canonical-url> --title",
@@ -2136,7 +2176,7 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertIn("phase_plan_issue.md", plan_text)
             self.assertIn("S90 — docs impact resolution / docs refresh", plan_text)
             self.assertIn("S99 — final quality gate", plan_text)
-            self.assertIn("code-reviewer gate", plan_text)
+            self.assertIn("step reviewer gate", plan_text)
             self.assertIn("commit gate", plan_text)
             self.assertIn("delegation 判断", plan_text)
             self.assertIn("report draft update before review", plan_text)
@@ -2146,6 +2186,23 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertIn("code-reviewer を pass まで再実行", plan_text)
             self.assertIn("spec-reviewer を pass まで再実行", plan_text)
             self.assertIn("対象ファイル:", plan_text)
+            self.assertIn("#### delegation contract", plan_text)
+            for fragment in (
+                "delegated role:",
+                "input docs:",
+                "allowed paths:",
+                "forbidden changes:",
+                "acceptance criteria:",
+                "required tests or docs-only verification:",
+                "reviewer focus:",
+                "stop conditions:",
+                "output required:",
+                "#### 具体テストケース一覧",
+                "#### step closure contract",
+                "#### behavior slice execution",
+                "#### step gate",
+            ):
+                self.assertIn(fragment, plan_text)
 
             report_text = (issue_templates_dir / "report.md").read_text(encoding="utf-8")
             self.assertIn("## 遭遇した問題と解決", report_text)
@@ -2154,6 +2211,8 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertIn("#### Closure Coverage", report_text)
             self.assertIn("#### Closure Delta", report_text)
             self.assertIn("#### Implementation Delegation Gate", report_text)
+            self.assertIn("#### Delegated Worker Evidence", report_text)
+            self.assertIn("#### Parent Implementation Exception", report_text)
             self.assertIn("#### Code Review Gate", report_text)
             self.assertIn("#### Step Commit Gate", report_text)
             self.assertIn("## Final Quality Gate", report_text)
@@ -2165,7 +2224,9 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertIn("no-op diff-clean command", report_text)
             self.assertIn("no-op read-only confirmation", report_text)
             self.assertIn("post-commit external evidence destination", report_text)
-            self.assertIn("| step | decision | required reason | agent role | delegated scope | result | local-execution rationale |", report_text)
+            self.assertIn("| step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | result |", report_text)
+            self.assertIn("| step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |", report_text)
+            self.assertIn("| step | delegation unavailable/impossible reason | user approval / risk acceptance | allowed files | allowed operation | rollback plan | post-change verification | reviewer gate | unavailable / denied / host conflict / waiver handling |", report_text)
             self.assertIn("delegated / approved-local-execution / degraded mode", report_text)
             self.assertNotIn("clean / expected only", report_text)
             self.assertIn("| step | closure ids | close condition | evidence | result | notes |", report_text)
@@ -2180,19 +2241,35 @@ class TestInitUpdate(CliRuntimeHarness):
             self.assertTrue((target / ".codex" / "agents" / "spec-manager.toml").is_file())
             self.assertTrue((target / ".github" / "agents" / "orchestrator.agent.md").is_file())
 
-            skill_text = (skills_root / "spec-driven-tdd-workflow" / "SKILL.md").read_text(encoding="utf-8")
-            self.assertIn("`discussions/`", skill_text)
-            self.assertIn("./spec-dock/scripts/spec-dock new doc adr --issue", skill_text)
-            self.assertIn("`spec-dock/docs/reference_deps.md`", skill_text)
-            self.assertIn("`spec-dock/docs/reference_sync.md`", skill_text)
-            self.assertIn("./spec-dock/scripts/spec-dock ...", skill_text)
-            self.assertNotIn("./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>", skill_text)
-            self.assertNotIn("./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>", skill_text)
-            self.assertNotIn("./spec-dock/scripts/spec-dock deps check <target>", skill_text)
-            self.assertNotIn("./spec-dock/scripts/spec-dock validate", skill_text)
-            self.assertNotIn("./spec-dock/scripts/spec-dock sync", skill_text)
-            self.assertNotIn("./spec ", skill_text)
-            self.assertNotIn("adrs/new-adr", skill_text)
+            workflow_skill_text = (skills_root / "spec-driven-tdd-workflow" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("`discussions/`", workflow_skill_text)
+            self.assertIn("./spec-dock/scripts/spec-dock new doc adr --issue", workflow_skill_text)
+            self.assertIn("`spec-dock/docs/reference_deps.md`", workflow_skill_text)
+            self.assertIn("`spec-dock/docs/reference_sync.md`", workflow_skill_text)
+            self.assertIn("./spec-dock/scripts/spec-dock ...", workflow_skill_text)
+            self.assertNotIn(
+                "./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>",
+                workflow_skill_text,
+            )
+            self.assertNotIn(
+                "./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>",
+                workflow_skill_text,
+            )
+            self.assertNotIn("./spec-dock/scripts/spec-dock deps check <target>", workflow_skill_text)
+            self.assertNotIn("./spec-dock/scripts/spec-dock validate", workflow_skill_text)
+            self.assertNotIn("./spec-dock/scripts/spec-dock sync", workflow_skill_text)
+            self.assertNotIn("./spec ", workflow_skill_text)
+            self.assertNotIn("adrs/new-adr", workflow_skill_text)
+
+            issue_skill_text = (skills_root / "spec-dock-issue-execution" / "SKILL.md").read_text(
+                encoding="utf-8"
+            )
+            self._assert_issue_execution_runtime_command_reminders(
+                issue_skill_text,
+                source="generated issue-execution skill",
+            )
             self.assertFalse(
                 (target / ".github" / "workflows" / "spec-dock-close.yml").exists()
             )
@@ -3024,6 +3101,7 @@ class TestInitUpdate(CliRuntimeHarness):
         epic_design = (template_root / "epic" / "design.md").read_text(encoding="utf-8")
         issue_design = (template_root / "issue" / "design.md").read_text(encoding="utf-8")
         issue_plan = (template_root / "issue" / "plan.md").read_text(encoding="utf-8")
+        issue_report = (template_root / "issue" / "report.md").read_text(encoding="utf-8")
         self.assertIn("UML（推奨: system context / target-state overview）", initiative_design)
         self.assertIn("```plantuml", initiative_design)
         self.assertIn("!include C4_Context.puml", initiative_design)
@@ -3182,6 +3260,19 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("代替検証方法:", issue_plan)
         self.assertIn("S01 の subsections を複製して記入する", issue_plan)
         self.assertIn("implementation-ready ではない", issue_plan)
+        self.assertIn("#### delegation contract", issue_plan)
+        for fragment in (
+            "delegated role:",
+            "input docs:",
+            "allowed paths:",
+            "forbidden changes:",
+            "acceptance criteria:",
+            "required tests or docs-only verification:",
+            "reviewer focus:",
+            "stop conditions:",
+            "output required:",
+        ):
+            self.assertIn(fragment, issue_plan)
         self.assertIn("#### step closure contract", issue_plan)
         self.assertIn("closure id:", issue_plan)
         self.assertIn("close 条件:", issue_plan)
@@ -3197,9 +3288,25 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertNotIn("TDD iterations", issue_plan)
         self.assertNotIn("update_plan", issue_plan)
         self.assertIn("commit gate", issue_plan)
-        self.assertIn("code-reviewer gate", issue_plan)
+        self.assertIn("step reviewer gate", issue_plan)
         self.assertIn("no-op gate", issue_plan)
         self.assertIn("## 要件 ↔ ステップ対応", issue_plan)
+        self.assertIn("delegation contract evidence:", issue_plan)
+        self.assertIn("code-reviewer / spec-reviewer docs/spec alignment", issue_plan)
+
+        self.assertIn("#### Delegated Worker Evidence", issue_report)
+        self.assertIn("#### Parent Implementation Exception", issue_report)
+        self.assertIn("| step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |", issue_report)
+        self.assertIn("| step | delegation unavailable/impossible reason | user approval / risk acceptance | allowed files | allowed operation | rollback plan | post-change verification | reviewer gate | unavailable / denied / host conflict / waiver handling |", issue_report)
+        for fragment in (
+            "workflow_issue.md",
+            "source of truth",
+            "dev-coder / doc-writer",
+            "docs-only inspection",
+            "reviewer role + passed / failed / unavailable / denied / waived / provisional",
+            "blocked / incomplete / waived with explicit risk acceptance / next action",
+        ):
+            self.assertIn(fragment, issue_report)
 
         phase_design = (repo_root / "src/spec_dock/assets/spec_dock/docs/phase_design.md").read_text(
             encoding="utf-8"
@@ -3280,6 +3387,9 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("`test id alias` と `resolves to closure id`", phase_plan_issue)
         self.assertIn("`test bundle` は Central index の `locked expectation` / `observable input/state` を再記述しない", phase_plan_issue)
         self.assertIn("各 step の close 判定は Issue 全体の一覧表ではなく", phase_plan_issue)
+        self.assertIn("`delegation contract` は `delegated role`、`input docs`、`allowed paths`、`forbidden changes`、`acceptance criteria`、`required tests or docs-only verification`、`reviewer focus`、`stop conditions`、`output required` を持つ", phase_plan_issue)
+        self.assertIn("runtime / CLI / infra / code / tests / scaffold behavior は `dev-coder`", phase_plan_issue)
+        self.assertIn("shipped docs / templates / skills / workflow text は `doc-writer`", phase_plan_issue)
         self.assertIn("`具体テストケース一覧`", phase_plan_issue)
         self.assertIn("カード型ネストリスト", phase_plan_issue)
         self.assertIn("横長 table は trace matrix", phase_plan_issue)
@@ -3289,6 +3399,7 @@ class TestInitUpdate(CliRuntimeHarness):
         for fragment in ("`前提`", "`操作`", "`期待結果`", "`失敗検出`", "`検証方法`"):
             self.assertIn(fragment, phase_plan_issue)
         self.assertIn("implementation-ready ではない", phase_plan_issue)
+        self.assertIn("delegated worker work を reviewer gate の代替として扱っている場合は fail", phase_plan_issue)
         self.assertIn("plan amendment と re-review を必須", phase_plan_issue)
         self.assertIn("every `required=yes` closure row", phase_plan_issue)
         self.assertIn("every bundle `closure id` が Central index に存在", phase_plan_issue)
@@ -3297,9 +3408,9 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertNotIn("failing test は iteration ごとに 1 本ずつ進める", phase_plan_issue)
         self.assertIn("commit/no-op は `workflow_issue.md` の実行 contract が所有", phase_plan_issue)
         self.assertIn("step 固有の review scope、commit scope、no-op 条件", phase_plan_issue)
-        self.assertIn("report-before-commit、code-reviewer pass、step commit、approved-no-op", phase_plan_issue)
+        self.assertIn("report-before-commit、step reviewer gate pass、step commit、approved-no-op", phase_plan_issue)
         self.assertIn("`1 implementation step = 1 review scope = 1 commit`", phase_plan_issue)
-        self.assertIn("`code-reviewer gate`、`commit gate`、`no-op gate`", phase_plan_issue)
+        self.assertIn("`step reviewer gate`、`commit gate`、`no-op gate`", phase_plan_issue)
         self.assertIn("`S99 final quality gate` は標準配置", phase_plan_issue)
         self.assertIn("`qa-reviewer`、issue-wide `code-reviewer`、`spec-reviewer`", phase_plan_issue)
         self.assertIn("`doc-writer` が修正", phase_plan_issue)
@@ -3317,6 +3428,9 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("仕様固定マイクロバッチTDD", workflow_issue)
         self.assertIn("Spec-Locked Micro-Batch TDD", workflow_issue)
         self.assertIn("Spec-Locked Closure Index", workflow_issue)
+        self.assertIn("Parent Agent Invariant", workflow_issue)
+        self.assertIn("inspect / plan / delegate / verify / integrate / report", workflow_issue)
+        self.assertIn("run-local orchestration metadata", workflow_issue)
         self.assertIn("Issue 全体のテストケース一覧や詳細なテスト実装指示ではなく", workflow_issue)
         self.assertIn("closure index の `id` を参照", workflow_issue)
         self.assertIn("required closure id が behavior slice", workflow_issue)
@@ -3329,14 +3443,21 @@ class TestInitUpdate(CliRuntimeHarness):
         self.assertIn("step closure contract / test bundle / pre-implementation evidence", workflow_issue)
         self.assertIn("bounded implementation batch", workflow_issue)
         self.assertIn("Implementation Delegation Gate", workflow_issue)
+        self.assertIn("delegated worker handoff", workflow_issue)
+        self.assertIn("`delegated role`、`scope`、`source of truth`、`allowed changes`、`forbidden changes`、`required verification`、`stop conditions`、`output required`", workflow_issue)
         self.assertIn("複数 layer / module / package", workflow_issue)
         self.assertIn("runtime / CLI / infra / templates / shipped scaffold / shared docs", workflow_issue)
         self.assertIn("integration test / migration / backward compatibility / filesystem / GitHub / active state", workflow_issue)
         self.assertIn("`delegated` / `approved-local-execution` / degraded mode", workflow_issue)
-        self.assertIn("implementation delegation は per-step `code-reviewer` の代替ではない", workflow_issue)
+        self.assertIn("implementation delegation は reviewer gate の代替ではない", workflow_issue)
+        self.assertIn("Parent Implementation Exception", workflow_issue)
+        self.assertIn("delegation 不可理由、user approval、allowed files、allowed operation、rollback plan、post-change verification、reviewer gate", workflow_issue)
+        self.assertIn("reviewer gate mapping", workflow_issue)
+        self.assertIn("docs-only / template-only / skill-text-only", workflow_issue)
+        self.assertIn("bounded delegated follow-up", workflow_issue)
         self.assertIn("test sensitivity evidence", workflow_issue)
         self.assertNotIn("Red → Green → Refactor → review", workflow_issue)
-        self.assertIn("code-reviewer → fix → re-review → commit → clean確認", workflow_issue)
+        self.assertIn("step reviewer gate → fix → re-review → commit → clean確認", workflow_issue)
         self.assertIn("`1 implementation step = 1 review scope = 1 commit`", workflow_issue)
         self.assertIn("`committed` または `approved-no-op`", workflow_issue)
         self.assertIn("docs impact `none` は、docs / templates / README / workflow / skill / migration notes を確認", workflow_issue)
@@ -3351,41 +3472,22 @@ class TestInitUpdate(CliRuntimeHarness):
             repo_root
             / "src/spec_dock/assets/install_root/.agents/skills/spec-dock-issue-execution/SKILL.md"
         ).read_text(encoding="utf-8")
-        self.assertIn("spec-dock/docs/phase_plan_issue.md", issue_execution_skill)
-        self.assertIn("spec-dock/docs/authoring/issue-plan.md", issue_execution_skill)
-        self.assertIn("Keep templates as scaffolds", issue_execution_skill)
-        self.assertIn("Spec authoring mode", issue_execution_skill)
-        self.assertIn("Execution mode", issue_execution_skill)
-        self.assertIn("optional diagram catalog", issue_execution_skill)
-        self.assertIn("authoritative source for diagram choices", issue_execution_skill)
-        self.assertIn("catalog-listed or project-specific sections", issue_execution_skill)
-        self.assertIn("Spec-Locked Closure Index", issue_execution_skill)
-        self.assertIn("1 implementation step = 1 code-reviewer scope = 1 commit", issue_execution_skill)
-        self.assertIn("Implementation Delegation Gate", issue_execution_skill)
-        self.assertIn("Delegation is conditionally mandatory", issue_execution_skill)
-        self.assertIn("Role selection matrix", issue_execution_skill)
-        self.assertIn("`repo-analyst` maps code paths", issue_execution_skill)
-        self.assertIn("`dev-coder` handles bounded implementation steps", issue_execution_skill)
-        self.assertIn("Implementation delegation does not replace review gates", issue_execution_skill)
-        self.assertIn("run the `code-reviewer` sub-agent", issue_execution_skill)
-        self.assertIn("After the step `code-reviewer` pass, commit the step scope", issue_execution_skill)
-        self.assertIn("In `S99 final quality gate`, run `qa-reviewer`, issue-wide `code-reviewer`, and `spec-reviewer`", issue_execution_skill)
-        self.assertIn("use `doc-writer` for the update and `spec-reviewer` for docs/spec alignment review", issue_execution_skill)
-        self.assertIn("final report ledger / final commit scope before the final commit", issue_execution_skill)
-        self.assertIn("final commit hash plus post-commit clean evidence are recorded in external delivery evidence", issue_execution_skill)
-        self.assertIn("required closure id", issue_execution_skill)
-        self.assertIn("behavior slice `closure ids` / `test ids`", issue_execution_skill)
-        self.assertIn("具体テストケース一覧", issue_execution_skill)
-        self.assertIn("table-only", issue_execution_skill)
-        self.assertIn("concrete test case id", issue_execution_skill)
-        self.assertNotIn("each test id at the start", issue_execution_skill)
-        for fragment in ("`前提`", "`操作`", "`期待結果`", "`失敗検出`", "`検証方法`"):
+        for fragment in (
+            "spec-dock/docs/workflow_issue.md as the source of truth",
+            "concise reminder for issue execution",
+            "parent agent responsible for orchestration",
+            "Route runtime, tests, and scaffold behavior to `dev-coder`",
+            "Route shipped docs, templates, skills, and workflow text to `doc-writer`",
+            "bounded delegated follow-up",
+            "Parent direct fixes require a documented Parent Implementation Exception",
+        ):
             self.assertIn(fragment, issue_execution_skill)
-        self.assertIn("verification command, or evidence path", issue_execution_skill)
-        self.assertIn("Step Contract Closure", issue_execution_skill)
-        self.assertIn("Test Contract Closure", issue_execution_skill)
-        self.assertIn("Closure Coverage", issue_execution_skill)
-        self.assertIn("Closure Delta", issue_execution_skill)
+        self._assert_issue_execution_runtime_command_reminders(
+            issue_execution_skill,
+            source="provider issue-execution skill",
+        )
+        self.assertNotIn("Spec authoring mode", issue_execution_skill)
+        self.assertNotIn("Role selection matrix", issue_execution_skill)
         self.assertNotIn("Add Use Case, Sequence", issue_execution_skill)
 
         workflow_skill = (
@@ -8397,15 +8499,25 @@ assert observed == {{"branch": "123-fix-login", "current_repo_slug": "current/re
         self.assertIn("thin", copilot_adapter_text.lower())
 
         for skill_text in (hub_text, issue_text, codex_adapter_text, copilot_adapter_text):
-            self.assertIn("./spec-dock/scripts/spec-dock", skill_text)
+            if "./spec-dock/scripts/spec-dock" not in skill_text:
+                self.assertIn("spec-dock/docs/workflow_issue.md as the source of truth", skill_text)
+            else:
+                self.assertIn("./spec-dock/scripts/spec-dock", skill_text)
             self.assertNotIn("./spec ", skill_text)
 
-        self.assertIn("./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>", issue_text)
-        self.assertIn("./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>", issue_text)
-        self.assertIn("./spec-dock/scripts/spec-dock deps check <target>", issue_text)
-        self.assertIn("./spec-dock/scripts/spec-dock validate", issue_text)
-        self.assertIn("./spec-dock/scripts/spec-dock sync", issue_text)
-        self.assertIn("--no-github", issue_text)
+        for fragment in (
+            "spec-dock/docs/workflow_issue.md as the source of truth",
+            "parent agent responsible for orchestration",
+            "Route runtime, tests, and scaffold behavior to `dev-coder`",
+            "Route shipped docs, templates, skills, and workflow text to `doc-writer`",
+            "bounded delegated follow-up",
+            "Parent direct fixes require a documented Parent Implementation Exception",
+        ):
+            self.assertIn(fragment, issue_text)
+        self._assert_issue_execution_runtime_command_reminders(
+            issue_text,
+            source="bundled issue-execution skill",
+        )
 
         for skill_text in (hub_text, codex_adapter_text, copilot_adapter_text):
             self.assertNotIn("./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>", skill_text)
@@ -8444,22 +8556,15 @@ assert observed == {{"branch": "123-fix-login", "current_repo_slug": "current/re
         self.assertIn("scope-specific constraints and decisions", epic_text)
         self.assertIn("fresh `spec-reviewer`", epic_text)
         self.assertIn("Spec Authoring Gate", epic_text)
-        self.assertIn("`spec-dock/docs/workflow_issue.md`", issue_text)
-        self.assertIn("`spec-dock/docs/workflow_spec_authoring.md`", issue_text)
-        self.assertIn("`spec-dock/docs/reference_deps.md`", issue_text)
-        self.assertIn("`spec-dock/docs/reference_sync.md`", issue_text)
-        self.assertIn("`spec-dock/docs/reference_github.md`", issue_text)
-        self.assertIn("`spec-dock/docs/reference_naming.md`", issue_text)
-        self.assertIn("`spec-dock/docs/phase_requirement.md`", issue_text)
-        self.assertIn("`spec-dock/docs/phase_design.md`", issue_text)
-        self.assertIn("`spec-dock/docs/phase_plan.md`", issue_text)
-        self.assertIn("`spec-dock/active/context-pack.md`", issue_text)
-        self.assertIn("approved behavior-slice execution", issue_text)
-        self.assertIn("source of truth", issue_text)
-        self.assertIn("fresh `spec-reviewer`", issue_text)
-        self.assertIn("Spec Authoring Gate", issue_text)
-        self.assertIn("docs impact resolution step", issue_text)
-        self.assertIn("final quality gate", issue_text)
+        for fragment in (
+            "spec-dock/docs/workflow_issue.md as the source of truth",
+            "concise reminder for issue execution",
+            "parent agent responsible for orchestration",
+            "Route runtime, tests, and scaffold behavior to `dev-coder`",
+            "Route shipped docs, templates, skills, and workflow text to `doc-writer`",
+            "Parent direct fixes require a documented Parent Implementation Exception",
+        ):
+            self.assertIn(fragment, issue_text)
 
         self.assertIn("`spec-dock/docs/workflow_adr.md`", adr_text)
         self.assertIn("`spec-dock/docs/reference_naming.md`", adr_text)


### PR DESCRIPTION
## 概要
`spec-dock` の Issue 実行 workflow に、親 Codex を実装者ではなく orchestration owner として扱う delegated-by-default 契約を追加しました。あわせて、plan / report / template / skill の各面に delegation contract と reviewer gate の記録面をそろえ、provider 側と dogfooding 側の内容を同期しています。

## 背景・目的
- 親 Codex が低レベル実装を抱え込みすぎず、`inspect / plan / delegate / verify / integrate / report` に責務を寄せるためです。
- 実装作業は step 単位で `dev-coder` や `doc-writer` に委任し、変更種別に応じて `code-reviewer` / `spec-reviewer` / `qa-reviewer` で検証する運用を明文化するためです。
- `approved-local-execution` を曖昧な例外にせず、親の direct implementation が必要な場合は `Parent Implementation Exception` として記録する前提に寄せるためです。

## 変更内容
- `workflow_issue.md` に `Parent Agent Invariant`、delegated worker handoff、`Parent Implementation Exception`、waiver / unavailable / denied の扱い、step reviewer gate mapping を追加しました。
- `phase_plan_issue.md` と `docs/authoring/issue-plan.md` に、各 implementation step の `delegation contract` を plan に埋め込む方針を追加しました。
- `templates/issue/plan.md` に step-local な delegation contract の雛形を追加し、`templates/issue/report.md` に delegation evidence、delegated worker evidence、parent exception、reviewer gate status の記録欄を追加しました。
- `spec-dock-issue-execution/SKILL.md` を、workflow policy を重複展開しすぎない concise reminder に整理しました。
- provider 側と dogfooding 側の docs / templates / skill を同期し、`tests/test_init_update.py` に scaffold 契約を固定する回帰テストを追加しました。

## 影響
- 実行ポリシー、plan authoring、report evidence、template scaffold、installed skill の契約が揃います。
- 変更対象は docs / templates / skill / tests で、runtime の機能追加はありません。
- 今後の issue 実行では、step ごとの委任先・許可範囲・検証・停止条件が plan と report から追跡しやすくなります。

## 検証
- `git diff --check` OK
- `./spec-dock/scripts/spec-dock validate` OK (`nodes=42`)
- targeted `unittest` OK
- `pytest` は `pytest` コマンド未導入のため実行不可

## リスク・注記
- workflow / template / skill の契約を広く触っているため、今後の issue では report 記録と reviewer gate の運用が期待通りに定着するかを継続確認したいです。
- 変更は provider 側と dogfooding mirror の同期を前提にしているため、差分 drift を出さない運用が必要です。

## レビュー観点
- 親 Codex の責務が `inspect / plan / delegate / verify / integrate / report` に限定されているか。
- `delegation contract` と `reviewer gate mapping` が plan / report / workflow で一貫しているか。
- docs-only / template-only / skill-text-only step と code / runtime / tests / scaffold behavior step の reviewer が正しく分かれているか。
- report の evidence 欄が、後続の issue で実際に使える粒度になっているか。

## フォローアップ
- 必要なら、この契約に沿って他の issue plan / report テンプレートの追従状況も確認します。

Closes #98
