### PR TITLE
feat(worktree): 長命 worktree 作成コマンドを追加

### DIFF
--- a/spec-dock/docs/guide.md
+++ b/spec-dock/docs/guide.md
@@ -11,6 +11,7 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 - `phase_*.md`: shared phase playbook（共通の作り方）
 - `phase_plan_<scope>.md`: scope 固有の plan authoring rule
 - `reference_*.md`: GitHub / naming / deps / sync などの参照仕様
+- Worktree: [reference_worktree.md](reference_worktree.md)
 - `discussions/`: raw capture、ヒアリング、調査、議論、ADR の作業面
 
 phase playbook:
@@ -126,6 +127,7 @@ spec-dock/
 ./spec-dock/scripts/spec-dock deps check <target>
 ./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>
 ./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>
+./spec-dock/scripts/spec-dock worktree create [label]
 ./spec-dock/scripts/spec-dock validate
 ./spec-dock/scripts/spec-dock sync
 ```

--- a/spec-dock/docs/reference_worktree.md
+++ b/spec-dock/docs/reference_worktree.md
@@ -1,0 +1,87 @@
+# reference: worktree
+
+`spec-dock worktree` は、長命の手動管理 Git linked worktree を作るための補助コマンドです。
+Codex app が `$CODEX_HOME/worktrees` 配下に作る短命 worktree は、このコマンドの管理対象ではありません。
+
+## command
+
+```bash
+./spec-dock/scripts/spec-dock worktree create [LABEL]
+```
+
+`LABEL` は任意です。指定する場合は lowercase letters、digits、hyphen のみを使います。
+underscore、dot、space、slash、uppercase、shell metacharacters は拒否されます。
+
+## directory layout
+
+main checkout と同じ親ディレクトリに `<repo-basename>-worktrees/` を作り、その中に worktree を作ります。
+main checkout の中に nested `.worktrees/` は作りません。
+
+```text
+~/workspace/tools/
+  spec-dock/
+  spec-dock-worktrees/
+    spec-dock-wt1/
+    spec-dock-feature/
+```
+
+linked worktree から実行した場合も、Git が認識する main worktree を基準に container path と repo basename を決めます。
+branch name は実行元 checkout の current branch を基準にします。
+
+## naming
+
+LABEL なし:
+
+```text
+id: wt1, wt2, wt3, ...
+path: <repo-basename>-worktrees/<repo-basename>-<id>
+branch: <current-branch>-<id>
+```
+
+LABEL あり:
+
+```text
+id: <label>, <label>2, <label>3, ...
+path: <repo-basename>-worktrees/<repo-basename>-<id>
+branch: <current-branch>-<id>
+```
+
+directory、branch、Git worktree record の collision がある場合は次候補へ進みます。
+candidate exhaustion は fatal error です。
+
+## bootstrap
+
+worktree 作成後、new worktree root で `make init` を任意 bootstrap として実行します。
+
+- `make init` target がない場合は `skipped`。
+- `make` が見つからない、Makefile parse error など detection に失敗した場合は `detection_failed` warning。
+- `make init` が失敗した場合は `failed` warning。
+- `make init` が成功した場合は `succeeded`。
+
+bootstrap の detection / execution failure は worktree 作成成功を取り消さず、command exit code も `0` のままです。
+
+## output
+
+成功時は absolute worktree path、id、branch、bootstrap status を出力します。
+bootstrap warning は既存 CLI warning path に流れます。
+
+```text
+spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/spec-dock-worktrees/spec-dock-wt1
+spec-dock: worktree bootstrap status=skipped command=-
+```
+
+## failure
+
+次は fatal error です。
+
+- Git repo 外での実行。
+- detached HEAD での実行。
+- invalid label。
+- container path の作成失敗。
+- non-retryable `git worktree add` failure。
+- candidate retry ceiling exhaustion。
+
+## scope boundary
+
+この command は create のみを扱います。
+`worktree list`、`status`、`remove`、`prune`、Codex-managed worktree cleanup は future extension です。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "epic",
+  "id": "epic-00107",
+  "title": "Worktree Provisioning",
+  "slug": "worktree-provisioning",
+  "created_at": "2026-05-22T09:37:01+09:00",
+  "updated_at": "2026-05-22T09:37:01+09:00",
+  "parent_id": "init-local-00002",
+  "initiative_id": "init-local-00002",
+  "epic_id": null,
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 107,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/design.md
@@ -1,0 +1,486 @@
+---
+種別: 設計書（Epic）
+ID: "epic-00107"
+タイトル: "Worktree Provisioning"
+関連GitHub: ["#107"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+依存: ["requirement.md"]
+親: ["init-local-00002"]
+---
+
+# epic-00107 Worktree Provisioning — 設計（HOW）
+
+## 全体像
+- 対象境界:
+  - `spec-dock worktree create [LABEL]` を runtime command として追加する。
+  - command は Git linked worktree と initial branch を作るが、spec node / active pointer / GitHub issue は変更しない。
+  - 作成先は main worktree の sibling container `<repo-basename>-worktrees/` 配下へ正規化する。
+  - 作成後 bootstrap は optional / non-fatal な `make init` として扱う。
+- 影響領域:
+  - CLI parser / registry
+  - command args / command outcome
+  - application use case
+  - Git / make subprocess adapter
+  - CLI text rendering
+  - runtime tests and shipped docs
+- 既存関係:
+  - `issue start` は active pointer / checkout lifecycle を扱う。
+  - `worktree create` は checkout 作成だけを扱い、active pointer は触らない。
+  - `new` / `delete` / `close` の post-sync pattern は spec tree mutation 用であり、worktree 作成には使わない。
+- 参照する親 diagram:
+  - `init-local-00002/design.md` の feature initiative / runtime baseline / additive expansion 図。
+
+## Component / Module View
+- タイトル:
+  - Worktree Create Runtime Components
+- 答える問い:
+  - `worktree create` を既存 layered runtime のどこへ追加し、どの責務をどの layer が持つか。
+- 範囲:
+  - CLI command parsing から Git worktree creation、optional bootstrap、CLI output まで。
+- 含めない詳細:
+  - `git worktree remove` / `prune` / `repair`
+  - Codex app managed worktree internals
+  - project-specific env / secret bootstrap details
+- 更新条件:
+  - command family、Git gateway contract、bootstrap contract、output contract が変わるとき。
+
+### UML（component / module）
+```plantuml
+@startuml
+skinparam monochrome true
+left to right direction
+
+package "cli" {
+  [parser.py] as Parser
+  [registry.py] as Registry
+  [dispatch.py] as Dispatch
+}
+
+package "commands" {
+  [worktree.py\nWorktreeCreateArgs] as Command
+}
+
+package "application" {
+  [contracts.py\nWorktreeCreateRequest/Result] as Contracts
+  [worktree.py\ncreate_worktree] as UseCase
+  [ports.py\nGitGateway + BootstrapGateway] as Ports
+}
+
+package "infra" {
+  [git_cli.py\nworktree/list/add/branch] as GitCli
+  [make_cli.py\nmake init detection/run] as MakeCli
+}
+
+package "presentation" {
+  [cli_text.py\nrender_worktree_create_text] as Presentation
+}
+
+Parser --> Registry : binds worktree create
+Registry --> Command : registers command spec
+Dispatch --> Command : builds args and runs spec
+Command --> Contracts : maps CLI args to request
+Command --> UseCase : calls create_worktree
+UseCase --> Ports : depends on protocols
+Ports --> GitCli : implemented by git adapter
+Ports --> MakeCli : implemented by bootstrap adapter
+Command --> Presentation : renders result
+@enduml
+```
+
+設計判断:
+- `commands/worktree.py` は argparse と `CommandOutcome` のみを扱い、Git subprocess を直接呼ばない。
+- `application/worktree.py` は id generation、collision retry、main worktree normalization、bootstrap outcome aggregation を所有する。
+- `infra/git_cli.py` は Git CLI の薄い adapter を持つ。Git output parsing のうち `git worktree list --porcelain` の構造変換は infra に置くが、どの candidate を採用するかは application に置く。
+- `infra/make_cli.py` は `make init` の存在確認と実行を担う。bootstrap failure は例外ではなく result として返す。
+- presentation は absolute path を主表示する。
+
+## Package Dependency
+- タイトル:
+  - Worktree Create Dependency Direction
+- 答える問い:
+  - 新しい worktree capability が既存 runtime の dependency direction を崩さないか。
+- 範囲:
+  - `spec_dock_runtime` 内の package dependency。
+- 含めない詳細:
+  - file-level exhaustive dependency
+  - test helper dependency
+- 更新条件:
+  - layer を跨ぐ import 方向が変わるとき。
+
+### UML（package dependency）
+```plantuml
+@startuml
+skinparam monochrome true
+top to bottom direction
+
+package "cli" as cli
+package "commands" as commands
+package "application" as application
+package "domain" as domain
+package "infra" as infra
+package "presentation" as presentation
+
+cli --> commands : command registry / dispatch
+cli --> application : runtime use-case wiring
+commands --> application : request/result contracts
+commands --> presentation : render command output
+application --> domain : validation helpers if extracted
+application --> infra : only via Ports protocols at runtime wiring
+infra ..> application : implements protocols, no use-case import
+presentation --> application : result dataclasses only
+@enduml
+```
+
+設計判断:
+- `application.contracts.UseCases` に `worktree_create` callable を追加する。
+- `application.ports.GitGateway` は worktree-specific methods を追加してよい。ただし `make init` は Git の責務ではないため、別 protocol `BootstrapGateway` を追加する。
+- domain への抽出は optional とする。label validation / candidate naming が複数 issue で再利用される場合だけ `domain/worktree.py` のような pure helper に逃がす。
+
+## Domain Model（DDD 必要時）
+- N/A:
+  - この epic は domain aggregate を追加しない。
+  - Worktree は永続化対象の SpecDock domain entity ではなく、Git CLI によって作成される external working tree である。
+  - ただし実装上は pure value として `WorktreeCandidate` / `WorktreeCreateResult` 相当を application contract に置き、testable にする。
+
+## 契約
+### CLI
+- CLI-001:
+  - command:
+    - `spec-dock worktree create [LABEL]`
+  - LABEL:
+    - optional
+    - `^[a-z0-9-]+$` のみ許可
+  - success:
+    - exit code `0`
+    - stdout に id、worktree absolute path、branch、bootstrap result を出す
+  - fatal error:
+    - exit code `1`
+    - stderr に invalid label / detached HEAD / Git repo 外 / non-retryable Git failure / path failure を出す
+  - bootstrap failure:
+    - exit code `0`
+    - worktree 作成 success として扱う
+    - warning に `make init` failure を出す
+
+### Application Result
+- `WorktreeCreateRequest`:
+  - `label: str | None`
+- `WorktreeCreateResult`:
+  - `id: str`
+  - `main_worktree_path: Path`
+  - `container_path: Path`
+  - `worktree_path: Path`
+  - `branch_name: str`
+  - `bootstrap_status: "skipped" | "succeeded" | "failed" | "detection_failed"`
+  - `bootstrap_command: list[str] | None`
+  - `bootstrap_exit_code: int | None`
+  - `warnings: list[str]`
+- fatal failure:
+  - invalid input and non-retryable Git/path failures are raised as `RuntimeError` so existing dispatch returns exit code `1`.
+
+### データ境界
+- 正本:
+  - Git repository metadata is the source of truth for linked worktree records.
+  - SpecDock docs are source of truth for command contract and workflow guidance.
+- 一貫性モデル:
+  - Worktree creation is an external Git mutation, not a SpecDock tree mutation.
+  - No `sync` or active pointer update is triggered by this command.
+  - Bootstrap result is observational output only and is not persisted in SpecDock state.
+
+## データモデル
+- model / table 変更:
+  - なし。
+- file / state 変更:
+  - Git creates linked worktree metadata under Git common dir.
+  - Git creates a new branch.
+  - Files are checked out into `<main-parent>/<repo-basename>-worktrees/<repo-basename>-<id>`.
+  - Optional `make init` may create project-specific untracked files, but SpecDock does not define those files.
+- 不変条件:
+  - SpecDock must not create nested worktrees inside the main checkout.
+  - SpecDock must not copy secret-bearing env files.
+  - SpecDock must not mutate active selection.
+
+### UML（data model）
+- N/A:
+  - No SpecDock persistence model or DB schema is changed.
+
+## 主要フロー
+- Flow-A: successful create without label
+  1. CLI parses `worktree create`.
+  2. Command validates CLI shape and builds `WorktreeCreateRequest(label=None)`.
+  3. Application resolves current branch and main worktree path from Git.
+  4. Application derives container path `<main-parent>/<repo-basename>-worktrees`.
+  5. Application evaluates candidates `wt1`, `wt2`, ... against directory / branch / worktree record collisions.
+  6. Application calls Git gateway to add worktree with `-b <current-branch>-<id>`.
+  7. Application calls BootstrapGateway for optional `make init`.
+  8. Presentation emits absolute path and bootstrap result.
+- Flow-B: retryable collision
+  - Candidate collision found before add or during `git worktree add` with known retryable message.
+  - Application increments candidate id and retries until a usable candidate is found or candidate ceiling `10000` is exceeded.
+  - Candidate ceiling `10000` follows the reference product's proven upper bound and prevents infinite retry loops.
+  - If no candidate is found by `10000`, command exits `1` with a fatal message that includes label mode, last attempted id, container path, and the reason that candidates were exhausted.
+- Flow-C: bootstrap failure
+  - Worktree creation succeeds.
+  - `make init` exists but returns non-zero, or bootstrap detection fails for a reason other than target-missing.
+  - Application returns result with `bootstrap_status=failed` for executed `make init` failure, or `bootstrap_status=detection_failed` for detection failure.
+  - Command exits `0`.
+- Flow-D: non-retryable failure
+  - Invalid label, detached HEAD, repo outside Git, path creation failure, or unknown Git error.
+  - Application raises `RuntimeError`.
+  - Dispatch returns exit code `1`.
+
+- diagram metadata:
+  - タイトル:
+    - Worktree Create Main Sequence
+  - 答える問い:
+    - success / collision / bootstrap の分岐をどこで扱うか。
+  - 範囲:
+    - CLI から Git worktree add と optional make init まで。
+  - 含めない詳細:
+    - exact subprocess stderr text
+    - issue-level test helper setup
+  - 更新条件:
+    - participant / branch / transaction boundary が変わるとき。
+
+### UML（main sequence）
+```plantuml
+@startuml
+skinparam monochrome true
+actor Operator
+participant "CLI parser" as Parser
+participant "commands.worktree" as Command
+participant "application.worktree" as App
+participant "GitGateway" as Git
+participant "BootstrapGateway" as Boot
+participant "presentation.cli_text" as View
+
+Operator -> Parser : spec-dock worktree create [LABEL]
+Parser -> Command : WorktreeCreateArgs
+Command -> App : WorktreeCreateRequest
+App -> Git : current_branch_or_none()
+App -> Git : main_worktree_path()
+App -> Git : worktree_records()
+loop candidate until available
+  App -> App : build id/path/branch
+  App -> Git : branch_exists(branch)
+  App -> App : check directory and record collisions
+end
+App -> Git : add_worktree(branch, path)
+alt add succeeds
+  App -> Boot : run_make_init_if_available(path)
+  Boot --> App : skipped/succeeded/failed
+  App --> Command : WorktreeCreateResult
+  Command -> View : render_worktree_create_text(result)
+  View --> Operator : stdout + warnings
+else retryable add collision
+  Git --> App : retryable error
+  App -> App : next candidate
+else non-retryable failure
+  Git --> App : fatal error
+  App --> Command : RuntimeError
+  Command --> Operator : exit 1 via dispatch
+end
+@enduml
+```
+
+## State / Activity
+- State:
+  - N/A:
+    - SpecDock does not persist a worktree lifecycle state.
+- Activity:
+  - Required:
+    - Candidate selection and bootstrap have meaningful branches.
+- diagram metadata:
+  - タイトル:
+    - Worktree Candidate Activity
+  - 答える問い:
+    - 候補採番、retryable collision、fatal failure、bootstrap warning の分岐はどう進むか。
+  - 範囲:
+    - one command invocation.
+  - 含めない詳細:
+    - implementation order across issues.
+  - 更新条件:
+    - retry / bootstrap / fatal branch が変わるとき。
+
+### UML（activity）
+```plantuml
+@startuml
+skinparam monochrome true
+start
+:Validate label;
+if (inside Git repo and branch?) then (yes)
+  :Resolve main worktree and container;
+  :n = 1;
+  repeat
+    :Build id/path/branch candidate;
+    if (dir/branch/record collision?) then (yes)
+      :n = n + 1;
+    else (no)
+      :git worktree add -b branch path;
+      if (add success?) then (yes)
+        if (make init available?) then (yes)
+          :run make init;
+          if (make init success?) then (yes)
+            :bootstrap=succeeded;
+          else (no)
+            :bootstrap=failed warning;
+          endif
+        else (no)
+          :bootstrap=skipped;
+        endif
+        :render success result;
+        stop
+      else (no)
+        if (retryable collision?) then (yes)
+          :n = n + 1;
+        else (no)
+          :fatal Git/path error;
+          stop
+        endif
+      endif
+    endif
+  repeat while (n <= max)
+  :fatal no candidate;
+  stop
+else (no)
+  :fatal invalid context;
+  stop
+endif
+@enduml
+```
+
+## 失敗設計
+- 失敗モード:
+  - invalid label:
+    - before Git mutation; exit `1`.
+  - Git repo 外 / detached HEAD:
+    - before Git mutation; exit `1`.
+  - no candidate after retry ceiling:
+    - retry ceiling is fixed at `10000`.
+    - before Git mutation or after retryable collisions; exit `1`.
+    - fatal output includes label mode, last attempted id, container path, and exhaustion reason.
+  - non-retryable `git worktree add` failure:
+    - exit `1`; output includes command context and whether path exists / branch exists / record exists when observable.
+  - path creation / permission failure:
+    - exit `1`; do not retry as naming collision.
+  - `make init` missing:
+    - success with `bootstrap_status=skipped`.
+  - `make -n init` detection failure:
+    - if stderr/stdout indicates target missing, success with `bootstrap_status=skipped`.
+    - if `make` is not installed, Makefile parse/include fails, or detection fails for another reason, success with `bootstrap_status=detection_failed` and warning.
+    - detection failure is non-fatal because requirement fixes bootstrap as optional / non-fatal.
+  - `make init` failure:
+    - success with warning and `bootstrap_status=failed`.
+- リトライ:
+  - Only directory / branch / worktree record collision and recognized retryable `git worktree add` collision messages are retried.
+  - Unknown Git errors are not retried.
+- 冪等性:
+  - Re-running the same command creates the next available id; it is not idempotent by output identity.
+  - It is collision-safe: existing candidates are skipped.
+- 部分失敗:
+  - If Git reports failure after partial path creation, command reports observable state and exits `1`.
+  - It does not auto-remove partial directories or branches, because cleanup can be destructive and is outside this epic.
+  - `make init` failure is not partial worktree failure; it is a successful worktree with failed bootstrap.
+  - `make -n init` detection failure is likewise not partial worktree failure; it is a successful worktree with a bootstrap detection warning.
+
+## 移行戦略
+- 移行戦略:
+  - Additive runtime command; no existing command behavior changes.
+  - Provider-side source under `src/spec_dock/assets/spec_dock/...` is updated first.
+  - Dogfooding workspace `spec-dock/...` is refreshed/inspected as validation, not treated as implementation source.
+- 必要時の dual write/read:
+  - N/A. No persisted SpecDock state is migrated.
+- ロールバック:
+  - Code rollback removes the command entrypoint.
+  - Worktrees created before rollback remain normal Git linked worktrees and can be removed manually with `git worktree remove`.
+
+## 観測性 / セキュリティ
+- 観測性:
+  - Success output includes absolute `worktree_path`, `branch_name`, `id`, and `bootstrap_status`.
+  - Warnings are emitted through existing `CliText.warnings`, so `dispatch` prints them to stderr with `spec-dock: (warn)`.
+  - Fatal errors use existing `RuntimeError` -> dispatch stderr contract.
+- ロール / 認可:
+  - No GitHub or credentialed remote operation.
+  - Local filesystem and Git repository permissions determine access.
+- 監査 / PII:
+  - No PII or secret handling.
+  - Command must not copy `.env*` or other secret-bearing files.
+- 安全性:
+  - Label validation prevents path traversal and shell metacharacters.
+  - Subprocess calls use argv lists, not shell strings.
+  - `make init` is executed only with `cwd` set to the created worktree root.
+
+## テスト戦略
+- 単体:
+  - label validation.
+  - id candidate generation for no-label and label modes.
+  - main worktree normalization from linked worktree records.
+  - retryable vs non-retryable error classification.
+- CLI/runtime:
+  - `spec-dock worktree create` creates `<repo-basename>-worktrees/<repo-basename>-wt1`.
+  - repeated invocation creates `wt2`.
+  - label invocation creates `<label>` and branch `<current-branch>-<label>`.
+  - invalid labels fail before mutation.
+  - detached HEAD / Git repo 外 fail.
+  - linked-worktree invocation uses main worktree basename/container.
+  - `make init` success / skipped / detection failure / execution failure all render correct output and exit code.
+  - non-retryable Git/path failures exit `1`.
+- E2E:
+  - No browser/UI E2E.
+  - Optional dogfooding smoke can run command in a temp repo, not against this live checkout, to avoid creating unmanaged worktrees during tests.
+- E-AC 対応:
+  - E-AC-001 -> basic create runtime test.
+  - E-AC-002 -> collision / repeated create test.
+  - E-AC-003 -> label naming test.
+  - E-AC-004 -> invalid label test.
+  - E-AC-005 -> `make init` success test.
+  - E-AC-006 -> bootstrap skipped test, including missing `init` target.
+  - E-AC-007 -> bootstrap detection failure and execution failure are warning + exit `0`.
+  - E-AC-008 -> linked-worktree normalization test.
+  - E-AC-009 -> non-retryable Git/path failure tests.
+  - E-AC-010 -> detached/outside repo tests.
+  - E-AC-011 -> provider/dogfooding parity and docs/help checks.
+
+## 関連 ADR
+- ADR なし。
+- `discussions/20260522t075615z-disc-new-epic-reuse-decision.md`:
+  - worktree provisioning を既存 lifecycle / host asset epic に混ぜず、新規 epic として扱う判断。
+
+## 設計決定
+- Q-001:
+  - 質問:
+    - `make init` target existence をどの方法で判定するか。
+  - 選択肢:
+    - A:
+      - `make -q init` で target の有無と up-to-date 判定を兼ねる。
+    - B:
+      - `make -n init` で dry-run し、target missing かどうかだけを見る。
+    - C:
+      - `Makefile` text を parse する。
+  - 推奨案:
+    - B。実行前に shell ではなく argv で `make -n init` を呼び、target missing なら skipped、存在が確認できたら実際の `make init` を実行する。Makefile parse は include / generated makefile に弱い。
+  - 決定:
+    - B を採用する。
+    - BootstrapGateway は worktree root で `make -n init` を実行して target の有無を判定し、target が存在する場合だけ `make init` を実行する。
+    - `make -n init` が target missing 以外で失敗した場合は `bootstrap_status=detection_failed` とし、worktree 作成成功 + warning + exit code `0` とする。
+  - 影響範囲:
+    - BootstrapGateway implementation
+    - tests
+- Q-002:
+  - 質問:
+    - partial Git failure の詳細をどこまで structured result に入れるか。
+  - 選択肢:
+    - A:
+      - fatal failure は `RuntimeError` text に留める。
+    - B:
+      - application result に partial failure variant を作る。
+  - 推奨案:
+    - A。fatal failure は command success result ではないため、既存 dispatch contract に合わせて `RuntimeError` とする。観測可能な path/branch/record 状態は error text に含める。
+  - 決定:
+    - A を採用する。
+    - partial Git failure は success result variant にせず、既存 dispatch contract に合わせて `RuntimeError` text として返す。
+    - retryable collision の candidate ceiling は `10000` とし、超過時は `RuntimeError` text に label mode、last attempted id、container path、exhaustion reason を含める。
+  - 影響範囲:
+    - application error contract
+    - CLI tests

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/20260522t074811z-research-worktree-provisioning-requirement-analysis.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/20260522t074811z-research-worktree-provisioning-requirement-analysis.md
@@ -1,0 +1,128 @@
+---
+種別: research
+ID: "20260522t074811z-research"
+タイトル: "worktree provisioning requirement analysis"
+状態: "completed"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107"]
+関連: []
+authority: "synthesized"
+derived_from: []
+reflected_to: ["../requirement.md"]
+---
+
+# 20260522t074811z-research worktree provisioning requirement analysis
+
+## 位置づけ
+- 用途: 外部仕様、実装事実、先例、制約など、検証可能な根拠を整理する。
+- authority default: `synthesized`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 調査結果が選択肢比較を必要とする場合は `disc`、長期判断を支える場合は `adr`、人間判断を必要とする場合は `interview` へつなぐ。
+- 事実、推測、未検証事項、判断への含意を混ぜない。
+
+## 調査目的 (必須)
+- `spec-dock` に worktree 作成 command を追加する epic の requirement を固めるため、次を明らかにする。
+  - 既存 `spec-dock` runtime command architecture の追加先。
+  - 参照プロダクト `taikyohiyou_project-issue-1716` の worktree naming / branch naming / bootstrap の実用実装。
+  - Git / Codex app / AGENTS.md / local environment の一次情報から見た、worktree placement と bootstrap の制約。
+  - 今回の epic で閉じる scope と、将来 issue / future epic へ送る scope。
+
+## 調査方法 (必須)
+- ローカル repo 調査:
+  - `git status --short --branch`
+  - `find spec-dock/active -maxdepth 3 ...`
+  - `rg -n "worktree|MakeInit|make init|git worktree" src spec-dock tests`
+  - `sed -n` で runtime parser / registry / command / infra / test harness を確認。
+- 参照プロダクト調査:
+  - `rg -n "worktree|MakeInit|make init|COMPOSE_PROJECT_NAME|git worktree" /Users/iwasawayuuta/workspace/product/taikyohiyou_project-issue-1716`
+  - `scripts/worktree/create_worktree.sh`
+  - `Makefile`
+  - `docs/dynamic-worktree-support.md`
+- 外部一次情報:
+  - Git worktree manual: https://git-scm.com/docs/git-worktree
+  - Codex app worktrees: https://developers.openai.com/codex/app/worktrees
+  - Codex app local environments: https://developers.openai.com/codex/app/local-environments
+  - Codex AGENTS.md guidance: https://developers.openai.com/codex/guides/agents-md
+
+## 調査結果 (必須)
+- 現在の `spec-dock` 状態:
+  - active initiative / epic / issue は `spec-dock/system/active-none/...` を指しており、active context は未設定。
+  - `epic-00107-worktree-provisioning` は既に `init-local-00002` 配下に作成されているが、`requirement.md` はテンプレート未記入状態だった。
+  - `epic-00107` の `.meta.json` は GitHub issue `#107` と紐づいている。
+- 既存 epic との関係:
+  - `epic-00054` は close / delete / self-update の lifecycle command expansion を扱っており、worktree 作成の能力追加は含まない。
+  - `epic-00074` は host agent / config asset expansion を扱っており、worktree 作成 command とは別の feature capability である。
+  - 既存 epic へ混ぜるより、並行開発 capability として新規 epic にするのが自然である。
+- `spec-dock` runtime architecture:
+  - CLI parser は `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py` で top-level subcommand を定義する。
+  - command registry は `cli/registry.py` で `commands/*` の `command_specs()` を集約する。
+  - user-facing command args / output は `commands/` と `presentation/`、orchestration は `application/`、Git subprocess は `infra/git_cli.py` が既存の層である。
+  - runtime tests は `tests/cli_runtime/`、domain/presentation tests はそれぞれ `tests/domain_runtime/`, `tests/presentation_runtime/` に分かれている。
+- 参照プロダクトの worktree 実装:
+  - `Makefile` の `worktree` target は `make worktree <optional-label>` 形式で `scripts/worktree/create_worktree.sh "$DIR_ARG"` を呼ぶ。
+  - label 省略時は `wt1`, `wt2`, ... を使い、label 指定時は `<label>`, `<label>2`, ... を使う。
+  - label は `^[a-z0-9-]+$` のみを許可する。
+  - worktree directory は現在 checkout の basename に `-<id>` を足した sibling directory として合成する。
+  - branch name は現在 branch に `-<id>` を足して合成する。
+  - directory existence、branch existence、`git worktree list --porcelain` の record existence を事前確認し、衝突時は番号を進める。
+  - `git worktree add -b <new-branch> <path>` が、retryable な衝突で失敗した場合も番号を進める。
+  - 作成後に worktree root で `make init` を実行する。
+- 参照プロダクトの bootstrap contract:
+  - `docs/dynamic-worktree-support.md` は project-local bootstrap の正本を `make init` とし、worktree 作成後に worktree root で `make init` を呼ぶと明記している。
+  - 同 docs は secret-bearing env file copy や `.env.git` generation を通常 worktree setup へ戻さないことを明記している。
+- Git worktree 一次情報:
+  - Git は main worktree と linked worktree を同じ repository metadata に紐づけ、複数 branch の同時 checkout を可能にする。
+  - `git worktree add -b <branch> <path>` は新しい branch を作って worktree に checkout する。
+  - `git worktree list --porcelain` は script 用の安定した一覧形式として使える。
+  - 不要な linked worktree は `git worktree remove` で消すのが基本であり、手動削除後は `git worktree prune` / `repair` が必要になる場合がある。
+- Codex app 一次情報:
+  - Codex app は `$CODEX_HOME/worktrees` に worktree を作り、通常 detached HEAD で開始する。
+  - Codex app の Handoff は Git 操作で Local と Worktree の間を移すが、同じ branch は複数 worktree で同時 checkout できない。
+  - Codex local environments は worktree setup steps と common actions を `.codex` folder に保存できる。
+  - Codex は `AGENTS.md` を global / project / nested scope で読み込み、repo guidance を作業前に取り込む。
+
+## 推測 / 未検証事項 (必須)
+- 推測:
+  - ユーザー発話の「MakeInit」は、参照プロダクトと周辺文脈から `make init` を指すと解釈するのが自然である。
+  - worktree container は `../<repo-basename>-worktrees/` が望ましい。ユーザーは `.<suffix>` ではなく、ハイフンまたはアンダースコアを好むと述べており、既存 repo 名 `spec-dock` と lowercase path ルールにも `spec-dock-worktrees` が合う。
+  - container 配下の個別 worktree directory 名は、参照プロダクトの naming を維持するため `<repo-basename>-<id>` とするのが最も保守的である。
+- 未検証:
+  - `spec-dock` 自体の `make init` で実行すべき具体的 bootstrap 内容は、この requirement phase では未設計。
+  - worktree cleanup / list / status を同じ command family に入れるべきかは、今回の user request の主眼ではないため future extension として扱う。
+  - command family は requirement 反映時に `worktree create` 採用で確定した。`worktree cleanup / list / status` の追加有無は future extension として未検証である。
+
+## 判断への含意 (必須)
+- Requirement へ反映すること:
+  - この epic は `init-local-00002` の feature expansion として、SpecDock が repo-local runtime command から dedicated linked worktree を作成できる capability を提供する。
+  - `../<repo-basename>-worktrees/` container を標準 placement とし、repo 内 nested `.worktrees/` は採らない。
+  - linked worktree から実行された場合でも、container placement と repo basename は Git worktree list の main worktree を基準に正規化する。
+  - naming は参照プロダクトに合わせ、id は省略時 `wtN`、label 指定時 `<label>N`、branch は current branch + `-<id>`、directory は repo basename + `-<id>` を基本にする。
+  - label validation は lowercase alnum + hyphen のみを要求する。
+  - 作成後 bootstrap は worktree root の `make init` を optional / non-fatal にする。存在しなければ skip し、存在して失敗しても worktree 作成自体は exit code 0 の成功として扱う。ただし operator が追える warning / output は残す。
+  - Codex-managed worktree を置き換えるのではなく、手動管理の長命 worktree 作成を扱う。
+  - main checkout での実装作業を禁止する epic ではなく、複数変更の並行開発を支援する epic として扱う。
+- Design / plan へ送ること:
+  - `worktree create` command の application / infra / presentation 責務境界。
+  - Git subprocess adapter の責務境界。
+  - `make init` target existence check と non-fatal warning の表現。
+  - created path / branch / init status の output contract。
+  - provider-side runtime と dogfooding workspace の更新順。
+
+## リスク/制約 (任意)
+- `make init` failure を完全に無音化すると、依存関係や env setup の失敗を operator が見落とす。要件では「作成失敗にはしない」が、warning として観測可能にする。
+- branch name は current branch へ suffix を足すため、保護 branch 上で実行しても新 branch は別名になる。ただし current branch が detached HEAD の場合は作成を拒否する必要がある。
+- worktree container を repo 外へ作るため、permission / parent path の存在 / path collision を明確な failure として扱う必要がある。
+- `git worktree add` は branch が他 worktree で checkout 済みの場合に拒否する。command は collision detection と retry で扱える範囲だけ retry し、未知エラーは隠蔽しない。
+
+## 反映先 (任意)
+- reflected_to:
+  - `../requirement.md`
+
+## 参考（References） (任意)
+- Git worktree manual: https://git-scm.com/docs/git-worktree
+- Codex app worktrees: https://developers.openai.com/codex/app/worktrees
+- Codex app local environments: https://developers.openai.com/codex/app/local-environments
+- Codex AGENTS.md guidance: https://developers.openai.com/codex/guides/agents-md
+- `/Users/iwasawayuuta/workspace/product/taikyohiyou_project-issue-1716/scripts/worktree/create_worktree.sh`
+- `/Users/iwasawayuuta/workspace/product/taikyohiyou_project-issue-1716/Makefile`
+- `/Users/iwasawayuuta/workspace/product/taikyohiyou_project-issue-1716/docs/dynamic-worktree-support.md`

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/20260522t075615z-disc-new-epic-reuse-decision.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/20260522t075615z-disc-new-epic-reuse-decision.md
@@ -1,0 +1,65 @@
+---
+種別: disc
+ID: "20260522t075615z-disc"
+タイトル: "new epic reuse decision"
+状態: "completed"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107"]
+関連: []
+authority: "synthesized"
+derived_from: ["20260522t074811z-research"]
+reflected_to: ["../requirement.md"]
+---
+
+# 20260522t075615z-disc new epic reuse decision
+
+## 位置づけ
+- 用途: 集まった情報をもとに、論点、評価軸、選択肢、合意点/未合意点を整理する。
+- authority default: `proposed`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 人間から回答を引き出し、回答欄や未回答事項を管理する場合は `interview` を使う。
+- 生ログや未整理の思考は `scratch`、事実確認や外部根拠は `research`、長期判断の固定は `adr` に分ける。
+- doc が大きくなりすぎたら、質問回答は `interview`、事実調査は `research`、raw capture は `scratch`、長期決定は `adr` へ分割する。
+
+## 議題 (必須)
+- `worktree` 作成 capability を既存 epic に追記するか、新しい epic `epic-00107 Worktree Provisioning` として扱うかを整理する。
+
+## 背景 (必須)
+- `init-local-00002` は feature expansion initiative であり、operator が日常的に使う command / workflow capability を価値単位で増やすことを目的にしている。
+- 既存 `epic-00054` は GitHub issue close、local node delete、repo-local self-update を扱う lifecycle command expansion であり、Git linked worktree 作成や branch/path/bootstrap naming は scope に含めていない。
+- 既存 `epic-00074` は host agent / config asset expansion であり、worktree 作成 command とは機能価値も影響範囲も異なる。
+- 今回の user intent は、`spec-dock` 自身を複数変更の並行開発に対応させるため、worktree 作成 command を runtime command 群へ追加することである。
+- worktree 作成は Git subprocess、path placement、branch naming、optional `make init` bootstrap、Codex-managed worktree との境界を含むため、既存 lifecycle / host asset epic に混ぜると設計の背骨が濁る。
+
+## 選択肢 (必須)
+- Option A:
+  - 既存 `epic-00054 GitHub lifecycle command expansion` に追加する。
+  - Pros:
+    - command expansion という大枠には近い。
+    - 既存 runtime command 追加の文脈を流用できる。
+  - Cons:
+    - `epic-00054` は close / delete / self-update の lifecycle gap を閉じる epic であり、parallel development workspace provisioning とは受け入れ条件が異なる。
+    - worktree path / branch naming / bootstrap / Codex boundary を追加すると、完了済みまたは進行済みの lifecycle contract が膨らむ。
+- Option B:
+  - 新規 `epic-00107 Worktree Provisioning` として扱う。
+  - Pros:
+    - 並行開発用 worktree 作成 capability を、独立した operator value として requirement / design / plan へ落とせる。
+    - Git worktree placement、naming、bootstrap、Codex-managed worktree との境界をこの epic の背骨として扱える。
+    - 将来の worktree status / remove / dashboard は同じ capability area の future extension として整理しやすい。
+  - Cons:
+    - command expansion epic が増えるため、initiative plan 上では `epic-00054` との関係を明記する必要がある。
+
+## 推奨案 (必須)
+- Option B。
+- worktree 作成は `spec-dock` の GitHub lifecycle 操作や host asset 配布とは別の operator capability であり、placement / naming / bootstrap / parallel development policy を一つの requirement として閉じる必要がある。
+- 既存 epic へ追記すると scope と acceptance criteria が混ざるため、新規 epic として管理する方が `workflow_epic.md` の「設計の背骨」を保てる。
+
+## 未決事項 (任意)
+- なし。CLI shape は `spec-dock worktree create [LABEL]`、output は absolute path 主表示として requirement で確定済みである。
+
+## 次アクション (必須)
+- `requirement.md` / `design.md` / `plan.md` / `adr` へ反映する内容:
+  - `requirement.md` は、worktree 作成 capability を `epic-00107` の scope として固定する。
+  - `epic-00054` / `epic-00074` は関連既存 epic として調査済みだが、本 epic へ統合しない。
+- 追加で作る discussion docs:
+  - なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../docs/rules/epic/discussions.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/.meta.json
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00108",
+  "title": "Worktree create CLI and output",
+  "slug": "worktree-create-cli-and-output",
+  "created_at": "2026-05-22T18:13:46+09:00",
+  "updated_at": "2026-05-22T18:13:46+09:00",
+  "parent_id": "epic-00107",
+  "initiative_id": "init-local-00002",
+  "epic_id": "epic-00107",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 108,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/design.md
@@ -1,0 +1,31 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00108"
+タイトル: "Worktree create CLI and output"
+関連GitHub: ["#108"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md", "iss-00110"]
+---
+
+# iss-00108 Worktree create CLI and output — 設計
+
+## 方針
+- 既存 command pattern に合わせて `commands/worktree.py` を追加し、parser の `worktree` group へ `create` leaf を bind する。
+- text rendering は `presentation/cli_text.py` に閉じ、command handler は request/result 変換だけを行う。
+
+## 変更点
+- `commands/worktree.py`: argument parsing と use case call。
+- `cli/parser.py`: `worktree create [LABEL]` subcommand。
+- `cli/registry.py`: command specs registration。
+- `cli/bootstrap.py`: application use case と infra gateways wiring。
+- `presentation/cli_text.py`: `render_worktree_create_text`。
+
+## テスト戦略
+- `tests/cli_runtime/test_worktree.py` の runtime command tests で parser/registry/bootstrap/rendering を統合確認する。
+- invalid label の non-zero は dispatch error path の smoke として確認する。
+
+## ロールバック
+- `worktree` command spec と parser group を削除すれば command surface を戻せる。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/plan.md
@@ -1,0 +1,74 @@
+---
+種別: 計画書（Issue）
+ID: "iss-00108"
+タイトル: "Worktree create CLI and output"
+関連GitHub: ["#108"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md", "design.md", "iss-00110"]
+---
+
+# iss-00108 Worktree create CLI and output — 計画
+
+## この計画で満たす要件ID
+- E-RQ-001, E-RQ-007, E-RQ-010
+- E-AC-001, E-AC-005, E-AC-007, E-AC-009, E-AC-010
+
+## Spec-Locked Closure Index
+| id | locked expectation | prevents | required | evidence level |
+|---|---|---|---:|---|
+| wt-cli-001 | `worktree create [LABEL]` が parser/registry/bootstrap を通って実行される | command 未登録回帰 | yes | runtime test |
+| wt-cli-002 | output が id/branch/path/bootstrap status を含む | user が作成先を特定できない回帰 | yes | runtime test |
+| wt-cli-003 | fatal error は non-zero で stderr に出る | failure が success に見える回帰 | yes | runtime test |
+
+## ステップ一覧
+
+### S01 CLI wiring and text output
+- behavior goal: core use case を user-facing command にする。
+- planned contract:
+  - scope: `commands/worktree.py`, `cli/parser.py`, `cli/registry.py`, `cli/bootstrap.py`, `presentation/cli_text.py`, `tests/cli_runtime/test_worktree.py`
+  - test obligation: `wt-cli-001`..`wt-cli-003`
+  - red or alternative evidence requirement: command missing red / invalid-label fail path characterization
+  - green verification: `python -m unittest tests.cli_runtime.test_worktree -v`
+  - refactor guardrail: existing command groups の arguments を変更しない。
+  - amendment trigger: JSON output や remove/status command が必要になった場合。
+- delegation contract:
+  - delegated role: `dev-coder`
+  - input docs: this issue docs and iss-00110 contracts
+  - allowed paths: planned contract scope
+  - forbidden changes: core naming rule changes, docs-only updates
+  - acceptance criteria: closure index all rows
+  - required tests: targeted runtime command tests
+  - reviewer focus: code-reviewer
+  - stop conditions: command output contract に additional fields が必要になった場合
+  - output required: changed files, verification result, ledger note
+#### 具体テストケース一覧
+- `tc-s01-001` acceptance: command creates worktree through CLI
+  - 前提: temp repo の initial commit がある。
+  - 操作: `worktree create` を実行する。
+  - 期待結果: exit 0 で worktree が作られ、stdout に id/branch/path/bootstrap が出る。
+  - 失敗検出: parser/registry/bootstrap/rendering の未接続を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-cli-001`, `wt-cli-002`
+- `tc-s01-002` negative: invalid label returns non-zero
+  - 前提: temp repo に worktree container がない。
+  - 操作: `worktree create bad_label` を実行する。
+  - 期待結果: exit non-zero、stderr に invalid label が出る。
+  - 失敗検出: fatal error が成功扱いになる回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-cli-003`
+- step closure contract: closure index all rows pass via targeted tests.
+- report evidence destination: issue report Step/Test Contract Closure.
+- step gate: targeted test pass, code-reviewer pass, commit gate.
+
+## S90 docs impact resolution / docs refresh
+- docs は iss-00109 の rollout step で扱う。
+
+## S99 final quality gate
+- epic final gate は iss-00109 へ集約する。
+
+## Final Exit Contract
+- CLI runtime tests pass。
+- command surface が reference docs と一致する状態へ iss-00109 で引き継がれる。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/report.md
@@ -1,0 +1,37 @@
+---
+種別: 実行レポート（Issue）
+ID: "iss-00108"
+タイトル: "Worktree create CLI and output"
+関連GitHub: ["#108"]
+状態: "in_progress"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00108 Worktree create CLI and output — report
+
+## Parent Implementation Exception
+- Reason: same-session host policy restricts write-capable subagent delegation.
+- Allowed files: CLI command, parser, registry, bootstrap, presentation, targeted tests.
+- Post-change verification: `python -m unittest tests.cli_runtime.test_worktree -v`.
+- Reviewer gate: pending final code/spec review.
+
+## Step Contract Closure
+- S01 / wt-cli-001: pass via targeted runtime tests, including CLI create and help smoke.
+- S01 / wt-cli-002: pass via output assertions for id, branch, absolute path, and bootstrap status.
+- S01 / wt-cli-003: pass via invalid label / detached HEAD / outside repo / path failure CLI tests.
+
+## Test Contract Closure
+- `python -m unittest tests.cli_runtime.test_worktree -v`: pass, 15 tests.
+- `python -m unittest tests.cli_runtime.test_worktree tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets -v`: pass, 17 tests.
+- `./spec-dock/scripts/spec-dock worktree create --help`: pass.
+
+## Spec Interpretation / Decision Ledger
+- No material interpretation changes beyond the approved epic design.
+- No decision entries.
+
+## Reviewer Gate Status
+- final code-reviewer: passed, no findings.
+- final qa-reviewer: passed, P2 follow-up test-depth suggestions only.
+- final spec-reviewer: passed.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/requirement.md
@@ -1,0 +1,33 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00108"
+タイトル: "Worktree create CLI and output"
+関連GitHub: ["#108"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00108 Worktree create CLI and output — 要件定義
+
+## 目的
+- core use case を `./spec-dock/scripts/spec-dock worktree create [LABEL]` として公開する。
+- 成功時に absolute path、id、branch、bootstrap status を読める CLI output を提供する。
+
+## スコープ
+- 必須:
+  - `worktree create` parser / registry / command wiring。
+  - `UseCases.worktree_create` bootstrap wiring。
+  - CLI text rendering。
+- 禁止:
+  - core naming / bootstrap rule の再定義。
+  - docs-only の拡張。
+
+## 受け入れ条件
+- AC-001: `worktree create` が runtime help と dispatch に存在する。
+- AC-002: 成功時 output が id、branch、absolute path、bootstrap status を含む。
+- AC-003: invalid label や fatal use-case error は existing dispatch error path で non-zero になる。
+
+## 未確定事項
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/.meta.json
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00109",
+  "title": "Worktree docs dogfooding and final verification",
+  "slug": "worktree-docs-dogfooding-and-final-verification",
+  "created_at": "2026-05-22T18:13:46+09:00",
+  "updated_at": "2026-05-22T18:13:46+09:00",
+  "parent_id": "epic-00107",
+  "initiative_id": "init-local-00002",
+  "epic_id": "epic-00107",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 109,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/design.md
@@ -1,0 +1,32 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00109"
+タイトル: "Worktree docs dogfooding and final verification"
+関連GitHub: ["#109"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md", "iss-00108"]
+---
+
+# iss-00109 Worktree docs dogfooding and final verification — 設計
+
+## 方針
+- provider docs を先に更新し、dogfooding workspace は shipped asset parity として同内容を持たせる。
+- final verification は runtime tests と spec-dock validate/sync を分けて記録する。
+
+## 変更点
+- `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+- `src/spec_dock/assets/spec_dock/docs/guide.md`
+- `spec-dock/docs/reference_worktree.md`
+- `spec-dock/docs/guide.md`
+- dogfooding `spec-dock/scripts/spec_dock_runtime/**` parity after update/copy path。
+
+## テスト戦略
+- docs は spec-reviewer の docs/spec alignment で確認する。
+- runtime parity は `./spec-dock/scripts/spec-dock worktree create --help` と targeted tests で確認する。
+- final tree は `./spec-dock/scripts/spec-dock validate` / `sync` で確認する。
+
+## ロールバック
+- docs additions と dogfooding copied runtime changes を provider assets と同期前の状態へ戻す。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/plan.md
@@ -1,0 +1,94 @@
+---
+種別: 計画書（Issue）
+ID: "iss-00109"
+タイトル: "Worktree docs dogfooding and final verification"
+関連GitHub: ["#109"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md", "design.md", "iss-00108"]
+---
+
+# iss-00109 Worktree docs dogfooding and final verification — 計画
+
+## この計画で満たす要件ID
+- E-RQ-008, E-RQ-009, E-RQ-010
+- E-AC-011 and final E-AC rollup
+
+## Spec-Locked Closure Index
+| id | locked expectation | prevents | required | evidence level |
+|---|---|---|---:|---|
+| wt-doc-001 | provider and dogfooding docs explain command, layout, bootstrap, scope boundary | stale or misleading user docs | yes | docs diff + review |
+| wt-doc-002 | dogfooding runtime exposes `worktree create` | provider-only implementation drift | yes | command/help smoke |
+| wt-doc-003 | final validation/sync/tests pass | incomplete rollout | yes | commands |
+
+## ステップ一覧
+
+### S01 docs and dogfooding parity
+- behavior goal: shipped docs と dogfooding docs/runtime を一致させる。
+- planned contract:
+  - scope: docs and generated dogfooding runtime parity files
+  - test obligation: docs/spec alignment and command smoke
+  - red or alternative evidence requirement: inspect-only for docs; command smoke for runtime parity
+  - green verification: `./spec-dock/scripts/spec-dock worktree create --help`
+  - refactor guardrail: workflow_issue semantics は変更しない。
+  - amendment trigger: documented command が implementation と不一致の場合。
+- delegation contract:
+  - delegated role: `doc-writer`
+  - input docs: epic requirement/design/plan and issue docs
+  - allowed paths: docs and dogfooding parity files
+  - forbidden changes: runtime behavior changes beyond provider parity
+  - acceptance criteria: `wt-doc-001`, `wt-doc-002`
+  - required tests/docs-only verification: command help smoke, docs review
+  - reviewer focus: spec-reviewer
+  - stop conditions: docs need new feature scope
+  - output required: changed files, verification result, ledger note
+#### 具体テストケース一覧
+- `tc-s01-001` docs alignment: reference docs mention sibling container
+  - 前提: provider docs and dogfooding docs exist.
+  - 操作: docs diff / inspection.
+  - 期待結果: command, layout, bootstrap, scope boundary が一致する。
+  - 失敗検出: nested `.worktrees/` や Codex-managed replacement を示す stale docs を検出する。
+  - 検証方法: spec-reviewer docs/spec alignment.
+  - 関連 closure id: `wt-doc-001`
+- `tc-s01-002` command smoke: dogfooding runtime exposes help
+  - 前提: dogfooding runtime has been updated from provider assets.
+  - 操作: `./spec-dock/scripts/spec-dock worktree create --help`
+  - 期待結果: command help exits 0 and shows optional label.
+  - 失敗検出: dogfooding runtime drift を検出する。
+  - 検証方法: shell command.
+  - 関連 closure id: `wt-doc-002`
+
+### S99 final quality gate
+- behavior goal: epic 全体の evidence を揃える。
+- planned contract:
+  - scope: final tests, validate/sync, report rollup
+  - test obligation: `wt-doc-003`
+  - red or alternative evidence requirement: final gate only
+  - green verification: `python -m unittest discover -v`, `./spec-dock/scripts/spec-dock validate`, `./spec-dock/scripts/spec-dock sync`, `git diff --check`
+  - refactor guardrail: test failure fixes must stay within epic scope.
+  - amendment trigger: new requirement or untested failure class is discovered.
+- delegation contract:
+  - delegated role: reviewer gates
+  - input docs: all epic and issue docs plus diff
+  - allowed paths: report updates and bounded fixes if needed
+  - forbidden changes: broad refactor
+  - acceptance criteria: all epic E-AC evidence pass
+  - required verification: final commands and reviewer passes
+  - reviewer focus: qa-reviewer, code-reviewer, spec-reviewer
+  - stop conditions: required gate unavailable/fail without fix
+  - output required: verdicts and unresolved risks
+#### 具体テストケース一覧
+- `tc-s99-001` final verification: runtime and spec tree pass
+  - 前提: implementation and docs are complete.
+  - 操作: final verification commands.
+  - 期待結果: tests, validate, sync, diff check pass.
+  - 失敗検出: rollout 不足や spec tree 不整合を検出する。
+  - 検証方法: listed commands.
+  - 関連 closure id: `wt-doc-003`
+
+## Final Exit Contract
+- docs parity and runtime parity are confirmed.
+- final reports contain verification and reviewer evidence.
+- one epic-level PR is created after all three issues are complete.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/report.md
@@ -1,0 +1,51 @@
+---
+種別: 実行レポート（Issue）
+ID: "iss-00109"
+タイトル: "Worktree docs dogfooding and final verification"
+関連GitHub: ["#109"]
+状態: "in_progress"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00109 Worktree docs dogfooding and final verification — report
+
+## Parent Implementation Exception
+- Reason: docs/runtime parity was updated locally under host policy; write-capable delegation was not available without explicit subagent delegation request.
+- Allowed files: provider docs, dogfooding docs/runtime parity, final report.
+- Post-change verification: final verification commands recorded below.
+- Reviewer gate: pending final spec/code/QA review.
+
+## Step Contract Closure
+- S01 / wt-doc-001: provider and dogfooding docs updated with reference_worktree.
+- S01 / wt-doc-002: dogfooding runtime contains worktree command after local update path partially succeeded.
+- S99 / wt-doc-003: pass via targeted tests, full unittest, validate, sync, command help, and diff check.
+
+## Test Contract Closure
+- `./spec-dock/scripts/spec-dock worktree create --help`: pass.
+- `python -m unittest tests.cli_runtime.test_worktree tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets -v`: pass, 17 tests.
+- `python -m unittest discover -v`: pass, 827 tests.
+- `./spec-dock/scripts/spec-dock validate`: pass, `nodes=50`.
+- `./spec-dock/scripts/spec-dock sync`: pass and updated active from branch `epic-00107`.
+- `git diff --check`: pass.
+
+## Reviewer Gate Status
+- final code-reviewer: passed, no findings.
+- final qa-reviewer: passed, P2 follow-up test-depth suggestions only.
+- final spec-reviewer: passed, P2 plan traceability suggestion addressed in `iss-00110/plan.md`.
+
+## Spec Interpretation / Decision Ledger
+- DEC-001:
+  - Status: resolved
+  - Type: tooling deviation
+  - Trigger: `uvx --from . spec-dock update .` failed on external uv cache permission.
+  - Disposition: applied
+  - Evidence: `PYTHONPATH=src python -m spec_dock.cli update .` partially updated dogfooding runtime before managed `.agents` permission failure; targeted `rg` confirmed worktree runtime files are present under dogfooding workspace.
+  - Follow-up: resolved by command smoke, parity tests, validate/sync, and full unittest.
+- DEC-002:
+  - Status: resolved
+  - Type: reviewer follow-up
+  - Trigger: reviewer found new worktree docs/runtime assets were missing from parity maps.
+  - Disposition: applied
+  - Evidence: added `reference_worktree.md`, `application/worktree.py`, `commands/worktree.py`, and `infra/make_cli.py` to parity maps; targeted parity tests pass.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/requirement.md
@@ -1,0 +1,33 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00109"
+タイトル: "Worktree docs dogfooding and final verification"
+関連GitHub: ["#109"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00109 Worktree docs dogfooding and final verification — 要件定義
+
+## 目的
+- `worktree create` の shipped docs と dogfooding workspace を整え、epic 全体の verification evidence を集約する。
+
+## スコープ
+- 必須:
+  - provider-side docs under `src/spec_dock/assets/spec_dock/docs/`。
+  - dogfooding docs / runtime parity。
+  - targeted tests、full relevant tests、`validate`、`sync`。
+  - Codex-managed worktree は scope 外であることの明記。
+- 禁止:
+  - feature scope を `remove` / `status` / `prune` へ広げる。
+
+## 受け入れ条件
+- AC-001: shipped docs と dogfooding docs が `worktree create [LABEL]`、sibling container、bootstrap rule、scope boundary を説明する。
+- AC-002: dogfooding runtime で `worktree create` command が存在する。
+- AC-003: final verification で targeted runtime tests、validate、sync が pass する。
+- AC-004: final report が E-AC-001..E-AC-011 を closure evidence に紐付ける。
+
+## 未確定事項
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/.meta.json
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/.meta.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": 1,
+  "type": "issue",
+  "id": "iss-00110",
+  "title": "Worktree create core use case",
+  "slug": "worktree-create-core-use-case",
+  "created_at": "2026-05-22T18:13:46+09:00",
+  "updated_at": "2026-05-22T18:13:46+09:00",
+  "parent_id": "epic-00107",
+  "initiative_id": "init-local-00002",
+  "epic_id": "epic-00107",
+  "_spec_dock": {
+    "managed": true,
+    "do_not_edit": true,
+    "edit_via": "spec-dock"
+  },
+  "github": {
+    "issue_number": 110,
+    "repo_owner": "chemitaro",
+    "repo_name": "spec-dock"
+  }
+}

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/design.md
@@ -1,0 +1,55 @@
+---
+種別: 設計書（Issue）
+ID: "iss-00110"
+タイトル: "Worktree create core use case"
+関連GitHub: ["#110"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md"]
+---
+
+# iss-00110 Worktree create core use case — 設計
+
+## 方針
+- `application/worktree.py` に pure orchestration を置き、Git と make の副作用は ports 経由に分離する。
+- worktree list の stable input は `git worktree list --porcelain` とし、main worktree は Git の出力順の先頭として扱う。
+- bootstrap は `BootstrapGateway` で `BootstrapResult` に集約し、failure を例外化しない。
+
+## 変更点
+- `application/contracts.py`
+  - `GitWorktreeRecord`
+  - `BootstrapResult`
+  - `WorktreeCreateRequest`
+  - `WorktreeCreateResult`
+  - `UseCases.worktree_create`
+- `application/ports.py`
+  - `GitGateway.worktree_list`
+  - `GitGateway.add_worktree_with_new_branch`
+  - `BootstrapGateway`
+  - `Ports.bootstrap_gateway`
+- `application/worktree.py`
+  - label validation、candidate generation、collision retry、bootstrap aggregation。
+- `infra/git_cli.py`
+  - porcelain parser、linked worktree add wrapper。
+- `infra/make_cli.py`
+  - `make -n init` detection と `make init` execution。
+
+## 依存関係
+```mermaid
+flowchart TD
+  command["commands/worktree.py"] --> usecase["application/worktree.py"]
+  usecase --> gitport["GitGateway"]
+  usecase --> bootport["BootstrapGateway"]
+  gitport --> gitcli["infra/git_cli.py"]
+  bootport --> makecli["infra/make_cli.py"]
+```
+
+## テスト戦略
+- `tests/cli_runtime/test_worktree.py` で temp repo を作り、real Git worktree による integration evidence を取る。
+- make は controlled Makefile で success path を検証し、missing target は real `make -n init` の skipped path で検証する。
+- live checkout には worktree を作らず、temp directory のみ使う。
+
+## ロールバック
+- `application/worktree.py`、`infra/make_cli.py`、追加 contract と adapter method を削除すれば既存 command surface への影響を戻せる。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/discussions/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/discussions/rules.md
@@ -1,0 +1,1 @@
+../../../../../../../docs/rules/issue/discussions.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/plan.md
@@ -1,0 +1,114 @@
+---
+種別: 計画書（Issue）
+ID: "iss-00110"
+タイトル: "Worktree create core use case"
+関連GitHub: ["#110"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+依存: ["requirement.md", "design.md"]
+---
+
+# iss-00110 Worktree create core use case — 計画
+
+## この計画で満たす要件ID
+- E-RQ-002, E-RQ-003, E-RQ-004, E-RQ-005, E-RQ-006
+- E-AC-002, E-AC-003, E-AC-004, E-AC-006, E-AC-007, E-AC-008, E-AC-009, E-AC-010
+
+## 依存関係から導く実装順序
+1. application contracts / ports を追加する。
+2. Git / make infra adapter を追加する。
+3. `application/worktree.py` の use case を実装する。
+4. temp repo integration tests で naming、retry、bootstrap、linked-worktree normalization を確認する。
+
+## Spec-Locked Closure Index
+| id | locked expectation | prevents | required | evidence level |
+|---|---|---|---:|---|
+| wt-core-001 | LABEL なしは `wtN`、LABEL ありは `<label>N` で collision retry する | branch/path 衝突で作成不能になる回帰 | yes | runtime test |
+| wt-core-002 | container は main worktree の sibling `<repo>-worktrees/` | nested checkout / linked 起点 path 逸脱 | yes | runtime test |
+| wt-core-003 | invalid label は作成前 fatal | unsafe path / branch name | yes | runtime test |
+| wt-core-004 | bootstrap result は skipped/succeeded/failed/detection_failed を保持し、failure は non-fatal | setup failure で worktree 作成が消える回帰 | yes | runtime test |
+| wt-core-005 | non-retryable path/Git failure は原因と `path_exists` / `branch_exists` / `record_exists` を出す | partial artifact state が見えない failure contract 回帰 | yes | runtime test |
+
+## ステップ一覧
+
+### S01 core use case and adapters
+- behavior goal:
+  - worktree creation の core contract を実装する。
+- planned contract:
+  - scope: `application/contracts.py`, `application/ports.py`, `application/worktree.py`, `infra/git_cli.py`, `infra/make_cli.py`, `tests/cli_runtime/test_worktree.py`
+  - test obligation: closure index 全行を temp repo runtime tests へ対応させる。
+  - red or alternative evidence requirement: new command 未実装のため targeted test は red から開始可能。
+  - green verification: `python -m unittest tests.cli_runtime.test_worktree -v`
+  - refactor guardrail: existing issue/new/sync command behavior へ触れない。
+  - amendment trigger: Codex-managed worktree 管理や remove/list が必要になった場合。
+- delegation contract:
+  - delegated role: `dev-coder`
+  - input docs: epic requirement/design/plan, this issue requirement/design/plan
+  - allowed paths: planned contract scope の runtime / tests
+  - forbidden changes: docs-only work, GitHub lifecycle close, unrelated commands
+  - acceptance criteria: `wt-core-001`..`wt-core-005`
+  - required tests: targeted runtime tests
+  - reviewer focus: code-reviewer
+  - stop conditions: real project checkout へ worktree を作る必要が出た場合
+  - output required: changed files, verification result, ledger note
+#### 具体テストケース一覧
+- `tc-s01-001` acceptance: auto id creates sibling worktree
+  - 前提: temp repo の initial commit がある。
+  - 操作: `worktree create` を実行する。
+  - 期待結果: `<repo>-worktrees/<repo>-wt1` と `<current-branch>-wt1` が作られる。
+  - 失敗検出: nested path や branch naming の回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-001`, `wt-core-002`
+- `tc-s01-002` acceptance: label collision retries
+  - 前提: temp repo で同じ label を二回使う。
+  - 操作: `worktree create feature` を二回実行する。
+  - 期待結果: `feature` と `feature2` が作られる。
+  - 失敗検出: collision retry 不足を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-001`
+- `tc-s01-003` negative: invalid label fails before mutation
+  - 前提: temp repo に worktree container がない。
+  - 操作: `worktree create bad_label` を実行する。
+  - 期待結果: non-zero exit で container が作られない。
+  - 失敗検出: unsafe label を受け入れる回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-003`
+- `tc-s01-004` acceptance: make init status is reported
+  - 前提: temp repo に `init` target のある Makefile を置く。
+  - 操作: `worktree create setup` を実行する。
+  - 期待結果: bootstrap `succeeded` で marker file が作られる。
+  - 失敗検出: bootstrap 実行漏れを検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-004`
+- `tc-s01-005` acceptance: linked worktree normalizes container
+  - 前提: temp repo で linked worktree を作成済み。
+  - 操作: linked worktree から `worktree create inner` を実行する。
+  - 期待結果: main checkout の sibling container に worktree が作られる。
+  - 失敗検出: linked 起点に nested container を作る回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-002`
+- `tc-s01-006` negative: non-retryable failure reports artifact state
+  - 前提: container creation failure または non-retryable `git worktree add` failure を発生させる。
+  - 操作: `worktree create` または use case を実行する。
+  - 期待結果: エラーに原因と `artifact_state=path_exists:<bool>,branch_exists:<bool>,record_exists:<bool>` が含まれる。
+  - 失敗検出: partial artifact state を観測できない failure contract 回帰を検出する。
+  - 検証方法: `tests/cli_runtime/test_worktree.py`
+  - 関連 closure id: `wt-core-005`
+- step closure contract:
+  - `wt-core-001`..`wt-core-005` が targeted test で pass。
+- report evidence destination:
+  - `report.md` の Test Contract Closure / Step Contract Closure。
+- step gate:
+  - targeted test pass、code-reviewer pass、commit gate。
+
+## S90 docs impact resolution / docs refresh
+- この issue では docs 更新を行わず、iss-00109 に委譲する。
+
+## S99 final quality gate
+- epic final gate は iss-00109 で集約する。
+
+## Final Exit Contract
+- `python -m unittest tests.cli_runtime.test_worktree -v` が pass。
+- core runtime files と tests の diff が issue requirement/design に追跡できる。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/report.md
@@ -1,0 +1,70 @@
+---
+種別: 実行レポート（Issue）
+ID: "iss-00110"
+タイトル: "Worktree create core use case"
+関連GitHub: ["#110"]
+状態: "in_progress"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00110 Worktree create core use case — report
+
+## Workflow Delegation Consent
+- Source: user requested epic and issue workflows; host policy restricts spawning to explicit requests, so implementation was executed locally with Parent Implementation Exception.
+
+## Parent Implementation Exception
+- Reason: current host policy does not allow write-capable subagent delegation unless explicitly requested; user requested workflow execution but not subagent delegation.
+- User approval: epic implementation request in current session.
+- Allowed files: runtime core and targeted tests listed in plan S01.
+- Rollback plan: revert S01 files or remove worktree command wiring.
+- Post-change verification: `python -m unittest tests.cli_runtime.test_worktree -v`.
+- Reviewer gate: pending final code/spec review.
+
+## Step Contract Closure
+- S01 / wt-core-001: pass via auto id, label retry, slash-current-branch, and non-collision Git failure tests.
+- S01 / wt-core-002: pass via sibling container and linked-worktree normalization tests.
+- S01 / wt-core-003: pass via invalid label matrix covering underscore, uppercase, dot, slash, spaces, leading whitespace, whitespace-only labels, and shell metacharacters.
+- S01 / wt-core-004: pass via bootstrap skipped, succeeded, failed, and detection_failed tests.
+- S01 / wt-core-005: pass via container creation failure and non-retryable `git worktree add` artifact-state tests.
+
+## Test Contract Closure
+- `python -m unittest tests.cli_runtime.test_worktree -v`: pass, 15 tests.
+- `python -m unittest tests.cli_runtime.test_worktree tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets -v`: pass, 17 tests.
+- Covered behavior:
+  - sibling container and branch naming
+  - label collision retry
+  - no-label auto-id collision retry
+  - add-time retryable Git collision
+  - raw invalid-label rejection
+  - command help exposing optional label
+  - current branch containing slash
+  - make init skipped/succeeded/failed/detection_failed
+  - detached HEAD
+  - outside Git repo
+  - container path failure
+  - non-collision `cannot lock ref` fatal classification with artifact-state output
+  - linked worktree normalization
+
+## Closure Delta
+- No requirement closure removed.
+- Environment-derived test expectation adjusted without changing product contract.
+- Reviewer finding resolved:
+  - whitespace labels are rejected without normalization.
+  - `invalid reference` and broad `cannot lock ref` retry classification removed.
+  - failure-path tests added before final close-out.
+  - artifact-state output now includes path, branch, and worktree-record state for non-retryable failures.
+
+## Spec Interpretation / Decision Ledger
+- DEC-001:
+  - Status: resolved
+  - Type: implementation deviation
+  - Trigger: workflow delegated-by-default policy vs host policy.
+  - Disposition: applied as Parent Implementation Exception.
+  - Evidence: targeted tests pass; final code-reviewer / qa-reviewer / spec-reviewer gates pass.
+
+## Reviewer Gate Status
+- final code-reviewer: passed, no findings.
+- final qa-reviewer: passed, P2 follow-up test-depth suggestions only.
+- final spec-reviewer: passed, P2 plan traceability suggestion addressed by adding `wt-core-005` and `tc-s01-006`.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/requirement.md
@@ -1,0 +1,46 @@
+---
+種別: 要件定義書（Issue）
+ID: "iss-00110"
+タイトル: "Worktree create core use case"
+関連GitHub: ["#110"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["epic-00107", "init-local-00002"]
+---
+
+# iss-00110 Worktree create core use case — 要件定義
+
+## 目的
+- `spec-dock worktree create` の中核となる application contract と Git / bootstrap adapter contract を実装する。
+- main checkout の兄弟に `<repo-basename>-worktrees/` を作る長命 worktree 運用を、CLI surface から独立してテスト可能にする。
+
+## スコープ
+- 必須:
+  - worktree id、directory、branch の候補生成。
+  - Git main worktree を基準にした container path 正規化。
+  - directory / branch / worktree record collision の retry。
+  - optional / non-fatal `make init` bootstrap result aggregation。
+- 禁止:
+  - Codex app managed worktree の再実装。
+  - `worktree remove` / `status` / `prune`。
+  - spec tree metadata の mutation。
+- 対象外:
+  - CLI parser / text rendering の詳細。
+  - shipped docs の追加。
+
+## 受け入れ条件
+- AC-001: main checkout から LABEL なしで作成すると、`wt1`、`<repo>-worktrees/<repo>-wt1`、`<current-branch>-wt1` が選ばれる。
+- AC-002: 同じ条件で繰り返すと collision を検出し、次候補 `wt2` または `<label>2` に進む。
+- AC-003: LABEL は `^[a-z0-9-]+$` のみ許可し、不正な値は worktree 作成前に fatal error になる。
+- AC-004: linked worktree から実行しても container path は main worktree の兄弟になり、branch prefix は実行元 checkout の current branch になる。
+- AC-005: `make init` がない場合は skipped、成功時は succeeded、検出失敗または実行失敗は warning として result に残り、worktree 作成自体は成功扱いになる。
+- AC-006: detached HEAD、Git repo 外、path creation failure、non-retryable Git failure は fatal error になる。
+
+## 例外・エッジケース
+- EC-001: branch exists / path exists / Git worktree record exists は retryable collision。
+- EC-002: retry ceiling `10000` を超えた場合は label mode、last attempted id、container path、reason を含む fatal error。
+- EC-003: generated branch が Git ref として不正な場合は fatal error。
+
+## 未確定事項
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/rules.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/rules.md
@@ -1,0 +1,1 @@
+../../../../../docs/rules/epic/issues.md

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/plan.md
@@ -1,0 +1,172 @@
+---
+種別: 計画書（Epic）
+ID: "epic-00107"
+タイトル: "Worktree Provisioning"
+関連GitHub: ["#107"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+依存: ["requirement.md", "design.md"]
+親: ["init-local-00002"]
+---
+
+# epic-00107 Worktree Provisioning — 計画（Issues / Order）
+
+## この計画で閉じる E-RQ / E-AC
+- E-RQ:
+  - E-RQ-001: runtime worktree creation command
+  - E-RQ-002: sibling `<repo-basename>-worktrees/` placement and linked-worktree normalization
+  - E-RQ-003: id / directory / branch naming
+  - E-RQ-004: label validation
+  - E-RQ-005: collision detection and retry
+  - E-RQ-006: optional / non-fatal `make init` bootstrap
+  - E-RQ-007: output contract
+  - E-RQ-008: Codex-managed worktree non-reimplementation
+  - E-RQ-009: parallel development support without banning main checkout work
+  - E-RQ-010: provider-side source of truth and layered runtime architecture
+- E-AC:
+  - E-AC-001: basic create
+  - E-AC-002: repeated create / collision
+  - E-AC-003: label naming
+  - E-AC-004: invalid label
+  - E-AC-005: `make init` success
+  - E-AC-006: bootstrap skipped
+  - E-AC-007: bootstrap detection/execution failure warning + exit `0`
+  - E-AC-008: linked-worktree normalization
+  - E-AC-009: non-retryable Git/path failure
+  - E-AC-010: detached/outside repo failure
+  - E-AC-011: provider / dogfooding / docs parity
+
+## Issue 分割方針
+- 分割原則:
+  - Issue 1 は pure contract / adapter foundation を閉じる。
+  - Issue 2 は CLI integration と user-visible output/docs を閉じる。
+  - Issue 3 は dogfooding refresh、parity、final epic verification を閉じる。
+  - SpecDock tree mutation と worktree creation は混ぜない。
+  - `worktree remove` / `status` / `prune` は future extension として扱い、この epic の issue に入れない。
+- 例外:
+  - Issue 1 の実装中に `domain/worktree.py` 抽出が不要と判断できる場合は、application-local helper に留めてよい。
+  - Issue 2 の docs 更新で provider docs と dogfooding docs の両方が同時に必要な場合は、provider-side 更新を先に行い、dogfooding parity は Issue 3 で確認する。
+
+## Issue 一覧（順序 / tranche 付き）
+- iss-00110-worktree-create-core-use-case:
+  - 目的:
+    - `worktree create` の application contract、GitGateway / BootstrapGateway、candidate generation、collision retry、main worktree normalization、bootstrap result aggregation を実装する。
+  - 成果物:
+    - `application.contracts` の `WorktreeCreateRequest` / `WorktreeCreateResult`
+    - `application.ports` の worktree / bootstrap protocols
+    - `application/worktree.py`
+    - `infra/git_cli.py` worktree list / main worktree / add worktree helpers
+    - `infra/make_cli.py`
+    - core unit/runtime tests for naming, retry, linked-worktree normalization, bootstrap statuses, fatal failures
+  - tranche:
+    - T1 core contract
+  - closes:
+    - E-RQ-002, E-RQ-003, E-RQ-004, E-RQ-005, E-RQ-006
+    - E-AC-002, E-AC-003, E-AC-004, E-AC-006, E-AC-007, E-AC-008, E-AC-009, E-AC-010
+  - 依存:
+    - approved requirement / design
+- iss-00108-worktree-create-cli-and-output:
+  - 目的:
+    - `spec-dock worktree create [LABEL]` を CLI command として公開し、absolute path primary output と warnings を実装する。
+  - 成果物:
+    - `commands/worktree.py`
+    - `cli/parser.py` / `cli/registry.py` / `cli/bootstrap.py` wiring
+    - `presentation/cli_text.py` の `render_worktree_create_text`
+    - CLI help
+    - runtime tests for command success/failure exit codes and output text
+  - tranche:
+    - T2 command surface
+  - closes:
+    - E-RQ-001, E-RQ-007, E-RQ-010
+    - E-AC-001, E-AC-005, E-AC-007, E-AC-009, E-AC-010
+  - 依存:
+    - iss-00110
+- iss-00109-worktree-docs-dogfooding-and-final-verification:
+  - 目的:
+    - shipped docs / dogfooding workspace / final validation を整え、Codex-managed worktree との境界と future extension を明文化する。
+  - 成果物:
+    - provider-side docs under `src/spec_dock/assets/spec_dock/docs/`
+    - dogfooding workspace parity inspection
+    - final runtime command smoke in temp repo
+    - final `validate` / `sync` / `python -m unittest` or targeted runtime test evidence
+    - epic `report.md` final E-AC status
+  - tranche:
+    - T3 rollout / close-out
+  - closes:
+    - E-RQ-008, E-RQ-009, E-RQ-010
+    - E-AC-011
+  - 依存:
+    - iss-00108
+
+## 統合チェックポイント
+- G1 分解レビュー:
+  - `iss-00110` plan が requirement / design の failure contract を全て testable に落としている。
+  - `worktree create` が spec tree mutation と混ざっていない。
+- G2 統合準備確認:
+  - `iss-00110` 完了後、application result と port protocols が CLI output に十分な情報を持っている。
+  - `bootstrap_status` の `skipped` / `succeeded` / `failed` / `detection_failed` が tests で区別されている。
+- G3 ロールアウト / docs 影響:
+  - `iss-00108` 完了後、CLI help と docs の command shape が `spec-dock worktree create [LABEL]` で一致している。
+  - absolute path primary output が docs / tests に反映されている。
+- G9 最終 Epic spec review:
+  - `iss-00109` で E-AC-001..E-AC-011 の evidence を report に集約する。
+  - provider-side source and dogfooding workspace parity を確認する。
+
+## 品質ゲート
+- test:
+  - `python -m unittest discover -v` または runtime affected tests。
+  - worktree creation tests は temp directory / temp Git repo を使い、live checkout へ worktree を作らない。
+  - `make init` tests は stub `make` または controlled Makefile を使い、real project bootstrap を実行しない。
+- observability:
+  - CLI output contains id, branch, absolute worktree path, bootstrap status.
+  - warnings use existing `CliText.warnings` path.
+- migration:
+  - No persisted SpecDock state migration.
+  - Existing commands keep backward-compatible behavior.
+- docs:
+  - command help / shipped docs / dogfooding docs agree on scope and non-scope.
+  - Codex-managed worktree is explicitly out of scope.
+
+## ロールアウト / docs impact
+- ロールアウト順序:
+  1. Core use case and adapters.
+  2. CLI command and output.
+  3. Docs / dogfooding parity / final verification.
+- 契約 / docs 更新:
+  - Add a worktree command section to shipped workflow/reference docs.
+  - Mention sibling container placement and no nested `.worktrees/`.
+  - Mention optional / non-fatal `make init`.
+  - Mention future extensions: list/status/remove/prune are out of scope.
+
+## Issue 準備完了条件
+- Issue に要求する最低条件:
+  - Requirement / design references are linked in issue docs.
+  - Each issue has concrete tests mapped to E-AC subset.
+  - Each issue states whether it may create Git worktrees and how tests isolate them.
+  - Each issue states cleanup expectations for temp repos/worktrees.
+  - Each issue keeps provider-side source of truth first.
+
+## 最終完了条件
+- E-AC 完了:
+  - E-AC-001..E-AC-011 have pass evidence in `report.md`.
+- 統合 / ロールアウト完了:
+  - Runtime command exists and passes targeted / full relevant tests.
+  - Shipped assets and dogfooding workspace are inspected.
+  - `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync` pass.
+- docs 影響解決:
+  - Provider docs and dogfooding docs show the same command contract.
+  - No stale wording suggests nested `.worktrees/` or Codex-managed worktree replacement.
+
+## 依存 / ブロッカー
+- D-001:
+  - Existing runtime layered architecture must remain intact.
+- D-002:
+  - Git CLI must be available for runtime command behavior.
+- D-003:
+  - `make` availability is optional; missing or failed bootstrap must not block worktree creation.
+- D-004:
+  - `epic-00054` and other runtime command work may touch parser / registry / presentation files; avoid overlapping edits in concurrent implementation worktrees.
+
+## 未確定事項
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/report.md
@@ -1,0 +1,109 @@
+---
+種別: レポート（Epic）
+ID: "epic-00107"
+タイトル: "Worktree Provisioning"
+状態: "in_progress"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+依存: ["requirement.md", "design.md", "plan.md"]
+親: ["init-local-00002"]
+---
+
+# epic-00107 Worktree Provisioning — レポート（進捗 / 決定 / 結果）
+
+## 進捗サマリー (必須)
+- 現在地（何が完了し、何が未完か）:
+  - requirement phase は調査、reuse 判定、要件定義、fresh spec-reviewer gate まで完了。
+  - design phase は既存 runtime 責務境界、failure contract、bootstrap contract、test strategy を固定し、fresh spec-reviewer gate まで完了。
+  - plan phase は issue 分割、tranche、integration checkpoint、quality gate、rollout/docs impact、final exit contract を作成済み。
+  - `requirement.md` / `design.md` / `plan.md` は `approved`。
+  - GitHub-linked issue `iss-00108` (#108), `iss-00109` (#109), `iss-00110` (#110) を作成済み。
+  - `worktree create` runtime core / CLI / docs / dogfooding parity の実装と tests は完了。
+  - reviewer feedback により label raw validation、bootstrap failure/detection failure tests、fatal Git/path failure tests、dogfooding parity maps を追加済み。
+  - final code-reviewer / qa-reviewer / spec-reviewer gates は pass。
+- 次のマイルストーン:
+  - final commit / push / epic-level PR 作成。
+- ブロッカー:
+  - なし。
+
+## Spec Authoring Gate
+
+| phase | investigated facts | open questions | delegation consent | reviewer | verdict | fixes | promotion |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| requirement | `workflow_epic.md`, `workflow_spec_authoring.md`, `phase_requirement.md`, upstream `init-local-00002/requirement.md`, existing `epic-00054` / `epic-00074`, `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/{cli,commands,application,infra,presentation}`, `tests/cli_runtime`, `/Users/iwasawayuuta/workspace/product/taikyohiyou_project-issue-1716/scripts/worktree/create_worktree.sh`, `Makefile`, `docs/dynamic-worktree-support.md`, Git worktree manual, Codex app worktree/local-environment/AGENTS.md docs | User intent was sufficient after local investigation. `MakeInit` was interpreted as `make init` from reference product evidence. User later accepted the recommended decisions for CLI shape and output path style: `spec-dock worktree create [LABEL]` and absolute path primary output. | User explicitly requested `$spec-dock-epic-planning`; reviewer use was limited to current repo/worktree, epic-00107, current session, `spec-reviewer`; destructive action, external publishing, credentialed access, scope expansion, and write-capable delegation excluded. | Fresh `spec-reviewer` 1 (`019e4eab-143a-7482-9f65-79fff2a99f60`) failed on bootstrap exit-code contract, linked-worktree invocation behavior, and research metadata. Fresh `spec-reviewer` 2 (`019e4ead-72c1-7d41-856d-792506c65cc2`) passed with P2/P3 hardening suggestions. Fresh `spec-reviewer` 3 (`019e4eb0-1eff-7ef1-bfa2-f3d7f3583b0c`) returned findings `[]`, `review_status: pass`. | passed | Fixed bootstrap failure to exit code 0 with warning, defined linked-worktree invocation normalization to main worktree, completed research metadata, added non-retryable Git failure AC, added `20260522t075615z-disc-new-epic-reuse-decision.md` for new-epic rationale, and resolved the two requirement open questions with the user-approved recommended options. | Promote requirement to design. |
+| design | Approved `requirement.md`, `phase_design.md`, `workflow_epic.md`, existing runtime parser / registry / dispatch / UseCases / Ports / GitGateway / CliText patterns, `tests/cli_runtime/harness.py`, reference product `create_worktree.sh`, Git worktree behavior, optional `make init` bootstrap constraints. | No user questions remained. Design-local choices were fixed in the design: candidate retry ceiling `10000`, `make -n init` detection with `detection_failed` warning, fatal Git partial failures as `RuntimeError`, absolute path output, and `worktree create` CLI shape. | Same epic-planning scope and reviewer boundary as requirement gate. | Fresh `spec-reviewer` 1 (`019e4edf-36ad-7243-a7b8-29b7f8a8ef0c`) failed on undefined retry ceiling, unclassified bootstrap detection errors, and proposed-only reuse-disc authority. Fresh `spec-reviewer` 2 (`019e4ee2-a04a-7a31-83b5-2d7e3f4705db`) returned findings `[]`, `review_status: pass`. | passed | Added retry ceiling `10000` and fatal no-candidate output contract, classified `make -n init` non-target failures as non-fatal `detection_failed`, and finalized reuse-decision discussion metadata. | Promote design to plan. |
+| plan | Approved `requirement.md`, approved `design.md`, `phase_plan.md`, `phase_plan_epic.md`, `workflow_epic.md`, upstream `init-local-00002/plan.md`, and generated `plan.md` issue slicing. | No open plan questions. Issue numbering is planned as `iss-00108`..`iss-00110`; actual creation may adjust only if runtime allocation conflicts. | Same epic-planning scope and reviewer boundary as requirement gate. | Fresh `spec-reviewer` 1 (`019e4ee6-655e-7551-968f-f246729b5cce`) failed because `report.md` still described `plan.md` as unstarted and pointed next milestone back to design work. Fresh `spec-reviewer` 2 (`019e4ee8-cb7d-7aa1-99d4-c11c413acf90`) returned `review_status: pass` with one P3 stale follow-up wording cleanup. | passed | Updated progress summary, next milestone, blocker, follow-up, and plan gate ledger to reflect the authored plan and reviewer finding. Removed stale design-phase follow-up wording. | Promote plan to issue decomposition. |
+
+## 決定事項（ADRリンク） (必須)
+- ADR なし。
+- `20260522t075615z-disc-new-epic-reuse-decision.md`: 既存 `epic-00054` / `epic-00074` ではなく、新規 `epic-00107` として worktree 作成 capability を扱う。
+- `requirement.md` Q-001: CLI shape は `spec-dock worktree create [LABEL]` を採用する。
+- `requirement.md` Q-002: command output は absolute path を主表示する。
+- `design.md`: candidate retry ceiling は `10000` とし、超過時は fatal `RuntimeError` とする。
+- `design.md`: `make -n init` detection failure は non-fatal `bootstrap_status=detection_failed` warning とする。
+
+## 完了した Issue / PR / Release (必須)
+- `iss-00110` Worktree create core use case:
+  - core contracts, ports, Git / make adapters, and core tests implemented.
+- `iss-00108` Worktree create CLI and output:
+  - parser, registry, command handler, bootstrap wiring, output rendering implemented.
+- `iss-00109` Worktree docs dogfooding and final verification:
+  - provider docs, dogfooding docs/runtime parity, snapshot/parity tests, and final verification evidence added.
+- PR:
+  - pending epic-level single PR.
+
+## 受け入れ条件（E-AC）の達成状況 (必須)
+- E-AC-001 basic create:
+  - pass via `test_worktree_create_uses_sibling_container_auto_id_and_branch`.
+- E-AC-002 repeated create / collision:
+  - pass via `test_worktree_create_retries_collisions_and_accepts_label`, `test_worktree_create_retries_auto_id_collisions`, and `test_worktree_create_retries_git_add_collision`.
+- E-AC-003 label naming:
+  - pass via label success tests and slash-current-branch branch prefix test.
+- E-AC-004 invalid label:
+  - pass via invalid label matrix for underscore, uppercase, dot, slash, spaces, leading whitespace, whitespace-only labels, and shell metacharacters.
+- E-AC-005 `make init` success:
+  - pass via `test_worktree_create_runs_make_init_when_available`.
+- E-AC-006 bootstrap skipped:
+  - pass via no-Makefile basic create test reporting `bootstrap status=skipped`.
+- E-AC-007 bootstrap detection/execution failure warning + exit `0`:
+  - pass via `test_worktree_create_keeps_worktree_when_make_init_fails` and `test_worktree_create_keeps_worktree_when_make_init_detection_fails`.
+- E-AC-008 linked-worktree normalization:
+  - pass via `test_worktree_create_normalizes_container_from_linked_worktree`.
+- E-AC-009 non-retryable Git/path failure:
+  - pass via container-file fatal path and non-collision `cannot lock ref` fatal classification test.
+  - Container creation failures include `artifact_state=path_exists:<bool>,branch_exists:<bool>,record_exists:<bool>` for the attempted worktree.
+  - Non-retryable `git worktree add` failures include attempted id/path/branch and `artifact_state=path_exists:<bool>,branch_exists:<bool>,record_exists:<bool>` so the caller can see whether no artifacts were created or partial state remains.
+- E-AC-010 detached/outside repo failure:
+  - pass via detached HEAD and outside Git repo tests.
+- E-AC-011 provider / dogfooding / docs parity:
+  - pass via docs/runtime parity tests and dogfooding command help smoke.
+
+## Final Quality Gate
+- Verification:
+  - `python -m unittest tests.cli_runtime.test_worktree tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets -v`: pass, 17 tests.
+  - `python -m unittest discover -v`: pass, 827 tests.
+  - `./spec-dock/scripts/spec-dock validate`: pass, `nodes=50`.
+  - `./spec-dock/scripts/spec-dock sync`: pass.
+  - `git diff --check`: pass.
+- Reviews:
+  - final `code-reviewer`: pass, no findings.
+  - final `qa-reviewer`: pass, P2 follow-up test-depth suggestions only.
+  - final `spec-reviewer`: pass, P2 traceability suggestion addressed in `iss-00110/plan.md`.
+- PR Delivery:
+  - Pending external delivery evidence. One epic-level PR will link #108, #109, and #110.
+
+## ロールアウト結果（必要なら） (任意)
+- Shipped runtime assets updated under `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/`.
+- Dogfooding runtime mirror updated under `spec-dock/scripts/spec_dock_runtime/`.
+- Shipped docs and dogfooding docs updated with `reference_worktree.md`.
+- `uvx --from . spec-dock update .` failed due external uv cache permission; `PYTHONPATH=src python -m spec_dock.cli update .` partially updated runtime before managed `.agents` permission failure, and direct parity evidence now confirms relevant runtime/docs mirror files match provider assets.
+
+## フォローアップ（別Issue化） (必須)
+- Future extension:
+  - `worktree list` / `status` / `remove` / `prune` remain out of scope.
+  - Codex-managed worktree cleanup remains out of scope.
+
+## 省略/例外メモ (必須)
+- User requested one epic-level PR rather than one PR per issue; issue execution was sequenced on the epic branch and will be delivered by one PR.
+- `issue finish` is intentionally deferred until after the epic-level PR is merged because `issue finish` closes the linked GitHub issue; running it before merge would prematurely close #108, #109, and #110. The PR body should link these issues with merge-time closure keywords, and post-merge cleanup should run the lifecycle closure.
+- Write-capable subagent delegation was not used because current host policy requires explicit subagent delegation permission; local implementation was recorded as Parent Implementation Exception in issue reports.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/requirement.md
@@ -1,0 +1,324 @@
+---
+種別: 要件定義書（Epic）
+ID: "epic-00107"
+タイトル: "Worktree Provisioning"
+関連GitHub: ["#107"]
+状態: "approved"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-22"
+親: ["init-local-00002"]
+---
+
+# epic-00107 Worktree Provisioning — 要件定義（WHAT / WHY）
+
+## 目的（Initiative との紐づき）
+- Initiative 目標 / 指標:
+  - `init-local-00002` の feature expansion として、SpecDock の日常運用に「並行開発用 worktree を安全に作る」能力を追加する。
+  - feature work を architecture maintenance と混ぜず、operator が複数 issue / 複数変更を branch / checkout 単位で分離して前進できるようにする。
+  - `Metric-001` の「feature value 中心の portfolio」に対して、runtime command で実用できる operator value を追加する。
+- この epic が提供する能力:
+  - repo-local SpecDock runtime command から、現在 checkout に紐づく linked worktree と新規 branch を作成できる。
+  - 作成先は main checkout の中ではなく、main checkout と同じ親 directory に作る `<repo-basename>-worktrees/` container 配下へ集約できる。
+  - worktree directory name / initial branch name は、既に実用している `taikyohiyou_project` の naming UX を踏襲して自動合成できる。
+  - worktree 作成後に、project-local bootstrap interface として worktree root の `make init` を optional / non-fatal に呼び出せる。
+  - Codex app が管理する短命 worktree とは別に、開発者が自分で管理する長命 worktree を作る導線を提供する。
+
+## ユースケース
+- 正常系:
+  - maintainer が `spec-dock` main checkout から worktree 作成 command を実行し、現在 branch を基点にした新 branch と linked worktree を作成する。
+  - maintainer が optional label を指定し、directory / branch に読みやすい suffix を付けた worktree を作成する。
+  - label を省略した場合、command は `wt1`, `wt2`, ... のように未使用 suffix を自動採番して作成する。
+  - 作成された worktree root に `make init` が存在する場合、command は bootstrap としてそれを実行する。
+  - `make init` が存在しない repo でも、worktree 作成自体は成功する。
+- 例外 / 運用シナリオ:
+  - directory / branch / Git worktree record が衝突する場合、command は次の suffix を試し、operator が手で番号を探さなくてよい。
+  - detached HEAD、Git repo 外、invalid label、permission error、unknown `git worktree add` error は fail-fast し、worktree 作成を成功扱いしない。
+  - `make init` が存在して失敗した場合でも、作成済み worktree / branch は成功成果物として残し、command 全体は作成失敗にしない。ただし non-fatal warning として operator が追える情報を出す。
+  - Codex-managed worktree は `$CODEX_HOME/worktrees` 側の短命作業として維持し、この command はそれを移動・置換・cleanup しない。
+
+## Epic 要件
+- E-RQ-001:
+  - SpecDock は repo-local runtime command として worktree 作成 capability を提供し、maintainer が `git worktree add` の naming / collision handling / bootstrap を毎回手作業で組み立てなくてよいこと。
+- E-RQ-002:
+  - 作成先 container は main checkout の内側ではなく、main checkout の親 directory 直下の `<repo-basename>-worktrees/` とすること。
+  - container 名は lowercase path policy に従い、dot suffix ではなく hyphen suffix を標準とすること。
+  - 例: `/Users/.../spec-dock` から作る場合、container は `/Users/.../spec-dock-worktrees/` であること。
+  - command が既存 linked worktree から実行された場合も、container placement と repo basename は Git が認識する main worktree を基準に正規化すること。
+- E-RQ-003:
+  - 個別 worktree directory name と initial branch name は、参照プロダクトの実用 naming を踏襲すること。
+  - label 省略時の id は `wt1`, `wt2`, ... とし、label 指定時の id は `<label>`, `<label>2`, ... とすること。
+  - 個別 worktree directory は `<repo-basename>-<id>` を基本とし、container 配下に作ること。
+  - initial branch は `<current-branch>-<id>` を基本とすること。
+- E-RQ-004:
+  - label は lowercase alphanumeric と hyphen のみを許可し、uppercase、underscore、dot、space、slash、shell metacharacter を拒否すること。
+- E-RQ-005:
+  - command は directory existence、branch existence、`git worktree list --porcelain` による worktree record existence を確認し、衝突時は次の id を試すこと。
+  - `git worktree add` 実行時に既存 branch / path / record 由来の retryable collision が発生した場合も、次の id を試すこと。
+- E-RQ-006:
+  - 作成後 bootstrap は worktree root の `make init` を project-local interface として扱うこと。
+  - `make init` が定義されていない repo では何もしないこと。
+  - `make init` が失敗しても worktree 作成自体を失敗にしないこと。
+  - `make init` が失敗した場合も command process は exit code 0 を返し、worktree 作成成功 + bootstrap warning として扱うこと。
+  - non-fatal bootstrap failure は warning / output として観測可能にし、作成済み path と branch を operator が把握できること。
+- E-RQ-007:
+  - command output は少なくとも、採用 id、worktree path、branch name、bootstrap 実行有無、bootstrap result を示すこと。
+- E-RQ-008:
+  - この epic は手動管理の長命 linked worktree 作成を扱い、Codex app の短命 / detached HEAD worktree 管理、Handoff、cleanup を再実装しないこと。
+- E-RQ-009:
+  - main checkout での実装作業を全面禁止する policy change はこの epic の目的にしないこと。
+  - ただし、複数変更を並行させる場合は dedicated worktree を作る導線を first-class にすること。
+- E-RQ-010:
+  - provider-side source of truth は `src/spec_dock/assets/spec_dock/...` とし、dogfooding workspace `spec-dock/...` は検証・反映対象として扱うこと。
+  - command 追加は既存 layered runtime architecture に沿い、monolithic shell script への逆戻りを避けること。
+
+## Epic 受け入れ条件
+- E-AC-001:
+  - 前提:
+    - Git repo の main checkout が `/tmp/example/spec-dock` にあり、current branch が `main` である
+    - `../spec-dock-worktrees/` は存在しない、または空である
+  - 操作:
+    - maintainer が worktree 作成 command を label なしで実行する
+  - 期待結果:
+    - `/tmp/example/spec-dock-worktrees/spec-dock-wt1` が linked worktree として作成される
+    - `main-wt1` branch が作成され、その worktree で checkout される
+    - command output が id / path / branch / bootstrap result を表示する
+  - 観測点:
+    - CLI / runtime test
+    - `git worktree list --porcelain` assertion
+- E-AC-002:
+  - 前提:
+    - `spec-dock-wt1` / `main-wt1` が既に存在する
+  - 操作:
+    - maintainer が label なしで再度 worktree 作成 command を実行する
+  - 期待結果:
+    - command は衝突を避けて `wt2` を採用する
+    - `/tmp/example/spec-dock-worktrees/spec-dock-wt2` と `main-wt2` が作成される
+  - 観測点:
+    - CLI / runtime test
+    - branch / directory / worktree record collision test
+- E-AC-003:
+  - 前提:
+    - current branch が `feature/base` である
+  - 操作:
+    - maintainer が worktree 作成 command に label `issue-107-worktree` を指定する
+  - 期待結果:
+    - id は `issue-107-worktree` になる
+    - worktree path は `<repo-parent>/<repo-basename>-worktrees/<repo-basename>-issue-107-worktree` になる
+    - branch は `feature/base-issue-107-worktree` になる
+  - 観測点:
+    - naming unit test
+    - CLI / runtime test
+- E-AC-004:
+  - 前提:
+    - label に `Issue_107`, `issue.107`, `issue/107`, `issue 107` のいずれかが指定される
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - command は invalid label として fail-fast する
+    - Git worktree / branch / directory は作成されない
+  - 観測点:
+    - validation test
+- E-AC-005:
+  - 前提:
+    - 作成先 worktree root の `Makefile` に `init` target が定義されている
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - command は worktree root で `make init` を実行する
+    - `make init` が成功した場合、output は bootstrap success を示す
+  - 観測点:
+    - subprocess invocation test
+    - cwd assertion
+- E-AC-006:
+  - 前提:
+    - 作成先 worktree root に `Makefile` がない、または `init` target がない
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - command は bootstrap を skip する
+    - worktree 作成は成功する
+    - output は bootstrap skipped を示す
+  - 観測点:
+    - CLI / runtime test
+- E-AC-007:
+  - 前提:
+    - 作成先 worktree root の `make init` が非ゼロ終了する
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - worktree / branch は作成済み成果物として残る
+    - command は exit code 0 で作成結果を成功として返す
+    - output は bootstrap failure を non-fatal warning として表示する
+  - 観測点:
+    - CLI / runtime test
+    - output assertion
+- E-AC-008:
+  - 前提:
+    - command が `/tmp/example/spec-dock-worktrees/spec-dock-existing` のような既存 linked worktree から実行される
+    - Git が認識する main worktree は `/tmp/example/spec-dock` である
+    - current branch は `main-existing` である
+  - 操作:
+    - maintainer が label なしで worktree 作成 command を実行する
+  - 期待結果:
+    - command は main worktree basename `spec-dock` を使って container `/tmp/example/spec-dock-worktrees/` を選ぶ
+    - 新しい個別 worktree は `/tmp/example/spec-dock-worktrees/spec-dock-wtN` に作成される
+    - initial branch は実行元 current branch を基点に `main-existing-wtN` として合成される
+    - `spec-dock-existing-worktrees/` や `spec-dock-existing-wtN` のような chained path は作られない
+  - 観測点:
+    - main-worktree normalization test
+    - CLI / runtime test
+- E-AC-009:
+  - 前提:
+    - label は valid で、current checkout も Git repo 内の branch checkout である
+    - ただし parent directory の permission、path creation、または `git worktree add` が retryable collision ではない理由で失敗する
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - command は fail-fast し、作成成功として扱わない
+    - unknown failure を次番号 retry で握りつぶさない
+    - output は non-retryable failure の原因と、作成済み成果物がないこと、または部分作成が発生した場合の状態を示す
+  - 観測点:
+    - non-retryable Git failure test
+    - permission / path failure test
+- E-AC-010:
+  - 前提:
+    - current checkout が detached HEAD である、または Git repo 外である
+  - 操作:
+    - maintainer が worktree 作成 command を実行する
+  - 期待結果:
+    - command は fail-fast する
+    - worktree / branch / directory は作成されない
+  - 観測点:
+    - failure-path test
+- E-AC-011:
+  - 前提:
+    - provider-side runtime implementation と dogfooding workspace を確認する
+  - 操作:
+    - epic close-out 時に docs / tests / command help を確認する
+  - 期待結果:
+    - provider-side source of truth と dogfooding `spec-dock/` の command contract が一致している
+    - Codex-managed worktree を再実装しない scope boundary が docs に残っている
+  - 観測点:
+    - provider / dogfooding parity check
+    - final spec review
+
+## スコープ
+- 必須:
+  - SpecDock runtime worktree creation command
+  - repo sibling `<repo-basename>-worktrees/` container placement
+  - taikyohiyou_project 由来の id / directory / branch naming
+  - label validation
+  - collision detection and retry
+  - optional / non-fatal `make init` bootstrap
+  - CLI output contract
+  - provider-side implementation docs / tests
+  - dogfooding workspace inspection / parity confirmation
+- 禁止:
+  - main checkout 内に `.worktrees/` や `worktrees/` を標準作成先として持ち込むこと
+  - Codex app managed worktree を移動・削除・再実装すること
+  - `make init` failure を worktree 作成失敗として扱うこと
+  - invalid label を shell / Git command に渡してから失敗させること
+  - unknown `git worktree add` failure を retryable collision として握りつぶすこと
+  - provider-side source of truth を飛ばして dogfooding workspace だけを編集すること
+- 対象外:
+  - worktree remove / prune / repair command
+  - worktree status dashboard / all-worktree diff summary
+  - Codex app Handoff integration
+  - Codex local environment `.codex` setup scripts の設計
+  - project-specific secret / env projection の実装
+  - main checkout での実装作業を禁止する repository policy 変更
+  - GitHub PR creation / merge lifecycle
+
+## 境界
+- 常に行う:
+  - worktree 作成は repo 外 sibling container に集約する
+  - linked worktree から実行された場合も、main worktree を基準に container と repo basename を決める
+  - current branch を基点に initial branch 名を合成する
+  - Git が管理する linked worktree として作成する
+  - `make init` は project-local bootstrap interface として扱い、存在しない / 失敗する場合でも作成済み worktree を残す
+  - operator が path / branch / bootstrap 状態を読める output を出す
+  - provider-side runtime architecture の layer 境界に沿って実装する
+- 判断が必要:
+  - `make init` target existence をどの方法で判定するか
+  - Git failure / partial state をどの structured result で表すか
+- 行わない:
+  - nested checkout を repo 内に作らない
+  - cleanup / remove を作成 command の副作用として実行しない
+  - detached HEAD から branch 名を推測して作成しない
+  - secret-bearing env file を新 worktree へ copy しない
+  - Codex-managed `$CODEX_HOME/worktrees` をこの command の管理対象にしない
+
+## 非機能要件
+- 性能:
+  - suffix collision retry は通常利用で体感遅延を生まないこと。
+  - 既存 `sync` / `validate` / `active` / `issue` command の性能に影響しないこと。
+- 信頼性 / 一貫性:
+  - directory / branch / worktree record の衝突を同じ id generation contract で扱うこと。
+  - Git command が未知の失敗を返した場合は、作成成功に見せないこと。
+  - 作成後 bootstrap の成否は worktree 作成結果と区別すること。
+- セキュリティ:
+  - label validation により path traversal、shell injection、unexpected ref name を防ぐこと。
+  - `make init` は作成された worktree root だけで実行し、任意 path の command 実行機構にしないこと。
+  - secret / env file copy は scope 外とし、worktree 作成 command が secret-bearing file を複製しないこと。
+- 運用:
+  - long-lived manual worktree と Codex-managed short-lived worktree の役割差が docs から分かること。
+  - created path / branch / bootstrap warning が operator の次行動に十分な情報を持つこと。
+  - `spec-dock` 自身の dogfooding repo でも作成 command を検証できること。
+
+## 依存 / 影響範囲
+- 影響する component:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/git_cli.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/`
+  - `src/spec_dock/assets/spec_dock/docs/`
+  - `tests/cli_runtime/`
+  - `tests/domain_runtime/` または `tests/presentation_runtime/`（分離した naming / output logic がある場合）
+  - dogfooding workspace `spec-dock/`
+- 外部依存:
+  - Git CLI
+  - `make`（optional bootstrap のみ）
+  - project-local `Makefile` / `make init` target（存在する場合のみ）
+- 互換性:
+  - additive command として追加し、既存 `new` / `active` / `issue` / `sync` / `validate` / `update` の contract を壊さない。
+  - 既存 repo に `make init` がない場合でも worktree 作成を利用できる。
+  - 既存 Codex-managed worktree behavior と競合しない。
+
+## 決定事項
+- Q-001:
+  - 質問:
+    - CLI shape は top-level `worktree [LABEL]` と subcommand family `worktree create [LABEL]` のどちらにするか。
+  - 選択肢:
+    - A:
+      - `spec-dock worktree [LABEL]`
+      - 参照プロダクトの `make worktree <optional-label>` に最も近く、作成専用 command として短い。
+    - B:
+      - `spec-dock worktree create [LABEL]`
+      - 将来 `list` / `remove` / `status` を同じ family に足しやすい。
+  - 推奨案:
+    - B。今回の epic は create のみだが、command family として予約しておく方が将来拡張と help 構造が自然である。
+  - 決定:
+    - B を採用する。
+    - worktree 作成 command の CLI shape は `spec-dock worktree create [LABEL]` を基本とする。
+  - 影響範囲:
+    - CLI parser
+    - docs
+    - tests
+- Q-002:
+  - 質問:
+    - output に absolute path と relative path のどちらを主表示するか。
+  - 選択肢:
+    - A:
+      - absolute path を主表示し、operator がどの checkout からでも迷わないようにする。
+    - B:
+      - current checkout からの relative path を主表示し、短い output にする。
+  - 推奨案:
+    - A。linked worktree から実行しても main worktree 基準へ正規化するため、absolute path のほうが誤読が少ない。
+  - 決定:
+    - A を採用する。
+    - command output は absolute path を主表示する。
+  - 影響範囲:
+    - CLI output
+    - tests

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/plan.md
@@ -84,6 +84,29 @@ ID: "init-local-00002"
     - 既存 installer foundation 上の asset 追加として 1 implementation issue で進める。
     - 同一 issue の中で metadata / file placement / tests / docs / cross-host validation を完了させる。
     - 新しい installer mechanism が必要と判明した場合だけ再分割する。
+- epic-00107-worktree-provisioning:
+  - 目的:
+    - SpecDock runtime command から、並行開発用の linked worktree と initial branch を安全に作成できる operator capability を追加する。
+  - deliverable:
+    - `spec-dock worktree create [LABEL]` command
+    - `<repo-basename>-worktrees/` sibling container placement
+    - label / id / directory / branch naming contract
+    - optional / non-fatal `make init` bootstrap
+    - Git failure / collision / linked-worktree invocation handling
+    - provider docs / dogfooding parity / tests
+  - metric link:
+    - Metric-001
+    - Metric-002
+  - depends on:
+    - current runtime command baseline
+    - `epic-00054` の lifecycle command expansion と command UX が競合しないこと
+  - 背景:
+    - `epic-00054` は GitHub issue close / local node delete / self-update の lifecycle gap を扱う。
+    - `epic-00107` は別の operator capability として、複数 issue / 複数変更を branch / checkout 単位で分離して前進できる worktree 作成導線を扱う。
+    - 既存 `taikyohiyou_project` で実用している `make worktree` の naming UX を参考にしつつ、SpecDock runtime の layered architecture へ取り込む。
+  - 実行方針:
+    - requirement / design / plan の spec authoring gate を通してから issue 分割する。
+    - command core、bootstrap/output/docs parity、dogfooding verification の順で閉じる。
 - epic-0003-operator-value-expansion:
   - 目的:
     - operator が日常運用で得られる feature value を広げる。
@@ -112,10 +135,12 @@ ID: "init-local-00002"
   - `epic-00054` は review-only issue を別建てせず、各 implementation issue に review と成功性確認を内包する。
   - `epic-00074` は `epic-00048` の completed baseline を拡張し、host-native config / subagent managed deployment を concrete feature epic として進める。
   - `epic-00074` は `epic-00067` の authority cleanup を再所有せず、feature initiative 側では利用価値としての multi-host setup 拡張に限定する。
+  - `epic-00107` は `epic-00054` と同じく runtime command を拡張するが、close/delete/update の lifecycle completion ではなく、並行開発用 worktree provisioning を扱うため独立 epic とする。
   - post-prototype 候補は current initiative の出口を曖昧にしないよう最後に整理する。
 - parallelizable:
   - `epic-00054` と epic-0003 は並行検討できる。
   - `epic-00074` は prerequisite groundwork が閉じている前提で `epic-00054` と並行検討できるが、installer / docs / dogfooding の重なりは調整が必要。
+  - `epic-00107` は `epic-00054` と command parser / docs / tests の変更面が重なるため、実装 issue の同時編集は避ける。ただし spec planning は並行可能である。
 
 ## 意思決定ゲート
 - G1 strategy review:
@@ -125,6 +150,7 @@ ID: "init-local-00002"
 - G3 governance/docs impact:
   - architecture initiative 側の guardrail を破っていないか確認する
   - `epic-00074` が architecture cleanup ではなく feature expansion として閉じているか確認する
+  - `epic-00107` が Codex-managed worktree を再実装せず、manual long-lived worktree provisioning に限定されているか確認する
 - G9 final initiative plan review:
   - current initiative と post-prototype candidate の境界を確認する
 

--- a/spec-dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/contracts.py
@@ -21,6 +21,7 @@ from ..infra.contracts import StoredMetaRecord
 
 
 POST_MUTATION_FATAL_WARNING_CODES: tuple[str, ...] = ("gh_fetch_failed",)
+BootstrapStatus = Literal["skipped", "succeeded", "failed", "detection_failed"]
 
 
 @dataclass(frozen=True)
@@ -59,6 +60,41 @@ class DoctorFinding:
 class DoctorResult:
     ok: bool
     findings: list[DoctorFinding]
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class GitWorktreeRecord:
+    path: Path
+    head: str | None
+    branch: str | None
+    detached: bool = False
+    bare: bool = False
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    status: BootstrapStatus
+    command: str | None
+    exit_code: int | None
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class WorktreeCreateRequest:
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class WorktreeCreateResult:
+    id: str
+    main_worktree_path: Path
+    container_path: Path
+    worktree_path: Path
+    branch_name: str
+    bootstrap_status: BootstrapStatus
+    bootstrap_command: str | None
+    bootstrap_exit_code: int | None
     warnings: list[str]
 
 
@@ -512,4 +548,7 @@ class UseCases:
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
         lambda _req: DoctorResult(ok=True, findings=[], warnings=[])
+    )
+    worktree_create: Callable[[WorktreeCreateRequest], WorktreeCreateResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("worktree_create is not configured")
     )

--- a/spec-dock/scripts/spec_dock_runtime/application/ports.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/ports.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from typing import Literal
 from typing import Protocol
 
-from .contracts import ArtifactWriteResult, SyncCommandResult, SyncRequest
+from .contracts import ArtifactWriteResult
+from .contracts import BootstrapResult
+from .contracts import GitWorktreeRecord
+from .contracts import SyncCommandResult
+from .contracts import SyncRequest
 from ..domain.models import IssueSnapshot, SpecGraph
 from ..infra.contracts import ActiveManifest
 from ..infra.contracts import ActiveManifestLoadResult
@@ -153,6 +157,17 @@ class GitGateway(Protocol):
     def origin_github_repo_slug(self, repo_root: Path) -> str | None:
         ...
 
+    def worktree_list(self, repo_root: Path) -> list[GitWorktreeRecord]:
+        ...
+
+    def add_worktree_with_new_branch(self, repo_root: Path, *, path: Path, branch: str) -> None:
+        ...
+
+
+class BootstrapGateway(Protocol):
+    def run_make_init_if_available(self, worktree_path: Path) -> BootstrapResult:
+        ...
+
 
 class ArtifactWriter(Protocol):
     def write(self, specdock_dir: Path, bundle: ArtifactBundle) -> ArtifactWriteResult:
@@ -201,3 +216,4 @@ class Ports:
     clock: Clock | None = None
     artifact_writer: ArtifactWriter | None = None
     sync_legacy_runner: SyncLegacyRunner | None = None
+    bootstrap_gateway: BootstrapGateway | None = None

--- a/spec-dock/scripts/spec_dock_runtime/application/worktree.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/worktree.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .contracts import WorktreeCreateRequest, WorktreeCreateResult
+from .ports import Ports
+
+
+_LABEL_RE = re.compile(r"^[a-z0-9-]+$")
+_MAX_ATTEMPTS = 10000
+_RETRYABLE_GIT_WORKTREE_ERRORS = (
+    "already exists",
+    "is already checked out",
+    "a branch named",
+)
+
+
+def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateResult:
+    if ports.repo_root is None:
+        raise RuntimeError("worktree create requires a repository root")
+    if ports.git_gateway is None:
+        raise RuntimeError("worktree create requires a Git gateway")
+    if ports.bootstrap_gateway is None:
+        raise RuntimeError("worktree create requires a bootstrap gateway")
+
+    label = _normalize_label(req.label)
+    repo_root = ports.repo_root
+    branch_prefix = ports.git_gateway.current_branch_or_none(repo_root)
+    if branch_prefix is None:
+        raise RuntimeError("worktree create requires a named current branch; detached HEAD is not supported")
+
+    records = ports.git_gateway.worktree_list(repo_root)
+    if not records:
+        raise RuntimeError("git worktree list returned no worktrees")
+    main_worktree = records[0].path
+    repo_basename = main_worktree.name
+    container = main_worktree.parent / f"{repo_basename}-worktrees"
+    known_paths = {_canonical_path(record.path) for record in records}
+    last_attempt_id = ""
+    last_reason = "no candidates attempted"
+
+    for index in range(1, _MAX_ATTEMPTS + 1):
+        worktree_id = _candidate_id(label, index)
+        last_attempt_id = worktree_id
+        worktree_path = container / f"{repo_basename}-{worktree_id}"
+        branch_name = f"{branch_prefix}-{worktree_id}"
+
+        collision = _preflight_collision(
+            repo_root=repo_root,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            known_paths=known_paths,
+            ports=ports,
+        )
+        if collision is not None:
+            last_reason = collision
+            continue
+
+        try:
+            container.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            state = _artifact_state(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                known_paths=known_paths,
+                ports=ports,
+                refresh_records=False,
+            )
+            raise RuntimeError(f"failed to create worktree container: {container} {state}\n{exc}") from exc
+
+        try:
+            ports.git_gateway.add_worktree_with_new_branch(repo_root, path=worktree_path, branch=branch_name)
+        except RuntimeError as exc:
+            message = str(exc)
+            if _is_retryable_worktree_add_error(message):
+                records = ports.git_gateway.worktree_list(repo_root)
+                known_paths = {_canonical_path(record.path) for record in records}
+                last_reason = f"retryable git collision: {message}"
+                continue
+            state = _artifact_state(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                known_paths=known_paths,
+                ports=ports,
+                refresh_records=True,
+            )
+            raise RuntimeError(
+                "git worktree add failed for non-retryable reason: "
+                f"id={worktree_id} path={worktree_path} branch={branch_name} {state}\n{message}"
+            ) from exc
+
+        bootstrap = ports.bootstrap_gateway.run_make_init_if_available(worktree_path)
+        return WorktreeCreateResult(
+            id=worktree_id,
+            main_worktree_path=main_worktree,
+            container_path=container,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            bootstrap_status=bootstrap.status,
+            bootstrap_command=bootstrap.command,
+            bootstrap_exit_code=bootstrap.exit_code,
+            warnings=list(bootstrap.warnings),
+        )
+
+    mode = "label" if label is not None else "auto"
+    raise RuntimeError(
+        "worktree create exhausted candidate attempts: "
+        f"mode={mode} last_id={last_attempt_id} container={container} reason={last_reason}"
+    )
+
+
+def _normalize_label(label: str | None) -> str | None:
+    if label is None:
+        return None
+    if not label:
+        raise RuntimeError("invalid worktree label: use lowercase letters, digits, and hyphens only")
+    if _LABEL_RE.fullmatch(label) is None:
+        raise RuntimeError("invalid worktree label: use lowercase letters, digits, and hyphens only")
+    return label
+
+
+def _candidate_id(label: str | None, index: int) -> str:
+    if label is None:
+        return f"wt{index}"
+    if index == 1:
+        return label
+    return f"{label}{index}"
+
+
+def _preflight_collision(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    branch_name: str,
+    known_paths: set[str],
+    ports: Ports,
+) -> str | None:
+    assert ports.git_gateway is not None
+    if _canonical_path(worktree_path) in known_paths:
+        return "worktree record already exists"
+    if worktree_path.exists():
+        return "worktree path already exists"
+    if ports.git_gateway.local_branch_exists(repo_root, branch_name):
+        return "branch already exists"
+    if not ports.git_gateway.check_ref_format_branch(repo_root, branch_name):
+        raise RuntimeError(f"generated worktree branch is invalid: {branch_name}")
+    return None
+
+
+def _canonical_path(path: Path) -> str:
+    return str(path.expanduser().resolve(strict=False))
+
+
+def _is_retryable_worktree_add_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(fragment in lowered for fragment in _RETRYABLE_GIT_WORKTREE_ERRORS)
+
+
+def _artifact_state(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    branch_name: str,
+    known_paths: set[str],
+    ports: Ports,
+    refresh_records: bool,
+) -> str:
+    assert ports.git_gateway is not None
+    record_paths = known_paths
+    if refresh_records:
+        try:
+            record_paths = {_canonical_path(record.path) for record in ports.git_gateway.worktree_list(repo_root)}
+        except RuntimeError:
+            record_paths = known_paths
+    try:
+        branch_exists = ports.git_gateway.local_branch_exists(repo_root, branch_name)
+    except RuntimeError:
+        branch_exists = "unknown"
+    path_exists = worktree_path.exists()
+    record_exists = _canonical_path(worktree_path) in record_paths
+    return (
+        "artifact_state="
+        f"path_exists:{path_exists},"
+        f"branch_exists:{branch_exists},"
+        f"record_exists:{record_exists}"
+    )

--- a/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -24,6 +24,7 @@ from ..application.set_active import set_active as application_set_active
 from ..application.set_active import show_active as application_show_active
 from ..application.sync_state import sync as application_sync
 from ..application.validate_tree import validate_tree as application_validate_tree
+from ..application.worktree import worktree_create as application_worktree_create
 from ..infra import active_store as infra_active_store
 from ..infra import artifact_writer as infra_artifact_writer
 from ..infra import clock as infra_clock
@@ -33,6 +34,7 @@ from ..infra import fs_repo as infra_fs_repo
 from ..infra import git_cli as infra_git_cli
 from ..infra import github_cli as infra_github_cli
 from ..infra import json_store as infra_json_store
+from ..infra import make_cli as infra_make_cli
 from ..infra import template_scaffolder as infra_template_scaffolder
 
 
@@ -187,6 +189,18 @@ class _GitGateway:
     def origin_github_repo_slug(self, repo_root: Path) -> str | None:
         return infra_git_cli.origin_github_repo_slug(repo_root)
 
+    def worktree_list(self, repo_root: Path):
+        return infra_git_cli.worktree_list(repo_root)
+
+    def add_worktree_with_new_branch(self, repo_root: Path, *, path: Path, branch: str) -> None:
+        infra_git_cli.add_worktree_with_new_branch(repo_root, path=path, branch=branch)
+
+
+@dataclass(frozen=True)
+class _BootstrapGateway:
+    def run_make_init_if_available(self, worktree_path: Path):
+        return infra_make_cli.run_make_init_if_available(worktree_path)
+
 
 @dataclass(frozen=True)
 class _JsonStore:
@@ -224,6 +238,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         active_state_store=_ActiveStateStore(),
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
+        bootstrap_gateway=_BootstrapGateway(),
         json_store=_JsonStore(),
         clock=_Clock(),
         artifact_writer=_ArtifactWriter(),
@@ -248,5 +263,6 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         issue_finish=lambda req: application_issue_finish(req, ports),
         validate_tree=lambda req: application_validate_tree(req, ports),
         doctor=lambda req: application_doctor(req, ports),
+        worktree_create=lambda req: application_worktree_create(req, ports),
     )
     return BootstrapContext(use_cases=use_cases)

--- a/spec-dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/parser.py
@@ -61,6 +61,14 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     _bind_leaf(issue_sub.add_parser("start", help="Set active issue and checkout its branch"), registry, "issue_start")
     _bind_leaf(issue_sub.add_parser("finish", help="Close active issue and clear active pointers"), registry, "issue_finish")
 
+    p_worktree = sub.add_parser("worktree", help="Manage long-lived Git worktrees")
+    worktree_sub = p_worktree.add_subparsers(dest="worktree_cmd", required=True)
+    _bind_leaf(
+        worktree_sub.add_parser("create", help="Create a sibling Git worktree and optional make init bootstrap"),
+        registry,
+        "worktree_create",
+    )
+
     _bind_leaf(
         sub.add_parser("sync", help="Generate index.json/tree.json (optionally enrich from GitHub)"),
         registry,

--- a/spec-dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/registry.py
@@ -11,6 +11,7 @@ from ..commands import new as new_commands
 from ..commands import sync as sync_commands
 from ..commands import update as update_commands
 from ..commands import validate as validate_commands
+from ..commands import worktree as worktree_commands
 from ..commands.contracts import CommandRegistry, CommandSpec
 
 
@@ -23,6 +24,7 @@ def build_registry() -> CommandRegistry:
     items.update(close_commands.command_specs())
     items.update(update_commands.command_specs())
     items.update(issue_commands.command_specs())
+    items.update(worktree_commands.command_specs())
     items.update(sync_commands.command_specs())
     items.update(deps_commands.command_specs())
     items.update(validate_commands.command_specs())

--- a/spec-dock/scripts/spec_dock_runtime/commands/worktree.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/worktree.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from ..application.contracts import UseCases, WorktreeCreateRequest
+from ..presentation.cli_text import render_worktree_create_text
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+
+
+@dataclass(frozen=True)
+class WorktreeCreateArgs(CommandArgs):
+    label: str | None
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "worktree_create": CommandSpec(
+            add_arguments=_add_worktree_create_arguments,
+            args_factory=_worktree_create_args,
+            run=_run_worktree_create,
+        ),
+    }
+
+
+def _add_worktree_create_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "label",
+        nargs="?",
+        help="Optional lowercase label for the worktree id (letters, digits, hyphens).",
+    )
+
+
+def _worktree_create_args(ns: argparse.Namespace) -> CommandArgs:
+    return WorktreeCreateArgs(label=getattr(ns, "label", None))
+
+
+def _run_worktree_create(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    typed = _expect_worktree_create_args(args)
+    result = use_cases.worktree_create(WorktreeCreateRequest(label=typed.label))
+    return CommandOutcome(exit_code=0, text=render_worktree_create_text(result))
+
+
+def _expect_worktree_create_args(args: CommandArgs) -> WorktreeCreateArgs:
+    if not isinstance(args, WorktreeCreateArgs):
+        raise RuntimeError("Invalid command args for worktree create")
+    return args

--- a/spec-dock/scripts/spec_dock_runtime/infra/git_cli.py
+++ b/spec-dock/scripts/spec_dock_runtime/infra/git_cli.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from ..application.contracts import GitWorktreeRecord
+
 
 def _ensure_git_available() -> None:
     if shutil.which("git") is None:
@@ -156,3 +158,68 @@ def origin_github_repo_slug(repo_root: Path) -> str | None:
             f"fetch={fetch_slug} push={push_slug}"
         )
     return fetch_slug
+
+
+def worktree_list(repo_root: Path) -> list[GitWorktreeRecord]:
+    _ensure_git_available()
+    cmd = ["git", "worktree", "list", "--porcelain"]
+    try:
+        p = subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"git failed: {' '.join(cmd)}\n{(e.stderr or '').strip()}") from e
+    return _parse_worktree_porcelain(p.stdout or "")
+
+
+def add_worktree_with_new_branch(repo_root: Path, *, path: Path, branch: str) -> None:
+    _ensure_git_available()
+    cmd = ["git", "worktree", "add", "-b", branch, str(path)]
+    try:
+        subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        stdout = (e.stdout or "").strip()
+        details = "\n".join(part for part in (stderr, stdout) if part)
+        raise RuntimeError(f"git failed: {' '.join(cmd)}\n{details}") from e
+
+
+def _parse_worktree_porcelain(text: str) -> list[GitWorktreeRecord]:
+    records: list[GitWorktreeRecord] = []
+    current: dict[str, object] = {}
+
+    def flush() -> None:
+        if "path" not in current:
+            return
+        branch_ref = current.get("branch")
+        branch = None
+        if isinstance(branch_ref, str):
+            prefix = "refs/heads/"
+            branch = branch_ref[len(prefix):] if branch_ref.startswith(prefix) else branch_ref
+        records.append(
+            GitWorktreeRecord(
+                path=Path(str(current["path"])),
+                head=current.get("head") if isinstance(current.get("head"), str) else None,
+                branch=branch,
+                detached=bool(current.get("detached", False)),
+                bare=bool(current.get("bare", False)),
+            )
+        )
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            flush()
+            current = {}
+            continue
+        if line.startswith("worktree "):
+            flush()
+            current = {"path": line[len("worktree "):]}
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch "):]
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "bare":
+            current["bare"] = True
+    flush()
+    return records

--- a/spec-dock/scripts/spec_dock_runtime/infra/make_cli.py
+++ b/spec-dock/scripts/spec_dock_runtime/infra/make_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..application.contracts import BootstrapResult
+
+
+_MISSING_INIT_TARGET_FRAGMENTS = (
+    "no rule to make target 'init'",
+    "no rule to make target `init'",
+    "no rule to make target init",
+    "no targets specified and no makefile found",
+    "no makefile found",
+)
+
+
+def run_make_init_if_available(worktree_path: Path) -> BootstrapResult:
+    if shutil.which("make") is None:
+        return BootstrapResult(
+            status="detection_failed",
+            command="make -n init",
+            exit_code=None,
+            warnings=["make init detection failed: make command not found"],
+        )
+
+    dry_run = subprocess.run(
+        ["make", "-n", "init"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if dry_run.returncode != 0:
+        stderr = (dry_run.stderr or "").strip()
+        if _is_missing_init_target(stderr):
+            return BootstrapResult(status="skipped", command=None, exit_code=None, warnings=[])
+        return BootstrapResult(
+            status="detection_failed",
+            command="make -n init",
+            exit_code=dry_run.returncode,
+            warnings=[f"make init detection failed: {stderr or 'unknown error'}"],
+        )
+
+    run = subprocess.run(
+        ["make", "init"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if run.returncode == 0:
+        return BootstrapResult(status="succeeded", command="make init", exit_code=0, warnings=[])
+    stderr = (run.stderr or "").strip()
+    stdout = (run.stdout or "").strip()
+    detail = stderr or stdout or "unknown error"
+    return BootstrapResult(
+        status="failed",
+        command="make init",
+        exit_code=run.returncode,
+        warnings=[f"make init failed: {detail}"],
+    )
+
+
+def _is_missing_init_target(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return any(fragment in lowered for fragment in _MISSING_INIT_TARGET_FRAGMENTS)

--- a/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -20,6 +20,7 @@ from ..application.contracts import (
     PostMutationSyncOutcome,
     SyncCommandResult,
     ValidationResult,
+    WorktreeCreateResult,
 )
 from .contracts import CliText
 
@@ -352,6 +353,20 @@ def render_issue_finish_text(result: IssueFinishResult) -> CliText:
         ),
         warnings=_post_sync_warnings(list(result.warnings), result.post_sync),
     )
+
+
+def render_worktree_create_text(result: WorktreeCreateResult) -> CliText:
+    stdout_lines = [
+        (
+            "spec-dock: ok (worktree create) "
+            f"id={result.id} branch={result.branch_name} path={result.worktree_path}"
+        ),
+        (
+            "spec-dock: worktree bootstrap "
+            f"status={result.bootstrap_status} command={result.bootstrap_command or '-'}"
+        ),
+    ]
+    return CliText(stdout_lines=stdout_lines, stderr_lines=[], warnings=list(result.warnings))
 
 
 def _delete_remote_close_payload(result: DeleteNodeResult) -> dict[str, list[str]]:

--- a/src/spec_dock/assets/spec_dock/docs/guide.md
+++ b/src/spec_dock/assets/spec_dock/docs/guide.md
@@ -11,6 +11,7 @@ runtime command の現行 contract は `./spec-dock/scripts/spec-dock ...` で�
 - `phase_*.md`: shared phase playbook（共通の作り方）
 - `phase_plan_<scope>.md`: scope 固有の plan authoring rule
 - `reference_*.md`: GitHub / naming / deps / sync などの参照仕様
+- Worktree: [reference_worktree.md](reference_worktree.md)
 - `discussions/`: raw capture、ヒアリング、調査、議論、ADR の作業面
 
 phase playbook:
@@ -126,6 +127,7 @@ spec-dock/
 ./spec-dock/scripts/spec-dock deps check <target>
 ./spec-dock/scripts/spec-dock deps add --from <issue-id> --to <issue-id>
 ./spec-dock/scripts/spec-dock deps remove --from <issue-id> --to <issue-id>
+./spec-dock/scripts/spec-dock worktree create [label]
 ./spec-dock/scripts/spec-dock validate
 ./spec-dock/scripts/spec-dock sync
 ```

--- a/src/spec_dock/assets/spec_dock/docs/reference_worktree.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_worktree.md
@@ -1,0 +1,87 @@
+# reference: worktree
+
+`spec-dock worktree` は、長命の手動管理 Git linked worktree を作るための補助コマンドです。
+Codex app が `$CODEX_HOME/worktrees` 配下に作る短命 worktree は、このコマンドの管理対象ではありません。
+
+## command
+
+```bash
+./spec-dock/scripts/spec-dock worktree create [LABEL]
+```
+
+`LABEL` は任意です。指定する場合は lowercase letters、digits、hyphen のみを使います。
+underscore、dot、space、slash、uppercase、shell metacharacters は拒否されます。
+
+## directory layout
+
+main checkout と同じ親ディレクトリに `<repo-basename>-worktrees/` を作り、その中に worktree を作ります。
+main checkout の中に nested `.worktrees/` は作りません。
+
+```text
+~/workspace/tools/
+  spec-dock/
+  spec-dock-worktrees/
+    spec-dock-wt1/
+    spec-dock-feature/
+```
+
+linked worktree から実行した場合も、Git が認識する main worktree を基準に container path と repo basename を決めます。
+branch name は実行元 checkout の current branch を基準にします。
+
+## naming
+
+LABEL なし:
+
+```text
+id: wt1, wt2, wt3, ...
+path: <repo-basename>-worktrees/<repo-basename>-<id>
+branch: <current-branch>-<id>
+```
+
+LABEL あり:
+
+```text
+id: <label>, <label>2, <label>3, ...
+path: <repo-basename>-worktrees/<repo-basename>-<id>
+branch: <current-branch>-<id>
+```
+
+directory、branch、Git worktree record の collision がある場合は次候補へ進みます。
+candidate exhaustion は fatal error です。
+
+## bootstrap
+
+worktree 作成後、new worktree root で `make init` を任意 bootstrap として実行します。
+
+- `make init` target がない場合は `skipped`。
+- `make` が見つからない、Makefile parse error など detection に失敗した場合は `detection_failed` warning。
+- `make init` が失敗した場合は `failed` warning。
+- `make init` が成功した場合は `succeeded`。
+
+bootstrap の detection / execution failure は worktree 作成成功を取り消さず、command exit code も `0` のままです。
+
+## output
+
+成功時は absolute worktree path、id、branch、bootstrap status を出力します。
+bootstrap warning は既存 CLI warning path に流れます。
+
+```text
+spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/spec-dock-worktrees/spec-dock-wt1
+spec-dock: worktree bootstrap status=skipped command=-
+```
+
+## failure
+
+次は fatal error です。
+
+- Git repo 外での実行。
+- detached HEAD での実行。
+- invalid label。
+- container path の作成失敗。
+- non-retryable `git worktree add` failure。
+- candidate retry ceiling exhaustion。
+
+## scope boundary
+
+この command は create のみを扱います。
+`worktree list`、`status`、`remove`、`prune`、Codex-managed worktree cleanup は future extension です。

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
@@ -21,6 +21,7 @@ from ..infra.contracts import StoredMetaRecord
 
 
 POST_MUTATION_FATAL_WARNING_CODES: tuple[str, ...] = ("gh_fetch_failed",)
+BootstrapStatus = Literal["skipped", "succeeded", "failed", "detection_failed"]
 
 
 @dataclass(frozen=True)
@@ -59,6 +60,41 @@ class DoctorFinding:
 class DoctorResult:
     ok: bool
     findings: list[DoctorFinding]
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class GitWorktreeRecord:
+    path: Path
+    head: str | None
+    branch: str | None
+    detached: bool = False
+    bare: bool = False
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    status: BootstrapStatus
+    command: str | None
+    exit_code: int | None
+    warnings: list[str]
+
+
+@dataclass(frozen=True)
+class WorktreeCreateRequest:
+    label: str | None = None
+
+
+@dataclass(frozen=True)
+class WorktreeCreateResult:
+    id: str
+    main_worktree_path: Path
+    container_path: Path
+    worktree_path: Path
+    branch_name: str
+    bootstrap_status: BootstrapStatus
+    bootstrap_command: str | None
+    bootstrap_exit_code: int | None
     warnings: list[str]
 
 
@@ -512,4 +548,7 @@ class UseCases:
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
         lambda _req: DoctorResult(ok=True, findings=[], warnings=[])
+    )
+    worktree_create: Callable[[WorktreeCreateRequest], WorktreeCreateResult] = lambda _req: (_ for _ in ()).throw(
+        RuntimeError("worktree_create is not configured")
     )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from typing import Literal
 from typing import Protocol
 
-from .contracts import ArtifactWriteResult, SyncCommandResult, SyncRequest
+from .contracts import ArtifactWriteResult
+from .contracts import BootstrapResult
+from .contracts import GitWorktreeRecord
+from .contracts import SyncCommandResult
+from .contracts import SyncRequest
 from ..domain.models import IssueSnapshot, SpecGraph
 from ..infra.contracts import ActiveManifest
 from ..infra.contracts import ActiveManifestLoadResult
@@ -153,6 +157,17 @@ class GitGateway(Protocol):
     def origin_github_repo_slug(self, repo_root: Path) -> str | None:
         ...
 
+    def worktree_list(self, repo_root: Path) -> list[GitWorktreeRecord]:
+        ...
+
+    def add_worktree_with_new_branch(self, repo_root: Path, *, path: Path, branch: str) -> None:
+        ...
+
+
+class BootstrapGateway(Protocol):
+    def run_make_init_if_available(self, worktree_path: Path) -> BootstrapResult:
+        ...
+
 
 class ArtifactWriter(Protocol):
     def write(self, specdock_dir: Path, bundle: ArtifactBundle) -> ArtifactWriteResult:
@@ -201,3 +216,4 @@ class Ports:
     clock: Clock | None = None
     artifact_writer: ArtifactWriter | None = None
     sync_legacy_runner: SyncLegacyRunner | None = None
+    bootstrap_gateway: BootstrapGateway | None = None

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .contracts import WorktreeCreateRequest, WorktreeCreateResult
+from .ports import Ports
+
+
+_LABEL_RE = re.compile(r"^[a-z0-9-]+$")
+_MAX_ATTEMPTS = 10000
+_RETRYABLE_GIT_WORKTREE_ERRORS = (
+    "already exists",
+    "is already checked out",
+    "a branch named",
+)
+
+
+def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateResult:
+    if ports.repo_root is None:
+        raise RuntimeError("worktree create requires a repository root")
+    if ports.git_gateway is None:
+        raise RuntimeError("worktree create requires a Git gateway")
+    if ports.bootstrap_gateway is None:
+        raise RuntimeError("worktree create requires a bootstrap gateway")
+
+    label = _normalize_label(req.label)
+    repo_root = ports.repo_root
+    branch_prefix = ports.git_gateway.current_branch_or_none(repo_root)
+    if branch_prefix is None:
+        raise RuntimeError("worktree create requires a named current branch; detached HEAD is not supported")
+
+    records = ports.git_gateway.worktree_list(repo_root)
+    if not records:
+        raise RuntimeError("git worktree list returned no worktrees")
+    main_worktree = records[0].path
+    repo_basename = main_worktree.name
+    container = main_worktree.parent / f"{repo_basename}-worktrees"
+    known_paths = {_canonical_path(record.path) for record in records}
+    last_attempt_id = ""
+    last_reason = "no candidates attempted"
+
+    for index in range(1, _MAX_ATTEMPTS + 1):
+        worktree_id = _candidate_id(label, index)
+        last_attempt_id = worktree_id
+        worktree_path = container / f"{repo_basename}-{worktree_id}"
+        branch_name = f"{branch_prefix}-{worktree_id}"
+
+        collision = _preflight_collision(
+            repo_root=repo_root,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            known_paths=known_paths,
+            ports=ports,
+        )
+        if collision is not None:
+            last_reason = collision
+            continue
+
+        try:
+            container.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            state = _artifact_state(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                known_paths=known_paths,
+                ports=ports,
+                refresh_records=False,
+            )
+            raise RuntimeError(f"failed to create worktree container: {container} {state}\n{exc}") from exc
+
+        try:
+            ports.git_gateway.add_worktree_with_new_branch(repo_root, path=worktree_path, branch=branch_name)
+        except RuntimeError as exc:
+            message = str(exc)
+            if _is_retryable_worktree_add_error(message):
+                records = ports.git_gateway.worktree_list(repo_root)
+                known_paths = {_canonical_path(record.path) for record in records}
+                last_reason = f"retryable git collision: {message}"
+                continue
+            state = _artifact_state(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                known_paths=known_paths,
+                ports=ports,
+                refresh_records=True,
+            )
+            raise RuntimeError(
+                "git worktree add failed for non-retryable reason: "
+                f"id={worktree_id} path={worktree_path} branch={branch_name} {state}\n{message}"
+            ) from exc
+
+        bootstrap = ports.bootstrap_gateway.run_make_init_if_available(worktree_path)
+        return WorktreeCreateResult(
+            id=worktree_id,
+            main_worktree_path=main_worktree,
+            container_path=container,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            bootstrap_status=bootstrap.status,
+            bootstrap_command=bootstrap.command,
+            bootstrap_exit_code=bootstrap.exit_code,
+            warnings=list(bootstrap.warnings),
+        )
+
+    mode = "label" if label is not None else "auto"
+    raise RuntimeError(
+        "worktree create exhausted candidate attempts: "
+        f"mode={mode} last_id={last_attempt_id} container={container} reason={last_reason}"
+    )
+
+
+def _normalize_label(label: str | None) -> str | None:
+    if label is None:
+        return None
+    if not label:
+        raise RuntimeError("invalid worktree label: use lowercase letters, digits, and hyphens only")
+    if _LABEL_RE.fullmatch(label) is None:
+        raise RuntimeError("invalid worktree label: use lowercase letters, digits, and hyphens only")
+    return label
+
+
+def _candidate_id(label: str | None, index: int) -> str:
+    if label is None:
+        return f"wt{index}"
+    if index == 1:
+        return label
+    return f"{label}{index}"
+
+
+def _preflight_collision(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    branch_name: str,
+    known_paths: set[str],
+    ports: Ports,
+) -> str | None:
+    assert ports.git_gateway is not None
+    if _canonical_path(worktree_path) in known_paths:
+        return "worktree record already exists"
+    if worktree_path.exists():
+        return "worktree path already exists"
+    if ports.git_gateway.local_branch_exists(repo_root, branch_name):
+        return "branch already exists"
+    if not ports.git_gateway.check_ref_format_branch(repo_root, branch_name):
+        raise RuntimeError(f"generated worktree branch is invalid: {branch_name}")
+    return None
+
+
+def _canonical_path(path: Path) -> str:
+    return str(path.expanduser().resolve(strict=False))
+
+
+def _is_retryable_worktree_add_error(message: str) -> bool:
+    lowered = message.lower()
+    return any(fragment in lowered for fragment in _RETRYABLE_GIT_WORKTREE_ERRORS)
+
+
+def _artifact_state(
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+    branch_name: str,
+    known_paths: set[str],
+    ports: Ports,
+    refresh_records: bool,
+) -> str:
+    assert ports.git_gateway is not None
+    record_paths = known_paths
+    if refresh_records:
+        try:
+            record_paths = {_canonical_path(record.path) for record in ports.git_gateway.worktree_list(repo_root)}
+        except RuntimeError:
+            record_paths = known_paths
+    try:
+        branch_exists = ports.git_gateway.local_branch_exists(repo_root, branch_name)
+    except RuntimeError:
+        branch_exists = "unknown"
+    path_exists = worktree_path.exists()
+    record_exists = _canonical_path(worktree_path) in record_paths
+    return (
+        "artifact_state="
+        f"path_exists:{path_exists},"
+        f"branch_exists:{branch_exists},"
+        f"record_exists:{record_exists}"
+    )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -24,6 +24,7 @@ from ..application.set_active import set_active as application_set_active
 from ..application.set_active import show_active as application_show_active
 from ..application.sync_state import sync as application_sync
 from ..application.validate_tree import validate_tree as application_validate_tree
+from ..application.worktree import worktree_create as application_worktree_create
 from ..infra import active_store as infra_active_store
 from ..infra import artifact_writer as infra_artifact_writer
 from ..infra import clock as infra_clock
@@ -33,6 +34,7 @@ from ..infra import fs_repo as infra_fs_repo
 from ..infra import git_cli as infra_git_cli
 from ..infra import github_cli as infra_github_cli
 from ..infra import json_store as infra_json_store
+from ..infra import make_cli as infra_make_cli
 from ..infra import template_scaffolder as infra_template_scaffolder
 
 
@@ -187,6 +189,18 @@ class _GitGateway:
     def origin_github_repo_slug(self, repo_root: Path) -> str | None:
         return infra_git_cli.origin_github_repo_slug(repo_root)
 
+    def worktree_list(self, repo_root: Path):
+        return infra_git_cli.worktree_list(repo_root)
+
+    def add_worktree_with_new_branch(self, repo_root: Path, *, path: Path, branch: str) -> None:
+        infra_git_cli.add_worktree_with_new_branch(repo_root, path=path, branch=branch)
+
+
+@dataclass(frozen=True)
+class _BootstrapGateway:
+    def run_make_init_if_available(self, worktree_path: Path):
+        return infra_make_cli.run_make_init_if_available(worktree_path)
+
 
 @dataclass(frozen=True)
 class _JsonStore:
@@ -224,6 +238,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         active_state_store=_ActiveStateStore(),
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
+        bootstrap_gateway=_BootstrapGateway(),
         json_store=_JsonStore(),
         clock=_Clock(),
         artifact_writer=_ArtifactWriter(),
@@ -248,5 +263,6 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         issue_finish=lambda req: application_issue_finish(req, ports),
         validate_tree=lambda req: application_validate_tree(req, ports),
         doctor=lambda req: application_doctor(req, ports),
+        worktree_create=lambda req: application_worktree_create(req, ports),
     )
     return BootstrapContext(use_cases=use_cases)

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
@@ -61,6 +61,14 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     _bind_leaf(issue_sub.add_parser("start", help="Set active issue and checkout its branch"), registry, "issue_start")
     _bind_leaf(issue_sub.add_parser("finish", help="Close active issue and clear active pointers"), registry, "issue_finish")
 
+    p_worktree = sub.add_parser("worktree", help="Manage long-lived Git worktrees")
+    worktree_sub = p_worktree.add_subparsers(dest="worktree_cmd", required=True)
+    _bind_leaf(
+        worktree_sub.add_parser("create", help="Create a sibling Git worktree and optional make init bootstrap"),
+        registry,
+        "worktree_create",
+    )
+
     _bind_leaf(
         sub.add_parser("sync", help="Generate index.json/tree.json (optionally enrich from GitHub)"),
         registry,

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
@@ -11,6 +11,7 @@ from ..commands import new as new_commands
 from ..commands import sync as sync_commands
 from ..commands import update as update_commands
 from ..commands import validate as validate_commands
+from ..commands import worktree as worktree_commands
 from ..commands.contracts import CommandRegistry, CommandSpec
 
 
@@ -23,6 +24,7 @@ def build_registry() -> CommandRegistry:
     items.update(close_commands.command_specs())
     items.update(update_commands.command_specs())
     items.update(issue_commands.command_specs())
+    items.update(worktree_commands.command_specs())
     items.update(sync_commands.command_specs())
     items.update(deps_commands.command_specs())
     items.update(validate_commands.command_specs())

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+from ..application.contracts import UseCases, WorktreeCreateRequest
+from ..presentation.cli_text import render_worktree_create_text
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+
+
+@dataclass(frozen=True)
+class WorktreeCreateArgs(CommandArgs):
+    label: str | None
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "worktree_create": CommandSpec(
+            add_arguments=_add_worktree_create_arguments,
+            args_factory=_worktree_create_args,
+            run=_run_worktree_create,
+        ),
+    }
+
+
+def _add_worktree_create_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "label",
+        nargs="?",
+        help="Optional lowercase label for the worktree id (letters, digits, hyphens).",
+    )
+
+
+def _worktree_create_args(ns: argparse.Namespace) -> CommandArgs:
+    return WorktreeCreateArgs(label=getattr(ns, "label", None))
+
+
+def _run_worktree_create(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    typed = _expect_worktree_create_args(args)
+    result = use_cases.worktree_create(WorktreeCreateRequest(label=typed.label))
+    return CommandOutcome(exit_code=0, text=render_worktree_create_text(result))
+
+
+def _expect_worktree_create_args(args: CommandArgs) -> WorktreeCreateArgs:
+    if not isinstance(args, WorktreeCreateArgs):
+        raise RuntimeError("Invalid command args for worktree create")
+    return args

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/git_cli.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/git_cli.py
@@ -5,6 +5,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from ..application.contracts import GitWorktreeRecord
+
 
 def _ensure_git_available() -> None:
     if shutil.which("git") is None:
@@ -156,3 +158,68 @@ def origin_github_repo_slug(repo_root: Path) -> str | None:
             f"fetch={fetch_slug} push={push_slug}"
         )
     return fetch_slug
+
+
+def worktree_list(repo_root: Path) -> list[GitWorktreeRecord]:
+    _ensure_git_available()
+    cmd = ["git", "worktree", "list", "--porcelain"]
+    try:
+        p = subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"git failed: {' '.join(cmd)}\n{(e.stderr or '').strip()}") from e
+    return _parse_worktree_porcelain(p.stdout or "")
+
+
+def add_worktree_with_new_branch(repo_root: Path, *, path: Path, branch: str) -> None:
+    _ensure_git_available()
+    cmd = ["git", "worktree", "add", "-b", branch, str(path)]
+    try:
+        subprocess.run(cmd, cwd=str(repo_root), capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        stderr = (e.stderr or "").strip()
+        stdout = (e.stdout or "").strip()
+        details = "\n".join(part for part in (stderr, stdout) if part)
+        raise RuntimeError(f"git failed: {' '.join(cmd)}\n{details}") from e
+
+
+def _parse_worktree_porcelain(text: str) -> list[GitWorktreeRecord]:
+    records: list[GitWorktreeRecord] = []
+    current: dict[str, object] = {}
+
+    def flush() -> None:
+        if "path" not in current:
+            return
+        branch_ref = current.get("branch")
+        branch = None
+        if isinstance(branch_ref, str):
+            prefix = "refs/heads/"
+            branch = branch_ref[len(prefix):] if branch_ref.startswith(prefix) else branch_ref
+        records.append(
+            GitWorktreeRecord(
+                path=Path(str(current["path"])),
+                head=current.get("head") if isinstance(current.get("head"), str) else None,
+                branch=branch,
+                detached=bool(current.get("detached", False)),
+                bare=bool(current.get("bare", False)),
+            )
+        )
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            flush()
+            current = {}
+            continue
+        if line.startswith("worktree "):
+            flush()
+            current = {"path": line[len("worktree "):]}
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):]
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch "):]
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "bare":
+            current["bare"] = True
+    flush()
+    return records

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/make_cli.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/make_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from ..application.contracts import BootstrapResult
+
+
+_MISSING_INIT_TARGET_FRAGMENTS = (
+    "no rule to make target 'init'",
+    "no rule to make target `init'",
+    "no rule to make target init",
+    "no targets specified and no makefile found",
+    "no makefile found",
+)
+
+
+def run_make_init_if_available(worktree_path: Path) -> BootstrapResult:
+    if shutil.which("make") is None:
+        return BootstrapResult(
+            status="detection_failed",
+            command="make -n init",
+            exit_code=None,
+            warnings=["make init detection failed: make command not found"],
+        )
+
+    dry_run = subprocess.run(
+        ["make", "-n", "init"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if dry_run.returncode != 0:
+        stderr = (dry_run.stderr or "").strip()
+        if _is_missing_init_target(stderr):
+            return BootstrapResult(status="skipped", command=None, exit_code=None, warnings=[])
+        return BootstrapResult(
+            status="detection_failed",
+            command="make -n init",
+            exit_code=dry_run.returncode,
+            warnings=[f"make init detection failed: {stderr or 'unknown error'}"],
+        )
+
+    run = subprocess.run(
+        ["make", "init"],
+        cwd=str(worktree_path),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if run.returncode == 0:
+        return BootstrapResult(status="succeeded", command="make init", exit_code=0, warnings=[])
+    stderr = (run.stderr or "").strip()
+    stdout = (run.stdout or "").strip()
+    detail = stderr or stdout or "unknown error"
+    return BootstrapResult(
+        status="failed",
+        command="make init",
+        exit_code=run.returncode,
+        warnings=[f"make init failed: {detail}"],
+    )
+
+
+def _is_missing_init_target(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return any(fragment in lowered for fragment in _MISSING_INIT_TARGET_FRAGMENTS)

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -20,6 +20,7 @@ from ..application.contracts import (
     PostMutationSyncOutcome,
     SyncCommandResult,
     ValidationResult,
+    WorktreeCreateResult,
 )
 from .contracts import CliText
 
@@ -352,6 +353,20 @@ def render_issue_finish_text(result: IssueFinishResult) -> CliText:
         ),
         warnings=_post_sync_warnings(list(result.warnings), result.post_sync),
     )
+
+
+def render_worktree_create_text(result: WorktreeCreateResult) -> CliText:
+    stdout_lines = [
+        (
+            "spec-dock: ok (worktree create) "
+            f"id={result.id} branch={result.branch_name} path={result.worktree_path}"
+        ),
+        (
+            "spec-dock: worktree bootstrap "
+            f"status={result.bootstrap_status} command={result.bootstrap_command or '-'}"
+        ),
+    ]
+    return CliText(stdout_lines=stdout_lines, stderr_lines=[], warnings=list(result.warnings))
 
 
 def _delete_remote_close_payload(result: DeleteNodeResult) -> dict[str, list[str]]:

--- a/tests/cli_runtime/test_worktree.py
+++ b/tests/cli_runtime/test_worktree.py
@@ -1,0 +1,360 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from tests.cli_runtime.harness import CliRuntimeHarness, main
+
+
+class TestCliWorktree(CliRuntimeHarness):
+    def _prepare_git_repo(self, target: Path) -> None:
+        if shutil.which("git") is None:
+            self.skipTest("git not available")
+        self.assertEqual(main(["init", str(target)]), 0)
+        self._run_git(target, ["init"])
+        self._run_git(target, ["add", "-A"])
+        self._run_git(
+            target,
+            ["-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "-m", "init"],
+        )
+
+    def test_worktree_create_uses_sibling_container_auto_id_and_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"])
+
+            self.assertEqual(p.returncode, 0, p.stderr)
+            current_branch = self._run_git(target, ["branch", "--show-current"]).stdout.strip()
+            expected_path = (target.parent / "sample-repo-worktrees" / "sample-repo-wt1").resolve()
+            self.assertIn(f"id=wt1", p.stdout)
+            self.assertIn(f"path={expected_path}", p.stdout)
+            self.assertIn("bootstrap status=skipped", p.stdout)
+            self.assertTrue(expected_path.is_dir())
+            self.assertTrue((expected_path / "spec-dock" / "scripts" / "spec-dock").is_file())
+            worktree_list = self._run_git(target, ["worktree", "list", "--porcelain"]).stdout
+            self.assertIn(str(expected_path), worktree_list)
+            self.assertIn(f"branch refs/heads/{current_branch}-wt1", worktree_list)
+
+    def test_worktree_create_retries_collisions_and_accepts_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            first = self._run_runtime_capture(target, ["worktree", "create", "feature"])
+            second = self._run_runtime_capture(target, ["worktree", "create", "feature"])
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            current_branch = self._run_git(target, ["branch", "--show-current"]).stdout.strip()
+            self.assertIn(f"id=feature branch={current_branch}-feature", first.stdout)
+            self.assertIn(f"id=feature2 branch={current_branch}-feature2", second.stdout)
+
+    def test_worktree_create_retries_auto_id_collisions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            first = self._run_runtime_capture(target, ["worktree", "create"])
+            second = self._run_runtime_capture(target, ["worktree", "create"])
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            current_branch = self._run_git(target, ["branch", "--show-current"]).stdout.strip()
+            self.assertIn(f"id=wt1 branch={current_branch}-wt1", first.stdout)
+            self.assertIn(f"id=wt2 branch={current_branch}-wt2", second.stdout)
+
+    def test_worktree_create_rejects_invalid_labels_without_creating_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            for label in (
+                "bad_label",
+                "Bad",
+                "bad.label",
+                "bad/label",
+                "bad label",
+                " label",
+                " ",
+                "bad;label",
+                "bad$label",
+                "bad&label",
+            ):
+                with self.subTest(label=label):
+                    p = self._run_runtime_capture(target, ["worktree", "create", label])
+
+                    self.assertNotEqual(p.returncode, 0)
+                    self.assertIn("invalid worktree label", p.stderr)
+            self.assertFalse((target.parent / "sample-repo-worktrees").exists())
+
+    def test_worktree_create_help_exposes_optional_label(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create", "--help"])
+
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn("worktree create [-h] [label]", p.stdout)
+            self.assertIn("Optional lowercase label", p.stdout)
+
+    def test_worktree_create_uses_current_branch_with_slash_for_branch_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            self._run_git(target, ["checkout", "-b", "feature/base"])
+
+            p = self._run_runtime_capture(target, ["worktree", "create", "slice"])
+
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn("id=slice branch=feature/base-slice", p.stdout)
+
+    def test_worktree_create_runs_make_init_when_available(self) -> None:
+        if shutil.which("make") is None:
+            self.skipTest("make not available")
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            (target / "Makefile").write_text("init:\n\t@echo initialized > .init-ran\n", encoding="utf-8")
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create", "setup"])
+
+            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-setup"
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn("bootstrap status=succeeded", p.stdout)
+            self.assertEqual((worktree_path / ".init-ran").read_text(encoding="utf-8").strip(), "initialized")
+
+    def test_worktree_create_keeps_worktree_when_make_init_fails(self) -> None:
+        if shutil.which("make") is None:
+            self.skipTest("make not available")
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            (target / "Makefile").write_text("init:\n\t@exit 7\n", encoding="utf-8")
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create", "setup"])
+
+            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-setup"
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn("bootstrap status=failed", p.stdout)
+            self.assertIn("spec-dock: (warn) make init failed:", p.stderr)
+            self.assertTrue(worktree_path.is_dir())
+            current_branch = self._run_git(target, ["branch", "--show-current"]).stdout.strip()
+            self.assertIn(
+                f"branch refs/heads/{current_branch}-setup",
+                self._run_git(target, ["worktree", "list", "--porcelain"]).stdout,
+            )
+
+    def test_worktree_create_keeps_worktree_when_make_init_detection_fails(self) -> None:
+        if shutil.which("make") is None:
+            self.skipTest("make not available")
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            (target / "Makefile").write_text("include missing.mk\ninit:\n\t@true\n", encoding="utf-8")
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create", "detect"])
+
+            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-detect"
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn("bootstrap status=detection_failed", p.stdout)
+            self.assertIn("spec-dock: (warn) make init detection failed:", p.stderr)
+            self.assertTrue(worktree_path.is_dir())
+
+    def test_worktree_create_fails_from_detached_head(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            head = self._run_git(target, ["rev-parse", "HEAD"]).stdout.strip()
+            self._run_git(target, ["checkout", "--detach", head])
+
+            p = self._run_runtime_capture(target, ["worktree", "create"])
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("detached HEAD is not supported", p.stderr)
+            self.assertFalse((target.parent / "sample-repo-worktrees").exists())
+
+    def test_worktree_create_fails_outside_git_repo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "plain-dir"
+            target.mkdir()
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"])
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("git failed: git rev-parse --abbrev-ref HEAD", p.stderr)
+
+    def test_worktree_create_fails_when_container_path_is_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            (target.parent / "sample-repo-worktrees").write_text("not a directory\n", encoding="utf-8")
+
+            p = self._run_runtime_capture(target, ["worktree", "create"])
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("failed to create worktree container", p.stderr)
+            self.assertIn("artifact_state=path_exists:False,branch_exists:False,record_exists:False", p.stderr)
+            self.assertFalse((target.parent / "sample-repo-worktrees" / "sample-repo-wt1").exists())
+
+    def test_worktree_create_treats_non_collision_git_add_failure_as_fatal(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_scripts_dir = Path(__file__).resolve().parents[2] / "src" / "spec_dock" / "assets" / "spec_dock" / "scripts"
+            sys_path_inserted = False
+
+            if str(runtime_scripts_dir) not in sys.path:
+                sys.path.insert(0, str(runtime_scripts_dir))
+                sys_path_inserted = True
+            try:
+                from spec_dock_runtime.application import contracts as app_contracts
+                from spec_dock_runtime.application import ports as app_ports
+                from spec_dock_runtime.application import worktree as app_worktree
+            finally:
+                if sys_path_inserted:
+                    sys.path.pop(0)
+
+            class FakeGitGateway:
+                def __init__(self) -> None:
+                    self.list_calls = 0
+
+                def current_branch_or_none(self, repo_root):
+                    return "main"
+
+                def worktree_list(self, repo_root):
+                    self.list_calls += 1
+                    if self.list_calls == 1:
+                        return [app_contracts.GitWorktreeRecord(path=Path(tmp) / "repo", head="abc", branch="main")]
+                    return [
+                        app_contracts.GitWorktreeRecord(path=Path(tmp) / "repo", head="abc", branch="main"),
+                        app_contracts.GitWorktreeRecord(
+                            path=Path(tmp) / "repo-worktrees" / "repo-wt1",
+                            head="abc",
+                            branch="main-wt1",
+                        ),
+                    ]
+
+                def local_branch_exists(self, repo_root, branch):
+                    return False
+
+                def check_ref_format_branch(self, repo_root, branch):
+                    return True
+
+                def add_worktree_with_new_branch(self, repo_root, *, path, branch):
+                    raise RuntimeError("git failed: git worktree add\nfatal: cannot lock ref 'refs/heads/main-wt1': Permission denied")
+
+            class FakeBootstrapGateway:
+                def run_make_init_if_available(self, worktree_path):
+                    raise AssertionError("bootstrap must not run after git add failure")
+
+            ports = app_ports.Ports(
+                node_reader=object(),
+                repo_root=Path(tmp) / "repo",
+                git_gateway=FakeGitGateway(),
+                bootstrap_gateway=FakeBootstrapGateway(),
+            )
+
+            with self.assertRaises(RuntimeError) as raised:
+                app_worktree.worktree_create(app_contracts.WorktreeCreateRequest(), ports)
+
+            message = str(raised.exception)
+            self.assertIn("non-retryable", message)
+            self.assertIn("cannot lock ref", message)
+            self.assertIn("artifact_state=path_exists:False,branch_exists:False,record_exists:True", message)
+            self.assertNotIn("exhausted candidate attempts", message)
+
+    def test_worktree_create_retries_git_add_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime_scripts_dir = Path(__file__).resolve().parents[2] / "src" / "spec_dock" / "assets" / "spec_dock" / "scripts"
+            sys_path_inserted = False
+
+            if str(runtime_scripts_dir) not in sys.path:
+                sys.path.insert(0, str(runtime_scripts_dir))
+                sys_path_inserted = True
+            try:
+                from spec_dock_runtime.application import contracts as app_contracts
+                from spec_dock_runtime.application import ports as app_ports
+                from spec_dock_runtime.application import worktree as app_worktree
+            finally:
+                if sys_path_inserted:
+                    sys.path.pop(0)
+
+            class FakeGitGateway:
+                def __init__(self) -> None:
+                    self.add_calls: list[tuple[Path, str]] = []
+
+                def current_branch_or_none(self, repo_root):
+                    return "main"
+
+                def worktree_list(self, repo_root):
+                    return [app_contracts.GitWorktreeRecord(path=Path(tmp) / "repo", head="abc", branch="main")]
+
+                def local_branch_exists(self, repo_root, branch):
+                    return False
+
+                def check_ref_format_branch(self, repo_root, branch):
+                    return True
+
+                def add_worktree_with_new_branch(self, repo_root, *, path, branch):
+                    self.add_calls.append((path, branch))
+                    if len(self.add_calls) == 1:
+                        raise RuntimeError("git failed: fatal: a branch named 'main-wt1' already exists")
+
+            class FakeBootstrapGateway:
+                def run_make_init_if_available(self, worktree_path):
+                    return app_contracts.BootstrapResult(
+                        status="skipped",
+                        command="make init",
+                        exit_code=None,
+                        warnings=[],
+                    )
+
+            git_gateway = FakeGitGateway()
+            ports = app_ports.Ports(
+                node_reader=object(),
+                repo_root=Path(tmp) / "repo",
+                git_gateway=git_gateway,
+                bootstrap_gateway=FakeBootstrapGateway(),
+            )
+
+            result = app_worktree.worktree_create(app_contracts.WorktreeCreateRequest(), ports)
+
+            self.assertEqual(result.id, "wt2")
+            self.assertEqual([branch for _, branch in git_gateway.add_calls], ["main-wt1", "main-wt2"])
+
+    def test_worktree_create_normalizes_container_from_linked_worktree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            first = self._run_runtime_capture(target, ["worktree", "create", "outer"])
+            self.assertEqual(first.returncode, 0, first.stderr)
+            linked = target.parent / "sample-repo-worktrees" / "sample-repo-outer"
+
+            p = subprocess.run(
+                [str(linked / "spec-dock" / "scripts" / "spec-dock"), "worktree", "create", "inner"],
+                cwd=str(linked),
+                env=os.environ.copy(),
+                capture_output=True,
+                text=True,
+            )
+
+            expected = (target.parent / "sample-repo-worktrees" / "sample-repo-inner").resolve()
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn(f"path={expected}", p.stdout)
+            current_branch = self._run_git(linked, ["branch", "--show-current"]).stdout.strip()
+            self.assertIn(f"branch={current_branch}-inner", p.stdout)
+            self.assertTrue(expected.is_dir())

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -83,6 +83,9 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/templates/README.md": "src/spec_dock/assets/spec_dock/templates/README.md",
         "spec-dock/scripts/README.md": "src/spec_dock/assets/spec_dock/scripts/README.md",
         "spec-dock/docs/guide.md": "src/spec_dock/assets/spec_dock/docs/guide.md",
+        "spec-dock/docs/reference_worktree.md": (
+            "src/spec_dock/assets/spec_dock/docs/reference_worktree.md"
+        ),
         "spec-dock/docs/phase_requirement.md": (
             "src/spec_dock/assets/spec_dock/docs/phase_requirement.md"
         ),
@@ -191,6 +194,9 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/scripts/spec_dock_runtime/application/sync_state.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/sync_state.py"
         ),
+        "spec-dock/scripts/spec_dock_runtime/application/worktree.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py"
+        ),
         "spec-dock/scripts/spec_dock_runtime/application/import_node.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/import_node.py"
         ),
@@ -212,11 +218,17 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/scripts/spec_dock_runtime/commands/import_cmd.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/import_cmd.py"
         ),
+        "spec-dock/scripts/spec_dock_runtime/commands/worktree.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py"
+        ),
         "spec-dock/scripts/spec_dock_runtime/domain/validation.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/domain/validation.py"
         ),
         "spec-dock/scripts/spec_dock_runtime/infra/git_cli.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/git_cli.py"
+        ),
+        "spec-dock/scripts/spec_dock_runtime/infra/make_cli.py": (
+            "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/make_cli.py"
         ),
         "spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py": (
             "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py"
@@ -733,6 +745,10 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00096-self-update-command/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00033-github-backed-identity-and-adr-mirror-workflow/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00033-github-backed-identity-and-adr-mirror-workflow/issues/iss-00034-github-mandatory-node-creation-contract/.meta.json",
@@ -783,6 +799,10 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00096-self-update-command/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00108-worktree-create-cli-and-output/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00109-worktree-docs-dogfooding-and-final-verification/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00110-worktree-create-core-use-case/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00033-github-backed-identity-and-adr-mirror-workflow/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00033-github-backed-identity-and-adr-mirror-workflow/issues/iss-00034-github-mandatory-node-creation-contract/.meta.json": [],


### PR DESCRIPTION
## 概要

- `spec-dock worktree create [label]` を追加し、長命開発用の linked worktree を sibling `<repo>-worktrees` 配下に作成できるようにした。
- worktree 作成後に任意の `make init` を非致命で実行し、作成結果と bootstrap 結果を CLI 出力で確認できるようにした。
- epic `#107` 配下の 3 issue を 1 つの PR に束ね、provider 側 runtime、dogfooding mirror、参照ドキュメント、回帰テストをまとめて更新した。

## 背景・目的

- spec-dock の開発で、main checkout だけでなく issue 単位の長命 worktree を使った並行開発を標準フローとして扱えるようにするため。
- main repository 内に nested worktree を置かず、repository basename に `-worktrees` を付けた sibling container を使う運用を CLI と docs に固定するため。
- GitHub-backed issue を spec-dock の既定フローで作成しつつ、今回は issue 単位 PR ではなく epic 単位 PR でまとめて閉じる方針に合わせた。

## 変更内容

- `WorktreeCreateRequest` / `WorktreeCreateResult` と Git / bootstrap ports を追加し、worktree 作成ユースケースを application 層に追加した。
- `git worktree list --porcelain` の解析、main worktree 起点の sibling container 解決、label / branch / path 衝突回避、retryable / non-retryable エラー判定を実装した。
- `make -n init` で target の有無を検出し、存在する場合だけ `make init` を実行する bootstrap adapter を追加した。検出失敗や実行失敗は worktree 作成自体を失敗扱いにしない。
- CLI に `worktree create [label]` を追加し、text output に id / branch / path と bootstrap status を表示するようにした。
- provider asset と dogfooding workspace の runtime / docs mirror を更新し、`reference_worktree.md` と guide からの導線を追加した。
- GitHub issue `#108`、`#109`、`#110` に対応する spec-dock issue docs と epic docs を追加・更新した。

## 影響範囲

- `spec-dock` runtime CLI の新規 command surface に影響する。
- Git 操作は linked worktree 作成、branch 作成、worktree 一覧読み取りに限定される。
- DB、外部 API、認証、既存 spec-dock node lifecycle の永続化契約には影響しない。
- scaffolded asset と dogfooding mirror の parity に影響するため、install/update で配布される runtime と docs の内容も変わる。

## 検証

- [x] `python -m unittest tests.cli_runtime.test_worktree tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets -v` が成功
- [x] `python -m unittest discover -v` が成功（827 tests）
- [x] `./spec-dock/scripts/spec-dock validate` が成功
- [x] `./spec-dock/scripts/spec-dock sync` が成功
- [x] `git diff --check` が成功
- [x] spec-reviewer / code-reviewer / QA reviewer が pass

## リスク・注意点

- `make init` は任意 target として扱い、失敗しても worktree 作成を失敗させないため、依存 install や local setup の失敗は bootstrap warning として利用者が確認する必要がある。
- branch 名は現在 branch 名に worktree id を suffix するため、base branch 名に slash が含まれるケースはテスト済みだが、リモート運用上の命名規約は各 repository のルールに依存する。
- `issue finish` は merge 前に実行すると GitHub issue を閉じるため、この PR では merge 後の closure に委ねる。

## 確認観点

- `worktree create` が main checkout と linked worktree のどちらから実行されても、main worktree の sibling container を選ぶこと。
- label validation が `^[a-z0-9-]+$` に閉じており、空白・大文字・dot・slash・shell metacharacter を受け付けないこと。
- Git collision 時の retry と、非 retryable error 時の `artifact_state` 出力がレビューに十分な情報を残すこと。
- provider side と dogfooding mirror の runtime / docs が parity test で一致していること。

## フォローアップ

- merge 後に spec-dock workflow に沿って issue / epic finish を実行する。
- 必要であれば、bootstrap warning の JSON output や retry ceiling 到達時の専用テストを追加する。

Refs #107
Closes #108
Closes #109
Closes #110
