### PR TITLE
feat(worktree)!: worktree作成を中央root配置に変更

### DIFF
--- a/spec-dock/docs/reference_worktree.md
+++ b/spec-dock/docs/reference_worktree.md
@@ -14,19 +14,38 @@ underscore、dot、space、slash、uppercase、shell metacharacters は拒否さ
 
 ## ディレクトリ構成（directory layout）
 
-main checkout と同じ親ディレクトリに `<repo-basename>-worktrees/` を作り、その中に worktree を作ります。
-main checkout の中に nested `.worktrees/` は作りません。
+`worktree create` は `SPEC_DOCK_WORKTREE_ROOT` で指定した central root 配下に、repo basename の namespace directory を作り、その中に worktree を作ります。
+`SPEC_DOCK_WORKTREE_ROOT` は必須です。未設定、空文字、空白のみの場合は fatal error になり、Git branch、worktree directory、bootstrap side effect は作られません。
+
+設定例:
+
+```bash
+export SPEC_DOCK_WORKTREE_ROOT="$HOME/workspace/worktrees"
+```
+
+layout:
 
 ```text
-~/workspace/tools/
+~/workspace/worktrees/
   spec-dock/
-  spec-dock-worktrees/
     spec-dock-wt1/
     spec-dock-feature/
 ```
 
-linked worktree から実行した場合も、Git が認識する main worktree を基準に container path と repo basename を決めます。
+worktree path は `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>` です。
+central root directory と namespace directory は、必要に応じて command が作成します。
+main checkout の中に nested `.worktrees/` は作りません。
+
+`SPEC_DOCK_WORKTREE_ROOT` は `~` 展開後に absolute path である必要があります。
+通常 directory と directory を指す symlink は許可されます。
+relative path、file、壊れた symlink、directory として使えない path は fatal error です。
+
+linked worktree から実行した場合も、Git が認識する main worktree を基準に namespace と repo basename を決めます。
 branch name は実行元 checkout の current branch を基準にします。
+
+過去バージョンで作られた sibling `<repo-basename>-worktrees/` は legacy placement です。
+この command は既存 sibling worktree を移動・削除・migration しません。
+future `worktree create` は central root を使い、missing env var 時に sibling placement へ fallback しません。
 
 ## 命名（naming）
 
@@ -34,7 +53,7 @@ LABEL なし:
 
 ```text
 id: wt1, wt2, wt3, ...
-path: <repo-basename>-worktrees/<repo-basename>-<id>
+path: $SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>
 branch: <current-branch>-<id>
 ```
 
@@ -42,7 +61,7 @@ LABEL あり:
 
 ```text
 id: <label>, <label>2, <label>3, ...
-path: <repo-basename>-worktrees/<repo-basename>-<id>
+path: $SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>
 branch: <current-branch>-<id>
 ```
 
@@ -66,7 +85,7 @@ bootstrap の detection / execution failure は worktree 作成成功を取り�
 bootstrap warning は既存 CLI warning path に流れます。
 
 ```text
-spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/spec-dock-worktrees/spec-dock-wt1
+spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/worktrees/spec-dock/spec-dock-wt1
 spec-dock: worktree bootstrap status=skipped command=-
 ```
 
@@ -77,7 +96,9 @@ spec-dock: worktree bootstrap status=skipped command=-
 - Git repo 外での実行。
 - detached HEAD での実行。
 - invalid label。
-- container path の作成失敗。
+- missing / blank `SPEC_DOCK_WORKTREE_ROOT`。
+- invalid `SPEC_DOCK_WORKTREE_ROOT`。
+- central root / namespace directory の作成失敗。
 - non-retryable `git worktree add` failure。
 - candidate retry ceiling exhaustion。
 

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/design.md
@@ -16,7 +16,7 @@ ID: "epic-00107"
 - 対象境界:
   - `spec-dock worktree create [LABEL]` を runtime command として追加する。
   - command は Git linked worktree と initial branch を作るが、spec node / active pointer / GitHub issue は変更しない。
-  - 作成先は main worktree の sibling container `<repo-basename>-worktrees/` 配下へ正規化する。
+  - 作成先は `SPEC_DOCK_WORKTREE_ROOT` 配下の `<repo-basename>/` namespace へ正規化する。
   - 作成後 bootstrap は optional / non-fatal な `make init` として扱う。
 - 影響領域:
   - CLI parser / registry
@@ -65,7 +65,7 @@ package "commands" {
 package "application" {
   [contracts.py\nWorktreeCreateRequest/Result] as Contracts
   [worktree.py\ncreate_worktree] as UseCase
-  [ports.py\nGitGateway + BootstrapGateway] as Ports
+  [ports.py\nEnvironmentGateway + GitGateway + BootstrapGateway] as Ports
 }
 
 package "infra" {
@@ -136,6 +136,7 @@ presentation --> application : result dataclasses only
 設計判断:
 - `application.contracts.UseCases` に `worktree_create` callable を追加する。
 - `application.ports.GitGateway` は worktree-specific methods を追加してよい。ただし `make init` は Git の責務ではないため、別 protocol `BootstrapGateway` を追加する。
+- `application.ports.EnvironmentGateway` は `SPEC_DOCK_WORKTREE_ROOT` lookup を扱い、command layer と use case の direct `os.environ` 依存を避ける。
 - domain への抽出は optional とする。label validation / candidate naming が複数 issue で再利用される場合だけ `domain/worktree.py` のような pure helper に逃がす。
 
 ## Domain Model（DDD 必要時）
@@ -157,7 +158,7 @@ presentation --> application : result dataclasses only
     - stdout に id、worktree absolute path、branch、bootstrap result を出す
   - fatal error:
     - exit code `1`
-    - stderr に invalid label / detached HEAD / Git repo 外 / non-retryable Git failure / path failure を出す
+    - stderr に missing / invalid `SPEC_DOCK_WORKTREE_ROOT` / invalid label / detached HEAD / Git repo 外 / non-retryable Git failure / path failure を出す
   - bootstrap failure:
     - exit code `0`
     - worktree 作成 success として扱う
@@ -194,7 +195,7 @@ presentation --> application : result dataclasses only
 - file / state 変更:
   - Git creates linked worktree metadata under Git common dir.
   - Git creates a new branch.
-  - Files are checked out into `<main-parent>/<repo-basename>-worktrees/<repo-basename>-<id>`.
+  - Files are checked out into `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>`.
   - Optional `make init` may create project-specific untracked files, but SpecDock does not define those files.
 - 不変条件:
   - SpecDock must not create nested worktrees inside the main checkout.
@@ -210,7 +211,7 @@ presentation --> application : result dataclasses only
   1. CLI parses `worktree create`.
   2. Command validates CLI shape and builds `WorktreeCreateRequest(label=None)`.
   3. Application resolves current branch and main worktree path from Git.
-  4. Application derives container path `<main-parent>/<repo-basename>-worktrees`.
+  4. Application requires and validates `SPEC_DOCK_WORKTREE_ROOT`, then derives namespace path `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>`.
   5. Application evaluates candidates `wt1`, `wt2`, ... against directory / branch / worktree record collisions.
   6. Application calls Git gateway to add worktree with `-b <current-branch>-<id>`.
   7. Application calls BootstrapGateway for optional `make init`.
@@ -219,7 +220,7 @@ presentation --> application : result dataclasses only
   - Candidate collision found before add or during `git worktree add` with known retryable message.
   - Application increments candidate id and retries until a usable candidate is found or candidate ceiling `10000` is exceeded.
   - Candidate ceiling `10000` follows the reference product's proven upper bound and prevents infinite retry loops.
-  - If no candidate is found by `10000`, command exits `1` with a fatal message that includes label mode, last attempted id, container path, and the reason that candidates were exhausted.
+  - If no candidate is found by `10000`, command exits `1` with a fatal message that includes label mode, last attempted id, namespace path, and the reason that candidates were exhausted.
 - Flow-C: bootstrap failure
   - Worktree creation succeeds.
   - `make init` exists but returns non-zero, or bootstrap detection fails for a reason other than target-missing.
@@ -310,7 +311,7 @@ skinparam monochrome true
 start
 :Validate label;
 if (inside Git repo and branch?) then (yes)
-  :Resolve main worktree and container;
+  :Resolve env root, main worktree, and namespace;
   :n = 1;
   repeat
     :Build id/path/branch candidate;
@@ -354,12 +355,14 @@ endif
 - 失敗モード:
   - invalid label:
     - before Git mutation; exit `1`.
+  - missing / invalid `SPEC_DOCK_WORKTREE_ROOT`:
+    - before Git mutation; exit `1`; output names the variable, path/cause when available, and an absolute-path setup example.
   - Git repo 外 / detached HEAD:
     - before Git mutation; exit `1`.
   - no candidate after retry ceiling:
     - retry ceiling is fixed at `10000`.
     - before Git mutation or after retryable collisions; exit `1`.
-    - fatal output includes label mode, last attempted id, container path, and exhaustion reason.
+    - fatal output includes label mode, last attempted id, namespace path, and exhaustion reason.
   - non-retryable `git worktree add` failure:
     - exit `1`; output includes command context and whether path exists / branch exists / record exists when observable.
   - path creation / permission failure:
@@ -386,7 +389,8 @@ endif
 
 ## 移行戦略
 - 移行戦略:
-  - Additive runtime command; no existing command behavior changes.
+  - Runtime placement change for `worktree create`; command surface and naming behavior remain compatible.
+  - Existing sibling `<repo-basename>-worktrees/` worktrees are legacy Git worktrees and are not moved or removed.
   - Provider-side source under `src/spec_dock/assets/spec_dock/...` is updated first.
   - Dogfooding workspace `spec-dock/...` is refreshed/inspected as validation, not treated as implementation source.
 - 必要時の dual write/read:
@@ -418,12 +422,12 @@ endif
   - main worktree normalization from linked worktree records.
   - retryable vs non-retryable error classification.
 - CLI/runtime:
-  - `spec-dock worktree create` creates `<repo-basename>-worktrees/<repo-basename>-wt1`.
+  - `spec-dock worktree create` requires `SPEC_DOCK_WORKTREE_ROOT` and creates `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-wt1`.
   - repeated invocation creates `wt2`.
   - label invocation creates `<label>` and branch `<current-branch>-<label>`.
   - invalid labels fail before mutation.
   - detached HEAD / Git repo 外 fail.
-  - linked-worktree invocation uses main worktree basename/container.
+  - linked-worktree invocation uses main worktree basename/namespace.
   - `make init` success / skipped / detection failure / execution failure all render correct output and exit code.
   - non-retryable Git/path failures exit `1`.
 - E2E:
@@ -480,7 +484,7 @@ endif
   - 決定:
     - A を採用する。
     - partial Git failure は success result variant にせず、既存 dispatch contract に合わせて `RuntimeError` text として返す。
-    - retryable collision の candidate ceiling は `10000` とし、超過時は `RuntimeError` text に label mode、last attempted id、container path、exhaustion reason を含める。
+    - retryable collision の candidate ceiling は `10000` とし、超過時は `RuntimeError` text に label mode、last attempted id、namespace path、exhaustion reason を含める。
   - 影響範囲:
     - application error contract
     - CLI tests

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/design.md
@@ -3,186 +3,374 @@
 ID: "iss-00130"
 タイトル: "Central Worktree Root Placement"
 関連GitHub: ["#130"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-26"
+最終更新: "2026-05-27"
 依存: ["requirement.md"]
 親: ["epic-00107", "init-local-00002"]
 ---
 
 # iss-00130 Central Worktree Root Placement — 設計（どう実現するか）
 
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
 ## 親図（Diagram）参照
 - Epic 図:
-  - ...
-- Initiative 図:
-  - ...
+  - `epic-00107/design.md` の Worktree Create Runtime Components と Package Dependency を参照する。
 - 再利用する決定:
-  - ...
+  - `spec-dock worktree create [LABEL]` の command surface は維持する。
+  - `commands` は CLI args と `CommandOutcome` のみを扱い、Git subprocess や environment lookup を直接持たない。
+  - `application/worktree.py` は id generation、collision retry、main worktree normalization、bootstrap outcome aggregation を所有する。
+  - Git / make side effect は ports 経由で扱う。
+- この issue で置き換える親決定:
+  - `epic-00107` の sibling placement は future `worktree create` の正本ではなくなる。
+  - future placement は `SPEC_DOCK_WORKTREE_ROOT` based central root とする。
 
 ## 目的・制約
 - 目的:
-  - ...
-- 必須 / 禁止:
-  - ...
-- 非交渉制約:
-  - ...
+  - `worktree create` の placement derivation を repo sibling container から central root に変更する。
+  - Codex sandbox writable root を product ごとに追加する運用を避ける。
+  - 既存 naming、collision retry、bootstrap、CLI surface の意味を保つ。
+- 必須:
+  - `SPEC_DOCK_WORKTREE_ROOT` を `worktree create` 専用の required precondition とする。
+  - missing / blank / whitespace-only env var は fatal とし、Git mutation、branch 作成、directory 作成、bootstrap より前に止める。
+  - env var 値は `Path(value).expanduser()` 後に absolute path であることを要求する。
+  - directory symlink は許可し、file、broken symlink、directory 以外、relative path は拒否する。
+  - namespace は Git main worktree basename とする。
+  - worktree path は `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>` とする。
+- 禁止:
+  - missing env var 時に sibling placement へ fallback すること。
+  - namespace override / config をこの issue で追加すること。
+  - existing sibling worktree を移動・削除・migration すること。
+  - `$CODEX_HOME/worktrees` を spec-dock managed worktree root として流用すること。
 - 前提:
-  - ...
+  - Requirement phase は fresh `spec-reviewer` により pass 済みである。
+  - local `.zshenv` / root directory は repo-managed artifact ではなく、report evidence として扱う。
 
 ## 既存実装 / 規約の理解
 - 参照した実装 / docs:
-  - ...
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+  - `tests/cli_runtime/test_worktree.py`
 - 現状理解:
-  - ...
+  - `application/worktree.py` は `records[0].path` を Git main worktree として扱い、`repo_basename = main_worktree.name` を導出する。
+  - 現行 container は `main_worktree.parent / f"{repo_basename}-worktrees"` である。
+  - `WorktreeCreateRequest` は `label` のみを持つ。CLI flag で root を渡す設計ではない。
+  - `Ports` には `GitGateway` と `BootstrapGateway` はあるが、environment / config boundary はない。
+  - `reference_worktree.md` と `tests/cli_runtime/test_worktree.py` は sibling placement を固定している。
 - 採用するパターン:
-  - ...
+  - use case は application layer に置く。
+  - side effect boundary は `ports.py` の protocol と `cli/bootstrap.py` の concrete adapter に分離する。
+  - CLI command は root override option を追加せず、existing `worktree create [LABEL]` を維持する。
 - 採用しないもの:
-  - ...
+  - `commands/worktree.py` で `os.environ` を読む。
+  - `application/worktree.py` が直接 `os.environ` を読む。
+  - `WorktreeCreateRequest` に root path を CLI input として追加する。
+  - sibling fallback を compatibility path として残す。
 - 影響範囲:
-  - ...
+  - runtime application / ports / bootstrap wiring
+  - worktree CLI runtime tests
+  - shipped docs and dogfooding docs
+  - parent Epic docs that currently describe sibling placement as future behavior
 
 ## 採用方針 / トレードオフ
-- 論点:
-  - ...
-- 選択肢:
-  - ...
-- 決定:
-  - ...
+- 論点: environment lookup boundary
+  - 選択肢:
+    - A: `EnvironmentGateway.getenv(name: str) -> str | None` を `application.ports` に追加する。
+    - B: `application/worktree.py` が直接 `os.environ` を読む。
+    - C: CLI command が env var を読んで request に詰める。
+  - 決定:
+    - A を採用する。
+  - 理由:
+    - Application layer が precondition と path derivation を所有できる。
+    - Unit-style tests で process-global environment に依存せず missing / present / malformed env を検証できる。
+    - CLI command は label parsing の責務に留まる。
+- 論点: root / namespace directory creation
+  - 決定:
+    - Env var が valid absolute path を指している場合、root / namespace は `mkdir(parents=True, exist_ok=True)` で作成してよい。
+  - 理由:
+    - Required env var により operator intent は明示されている。
+    - 初回利用時の setup friction を減らしつつ、relative / file / broken symlink は拒否できる。
+- 論点: namespace ownership
+  - 決定:
+    - Namespace は Git main worktree basename のみとし、owner metadata や override は追加しない。
+  - 理由:
+    - User intent は product name as-is であり、同 basename collision は現時点で未発生。
+    - 今回の目的は placement contract の変更であり、namespace registry の導入ではない。
 
 ## 依存関係分析
 - module 依存:
-  - ...
-- class 依存（必要時）:
-  - ...
-- function 依存（必要時）:
-  - ...
+  - `commands/worktree.py` -> `application.contracts.WorktreeCreateRequest` / `application.worktree.worktree_create`
+  - `application/worktree.py` -> `application.ports.Ports` / `GitGateway` / `BootstrapGateway` / new `EnvironmentGateway`
+  - `cli/bootstrap.py` -> concrete env adapter and existing Git / bootstrap adapters
+  - `presentation/cli_text.py` -> `WorktreeCreateResult`
 - file 依存:
-  - ...
+  - `ports.py` の protocol / `Ports` field を先に追加しないと、`worktree.py` の env lookup を isolated に実装できない。
+  - `worktree.py` の path derivation が変わると、`test_worktree.py` の success / bootstrap / collision / linked-worktree expectations を更新する必要がある。
+  - Docs は runtime contract が固まったあとに更新する。
 - 上流 / 前提:
-  - ...
+  - `requirement.md` AC-001..AC-009。
+  - Parent Epic の existing worktree command surface。
 - 下流 / 依存先:
-  - ...
+  - `plan.md` は this design の dependency order に従い、env boundary -> central placement -> existing behavior preservation -> docs impact の順に step を置く。
 - 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
+  - `EnvironmentGateway` protocol and runtime wiring。
 - 順序への影響:
-  - plan では upstream / prerequisite から順に step を組む
+  - Missing-env fatal behavior を先に test / implement し、silent sibling fallback の再発を防ぐ。
+  - Central placement 変更はその後に行い、既存 behavior regression を path update と一緒に閉じる。
+  - Docs / parent Epic update は runtime behavior と tests の後で行う。
 
 ## モジュール依存図（Module Dependency Diagram）
 - タイトル:
-  - ...
+  - Central Worktree Root Runtime Boundary
 - 答える問い:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
+  - `SPEC_DOCK_WORKTREE_ROOT` をどの layer で読み、どの module が central placement を決めるか。
 - 範囲:
-  - ...
+  - `worktree create` の CLI parse、application precondition、ports、runtime wiring、output、tests。
 - 含めない詳細:
-  - 網羅的な call graph / 全 method / 全 import は描かない
+  - 全 command registry。
+  - `git worktree list --porcelain` parser の詳細。
+  - `make init` detection の内部実装。
 - 更新条件:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- 図:
-  - 下の `plantuml` block を更新する
+  - Env/config boundary、placement derivation、result contract、docs/runtime parity の対象ファイルが変わるとき。
 
-### 図表（UML / 原則: モジュール依存 / パッケージ依存差分）
+### 図表（UML / モジュール依存）
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
+skinparam monochrome true
 
-rectangle "対象module-a" as A
-rectangle "対象module-b" as B
-A --> B : depends_on
+rectangle "commands/worktree.py\nparse label only" as CMD
+rectangle "application/contracts.py\nWorktreeCreateRequest/Result" as CONTRACTS
+rectangle "application/ports.py\nEnvironmentGateway\nGitGateway\nBootstrapGateway" as PORTS
+rectangle "application/worktree.py\nprecondition\npath derivation\ncollision retry\nbootstrap aggregation" as APP
+rectangle "cli/bootstrap.py\nos.environ adapter\nruntime wiring" as BOOT
+rectangle "presentation/cli_text.py\nsuccess output" as TEXT
+rectangle "tests/cli_runtime/test_worktree.py\nCLI and fake-port coverage" as TESTS
+rectangle "reference_worktree.md\nuser-facing contract" as DOCS
+
+CMD --> CONTRACTS : builds request
+CMD --> APP : calls use case
+APP --> PORTS : reads env and side-effect ports
+APP --> CONTRACTS : returns result
+BOOT --> PORTS : implements adapters
+TEXT --> CONTRACTS : renders result
+TESTS --> CMD : CLI behavior
+TESTS --> APP : app-level fake ports
+DOCS ..> APP : describes runtime contract
 @enduml
 ```
 
-## ローカル図の差分（Local Diagram Delta / 必要時）
+## ローカル図の差分（Local Diagram Delta）
 - 変更する境界 / 責務 / 相互作用:
-  - N/A: 理由
+  - Application layer に `EnvironmentGateway` dependency を追加する。
+  - `worktree.py` の placement derivation を sibling container から env-root namespace container へ置き換える。
+  - `commands/worktree.py` の責務は変えない。
 
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
+- `EnvironmentGateway`:
+  - 追加場所:
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - contract:
+    - `getenv(name: str) -> str | None`
+  - concrete implementation:
+    - `cli/bootstrap.py` の adapter が `os.environ.get(name)` を返す。
+- `Ports`:
+  - `environment_gateway: EnvironmentGateway | None = None` を追加する。
+  - `worktree_create` は missing `environment_gateway` を runtime wiring error として fatal にする。
+- `WorktreeCreateRequest`:
+  - 変更しない。Root は command input ではなく environment contract である。
+- `WorktreeCreateResult`:
+  - 原則変更しない。
+  - `container_path` は new namespace directory、つまり `$SPEC_DOCK_WORKTREE_ROOT/<namespace>` を表す。
+- Error contract:
+  - Missing / blank env var:
+    - fatal error。
+    - message は `SPEC_DOCK_WORKTREE_ROOT`、required reason、absolute path setup example を含む。
+  - Invalid root:
+    - fatal error。
+    - message は `SPEC_DOCK_WORKTREE_ROOT`、offending raw value、`~` 展開後の resolved path、原因、absolute path setup example を含む。
+    - relative path、file、broken symlink、non-directory path を区別できる原因を含める。
+  - Namespace mkdir failure:
+    - existing artifact-state style を維持し、対象 container path と原因を追えるようにする。
+    - message は `SPEC_DOCK_WORKTREE_ROOT`、resolved root、namespace/container path、原因、absolute path setup example を含む。
 
-## シーケンス差分（Sequence Delta / 必要時）
+## シーケンス差分（Sequence Delta）
 - 変更する相互作用:
-  - N/A: 理由
+  - `worktree_create` の precondition に env lookup / validation が追加される。
 - retry / transaction / external API / queue:
-  - ...
+  - Git retry behavior は既存の retryable collision handling を維持する。
+  - Env validation failure は retry しない。
 - UML:
-  - N/A: 理由
+```plantuml
+@startuml
+skinparam monochrome true
+actor Maintainer
+participant "commands/worktree.py" as CMD
+participant "application/worktree.py" as APP
+participant "EnvironmentGateway" as ENV
+participant "GitGateway" as GIT
+participant "BootstrapGateway" as BOOT
+participant "presentation/cli_text.py" as TEXT
 
-## ドメインモデル差分（Domain Model Delta / 必要時）
-- 親 model 参照:
-  - ...
+Maintainer -> CMD : worktree create [LABEL]
+CMD -> APP : WorktreeCreateRequest(label)
+APP -> ENV : getenv("SPEC_DOCK_WORKTREE_ROOT")
+alt missing / blank / invalid root
+  APP --> CMD : RuntimeError with setup guidance
+else valid root
+  APP -> GIT : current_branch_or_none(repo_root)
+  APP -> GIT : worktree_list(repo_root)
+  APP -> APP : namespace = main_worktree.name\npath = env_root / namespace / repo-id
+  APP -> APP : validate collisions and mkdir namespace
+  APP -> GIT : add_worktree_with_new_branch(path, branch)
+  APP -> BOOT : run_make_init_if_available(worktree_path)
+  APP --> CMD : WorktreeCreateResult
+  CMD -> TEXT : render_worktree_create_text(result)
+end
+@enduml
+```
+
+## ドメインモデル差分（Domain Model Delta）
 - aggregate / entity / value object 変更:
-  - N/A: 理由
+  - N/A: SpecDock persisted domain entity は追加しない。
 - domain event / policy / specification 変更:
-  - ...
+  - N/A: Worktree placement は runtime command policy であり、Spec graph state には保存しない。
 - 不変条件の変更:
-  - ...
-- UML:
-  - N/A: 理由
+  - `worktree create` は active selection / spec graph / GitHub issue を変更しない。
+  - `SPEC_DOCK_WORKTREE_ROOT` missing / invalid の場合は filesystem / Git mutation を行わない。
 
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- 責務:
-  - ...
-- 連携:
-  - ...
-- UML:
-  - N/A: 理由
+## クラス / インターフェース詳細設計
+- `EnvironmentGateway`:
+  - 責務:
+    - Environment variable lookup の port。
+  - 連携:
+    - `application/worktree.py` から `getenv("SPEC_DOCK_WORKTREE_ROOT")` で呼ばれる。
+    - `cli/bootstrap.py` の concrete adapter が実 process environment に接続する。
+- `worktree_create` helper:
+  - 追加候補:
+    - `_resolve_worktree_root(ports: Ports) -> Path`
+    - `_validate_worktree_root(raw_value: str) -> Path`
+  - 責務:
+    - blank check、`expanduser()`、absolute path check、file/symlink/directory validation、setup guidance。
+  - 注意:
+    - helper は direct `os.environ` を読まない。
 
 ## ディレクトリ / ファイル変更計画
 ```text
-.
-|-- src/
-|   |-- package/
-|   |   |-- new_module.py        # 追加: 目的; 依存: ...
-|   |   |-- existing_module.py   # 変更: 目的; 依存: ...
-|   |   `-- renamed_module.py    # 移動/rename 元: src/package/old_module.py; 目的
-|   `-- tests/
-|       `-- test_new_module.py   # 追加/変更: 目的; 依存: src/package/new_module.py
-|-- docs/
-|   `-- reference.md             # 読取のみ: 目的
-`-- legacy/
-    `-- obsolete_file.py         # 削除: 目的; 依存: 代替準備完了
+src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/
+|-- application/
+|   |-- ports.py       # 変更: EnvironmentGateway protocol と Ports field を追加
+|   |-- worktree.py    # 変更: required env validation と central namespace placement
+|   `-- contracts.py   # 原則変更なし; result field の意味だけ design/docs で明確化
+|-- cli/
+|   `-- bootstrap.py   # 変更: os.environ backed EnvironmentGateway を runtime ports に wiring
+|-- commands/
+|   `-- worktree.py    # 原則変更なし; root flag は追加しない
+`-- presentation/
+    `-- cli_text.py    # 原則変更なし; success path は absolute worktree path を維持
+
+src/spec_dock/assets/spec_dock/docs/
+`-- reference_worktree.md # 変更: central root, env requirement, legacy sibling boundary
+
+spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/
+`-- epic-00107-worktree-provisioning/
+    |-- requirement.md # 変更: future placement を central root contract に更新
+    |-- design.md      # 変更: sibling placement を legacy / superseded context へ更新
+    `-- plan.md        # 変更: docs/verification wording を central root に更新
+
+spec-dock/docs/
+`-- reference_worktree.md # provider-side docs 更新後、通常 refresh / parity path で更新
+
+tests/
+`-- cli_runtime/
+    `-- test_worktree.py # 変更: env-required, central-root, path validation, regression coverage
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001:
+  - `EnvironmentGateway` と early precondition check で missing / blank env を fatal にする。
+  - Git / directory / bootstrap before-side-effect を tests で検証する。
+- AC-002:
+  - `container = env_root / repo_basename`、`worktree_path = container / f"{repo_basename}-{id}"` に変更する。
+- AC-003:
+  - Valid root の場合だけ root / namespace `mkdir(parents=True, exist_ok=True)` を許可する。
+- AC-004:
+  - `_validate_worktree_root` で `~` expansion、absolute check、file/broken symlink/non-directory rejection、directory symlink allowance、invalid-root remediation message を固定する。
+- AC-005:
+  - `_normalize_label`、`_candidate_id`、branch naming、retryable Git collision handling は維持する。
+- AC-006:
+  - `records[0].path` を main worktree basename source として維持する。
+  - branch prefix は `current_branch_or_none(repo_root)` の結果を維持する。
+- AC-007:
+  - `BootstrapGateway.run_make_init_if_available` をそのまま使い、status / warnings の result aggregation を維持する。
+- AC-008:
+  - provider docs、dogfooding docs、parent Epic docs を central root contract に整合させる。
+- AC-009:
+  - local env / filesystem は report evidence として検証し、repo-managed artifact にはしない。
+- EC-001:
+  - invalid label は existing validation で fatal。env / placement side effect より前に閉じる。
+- EC-002:
+  - invalid root / namespace creation failure は fatal とし、path と原因を error に出す。
+- EC-003:
+  - Existing namespace directory は directory として使える限り許可する。
+- EC-004:
+  - Same basename collision は path / branch / Git worktree record collision のみで扱う。
+- EC-005:
+  - Existing sibling worktree migration は実装しない。Docs に legacy boundary を残す。
 
 ## テスト戦略
-- 単体:
-  - ...
-- 統合:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
+- 単体 / application-level:
+  - Fake `EnvironmentGateway` で missing / blank / present env を検証する。
+  - Fake `GitGateway` / `BootstrapGateway` で non-retryable failure と retryable collision を検証する。
+- CLI runtime:
+  - Missing / blank `SPEC_DOCK_WORKTREE_ROOT` の fatal behavior と no side effect。
+  - Valid env root による central path creation。
+  - Env root missing 時の root / namespace auto creation。
+  - `~` expansion、relative path rejection、file path rejection、broken symlink rejection、directory symlink allowance。
+  - label / id / branch / collision / linked worktree / bootstrap の existing regression を central root expected path に更新。
+- Docs / parity:
+  - `reference_worktree.md` と parent Epic docs の placement contract inspection。
+  - provider-side source と dogfooding workspace の parity test or update evidence。
+- Manual / local evidence:
+  - `printenv SPEC_DOCK_WORKTREE_ROOT`
+  - `.zshenv` export inspection
+  - `/Users/iwasawayuuta/workspace/worktrees` existence or creatability
 
 ## 要件 / 例外 -> 検証マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001 -> `test_worktree_create_requires_spec_dock_worktree_root_without_side_effects`
+- AC-002 -> `test_worktree_create_uses_central_root_auto_id_and_branch`
+- AC-003 -> central-root success test with missing root fixture
+- AC-004 -> path validation tests for tilde / relative / file / broken symlink / directory symlink
+- AC-005 -> updated existing collision, label, branch prefix, non-retryable Git failure tests
+- AC-006 -> updated linked-worktree normalization test
+- AC-007 -> updated bootstrap success / failure / detection failure tests
+- AC-008 -> docs inspection and parity/update verification
+- AC-009 -> report evidence from local shell/filesystem inspection
+- EC-001 -> existing invalid label test updated to assert no central/sibling side effects
+- EC-002 -> invalid root tests including env var name, offending/resolved path, cause, and setup example in stderr
+- EC-003 -> existing namespace directory success/collision tests
+- EC-004 -> scope inspection; no namespace override code/config
+- EC-005 -> docs inspection; no migration code
 
-## リスク / 移行 / ロールバック（必要時）
-- ...
+## リスク / 移行 / ロールバック
+- リスク:
+  - Typoed absolute env path may be auto-created.
+    - Mitigation: relative / invalid paths are fatal, and output/error shows resolved path.
+  - Same basename repositories share a namespace.
+    - Mitigation: out of scope is explicit; future namespace override can be added if a real collision appears.
+  - Parent Epic docs may retain stale sibling wording.
+    - Mitigation: S90 docs impact step updates parent Epic and shipped docs together.
+- 移行:
+  - Existing sibling worktrees are left untouched.
+  - Future `worktree create` uses central root only.
+  - No SpecDock persisted state migration is required.
+- ロールバック:
+  - Revert `worktree.py` placement derivation and docs/tests to sibling placement.
+  - No migration rollback is required because existing sibling worktrees were never moved.
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081258z-scratch-user-input-capture.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081258z-scratch-user-input-capture.md
@@ -1,0 +1,57 @@
+---
+種別: scratch
+ID: "20260526t081258z-scratch"
+タイトル: "User Input Capture"
+状態: "draft | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "raw"
+derived_from: []
+reflected_to: []
+---
+
+# 20260526t081258z-scratch User Input Capture
+
+## 位置づけ
+- 用途: 未整理の発話、観察、思考、会話ログ、作業中の下書きを低摩擦に置く。
+- authority default: `raw`。raw capture は非 authoritative であり、この文書だけで決定済み、調査済み、要件確定として扱わない。
+- 長期保存する価値が出たら、文脈をもとに `interview` / `research` / `disc` / `adr` を新規作成するか、`requirement.md` / `design.md` / `plan.md` を修正する。
+- 既存 `note` artifact は grandfathered だが、新規 raw capture には `scratch` を使う。
+
+## メモ (必須)
+- 2026-05-26 user input:
+  - 現行の `spec-dock worktree create` は、product root と同じ親 path に worktree container を自動生成する。
+  - Codex sandbox を有効にしている場合、その sibling container は current project writable root の外になり、作業権限がない問題がある。
+  - Codex の editable root を project ごとに追加することはできるが、手動設定が project ごとに必要になり human error につながる。
+  - 通常の product checkout と linked worktree は lifecycle が異なる。worktree は役割を終えたら削除する短命・一時的な開発 surface である。
+  - この PC で開発する全 product の spec-dock managed worktree を 1 つの directory に集約し、その directory だけを Codex writable root として許可したい。
+  - 集約 directory は `/Users/iwasawayuuta/workspace/worktrees` が候補。
+  - shell environment variable に worktree root path をあらかじめ設定し、tool はその env var があることを前提にしたい。
+  - env var がない状態で worktree を作成しようとした場合、worktree は作成せず、警告または明確な message を表示する。
+  - この開発環境では `/Users/iwasawayuuta/workspace/worktrees` を作成し、zsh profile で CLI environment variable として export する想定。
+  - worktree root 配下の namespace は各 product 名をそのまま使いたい。この repo では `spec-dock` が namespace に該当する。
+  - namespace 内の個別 worktree 名は現行の命名 logic を基本的に維持する想定。ただし、より良い修正案があれば提案してほしい。
+  - 要件定義を作る前に、既存コードベースを十分に理解し、必要なヒアリングを行う。
+  - 調査、分析、ヒアリングは `discussions/` に document を積み重ねながら進める。
+
+## 整理メモ（任意）
+- facts:
+  - user intent is not simply changing one path; it changes the placement contract from implicit sibling path to explicit environment-provided central root.
+  - user wants missing env var to be blocking for `worktree create`, not fallback to old sibling behavior.
+- questions:
+  - exact env var name must be fixed.
+  - whether spec-dock should create the root directory when env var is set but the directory does not exist needs confirmation.
+  - namespace collision behavior across products with identical basename needs confirmation.
+- decisions:
+  - none yet; interview required before canonical requirement promotion.
+- actions:
+  - inspect current `worktree create` implementation, docs, tests, and local shell/workspace layout.
+  - create research and discussion docs before editing `requirement.md`.
+- links:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `tests/cli_runtime/test_worktree.py`
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+- discard condition:
+  - Once the canonical `requirement.md`, `design.md`, and `plan.md` reflect the accepted scope and this raw capture has been linked from report evidence, this scratch document can remain as raw provenance only.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-01-interview-requirement-interview.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-01-interview-requirement-interview.md
@@ -1,0 +1,299 @@
+---
+種別: interview
+ID: "20260526t081259z-01-interview"
+タイトル: "Requirement Interview"
+状態: "draft | answered | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "raw"
+derived_from: []
+reflected_to: []
+---
+
+# 20260526t081259z-01-interview Requirement Interview
+
+## 位置づけ
+- 用途: 人間から目的、制約、期待、判断基準、未決事項を引き出し、回答を記録する。
+- authority default: `raw`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から論点整理が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## ヒアリング概要 (必須)
+- 対象者:
+  - iwasawayuuta
+- 回答が必要な理由:
+  - `iss-00130` は existing approved Epic contract の sibling placement を置き換えるため、env var 名、root creation policy、namespace collision policy を要件として固定してから `requirement.md` へ昇格する必要がある。
+- 反映予定先:
+  - `requirement.md`:
+    - 目的、前提、スコープ、受け入れ条件、例外・エッジケース、未確定事項。
+  - `design.md`:
+    - env lookup boundary、path derivation、namespace rule、test strategy。
+  - `plan.md`:
+    - missing env / present env / namespace / collision / docs update の step と closure。
+  - `adr`:
+    - 必要なら central root adoption の長期判断として昇格する。
+
+## 質問ブロック（必要な数だけ繰り返す） (必須)
+
+### 質問 1
+- 質問主題:
+  - Environment variable name
+- 回答してほしいこと:
+  - Required env var name を `SPEC_DOCK_WORKTREE_ROOT` にしてよいか。あるいは generic な `WORKTREE_ROOT` を希望するか。
+- なぜ質問するのか:
+  - Env var name は CLI contract、error message、docs、tests、local shell setup のすべてに影響する。
+- 背景:
+  - User wording is "worktree root path as shell environment variable"; current environment has no existing worktree-root variable.
+- 詳細説明:
+  - Tool-specific name avoids collision. Generic name is shorter but other tools may already use or expect it.
+- 事前分析:
+  - 確認済みの docs / code / tests / ADR / discussions / primary source:
+    - Current `WorktreeCreateRequest` has only `label`.
+    - Current shell env and zsh files do not define a worktree-root variable.
+  - まだ人間判断が必要な理由:
+    - This is user-facing naming and should match the intended convention across the user's development machine.
+- 回答案:
+  - A:
+    - `SPEC_DOCK_WORKTREE_ROOT`
+  - B:
+    - `WORKTREE_ROOT`
+- 選択肢比較:
+  - 評価軸:
+    - collision risk, readability, cross-tool convention, docs clarity.
+- メリット:
+  - A:
+    - Tool ownership is clear; unlikely to conflict; docs can be exact.
+  - B:
+    - Short and generic; may be useful if multiple tools share the same root.
+- デメリット:
+  - A:
+    - Longer name; other tools will not naturally share it.
+  - B:
+    - Collision or ambiguous ownership risk.
+- リスク:
+  - A generic variable could be accidentally reused by unrelated tooling with a different lifecycle expectation.
+- ベストプラクティス分析:
+  - Prefer tool-specific env vars when the semantics are part of a tool contract and failure behavior is strict.
+- 推奨案:
+  - A: `SPEC_DOCK_WORKTREE_ROOT`
+- 未回答時の影響:
+  - Requirement cannot finalize env contract; error text and tests remain ambiguous.
+- 回答欄:
+  - 2026-05-26 answer:
+    - A: `SPEC_DOCK_WORKTREE_ROOT` を採用する。
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` の前提 / 非交渉制約 / AC / EC。
+    - `design.md` の env lookup boundary。
+  - 追加で作る discussion docs:
+    - ADR candidate if env var naming becomes a long-lived convention.
+
+### 質問 2
+- 質問主題:
+  - Env var set but directory missing
+- 回答してほしいこと:
+  - `SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees` のように env var は設定済みだが directory が存在しない場合、`worktree create` が root / namespace directory を作成してよいか、それとも fail-fast すべきか。
+- なぜ質問するのか:
+  - Convenience と typo detection のトレードオフがある。
+- 背景:
+  - User wording includes "directory を作成し、env var にセットしておく"。Tool が作るのか、事前 setup が作るのかは未確定。
+- 詳細説明:
+  - 現行実装は sibling container を `mkdir(parents=True, exist_ok=True)` で作る。central root でも同様に作ると初回利用は楽だが、env var typo に気づきにくくなる。
+- 事前分析:
+  - 確認済みの docs / code / tests / ADR / discussions / primary source:
+    - Current implementation creates sibling container.
+    - Current tests cover container creation failure when path is a file.
+  - まだ人間判断が必要な理由:
+    - Central root は machine-wide convention なので、誤 path を自動作成する挙動の是非は operator policy。
+- 回答案:
+  - A:
+    - Env var missing is fatal。Env var set + root missing は command が root and namespace を作成する。
+  - B:
+    - Env var missing も root missing も fatal。setup command or shell setup must create it first。
+- 選択肢比較:
+  - 評価軸:
+    - first-use convenience, typo detection, current behavior compatibility.
+- メリット:
+  - A:
+    - 初回利用が楽。現在の `mkdir` behavior に近い。
+  - B:
+    - 誤った env path を早く検出できる。
+- デメリット:
+  - A:
+    - Typoed path に空 directory を作ってしまう。
+  - B:
+    - Setup 手順が増える。
+- リスク:
+  - A の場合、誤設定で `/Users/iwasawayuuta/workspace/worktree` のような似た path が作られる可能性。
+- ベストプラクティス分析:
+  - Required env var で operator intent は明示されているため、directory 作成は許容できる。ただし output / error に resolved root を出すべき。
+- 推奨案:
+  - A。Missing env var は fatal にしつつ、env var が明示されている場合はその root / namespace を作成してよい。
+- 未回答時の影響:
+  - Container creation tests and failure contract cannot be finalized.
+- 回答欄:
+  - 2026-05-26 answer:
+    - A: Env var missing is fatal。Env var set + root missing は command が root / namespace directory を作成してよい。
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` EC / AC
+    - `design.md` path creation policy
+  - 追加で作る discussion docs:
+    - none expected
+
+### 質問 3
+- 質問主題:
+  - Namespace rule and collision tolerance
+- 回答してほしいこと:
+  - Central root 配下の namespace は常に Git main worktree basename を使う、でよいか。例: `/Users/.../tools/spec-dock` -> `spec-dock`。
+- なぜ質問するのか:
+  - Central root では、異なる親 directory に同名 repo があると namespace が衝突する。
+- 背景:
+  - User preference is "各プロダクトの名前をそのまま適用"; this repo は `spec-dock`。
+- 詳細説明:
+  - Existing logic already uses main worktree basename as repo basename. The central root can keep that rule for readability, but it loses the parent directory's collision separation.
+- 事前分析:
+  - 確認済みの docs / code / tests / ADR / discussions / primary source:
+    - Current implementation uses `main_worktree.name`.
+    - Existing branch/path naming depends on `repo_basename`.
+  - まだ人間判断が必要な理由:
+    - Product name and directory basename are usually equal but not guaranteed.
+- 回答案:
+  - A:
+    - Default namespace is repo basename only. No override in this issue.
+  - B:
+    - Default namespace is repo basename, with optional override config/flag/env added now.
+  - C:
+    - Namespace includes category prefix, e.g. `tools-spec-dock`, to avoid collisions.
+- 選択肢比較:
+  - 評価軸:
+    - readability, collision avoidance, implementation scope, user preference.
+- メリット:
+  - A:
+    - Simple; matches user preference for product name.
+  - B:
+    - Handles product-name mismatch.
+  - C:
+    - Avoids same-basename collisions.
+- デメリット:
+  - A:
+    - Same-basename products can collide.
+  - B:
+    - Adds config surface before a demonstrated need.
+  - C:
+    - Less aligned with "product name as-is".
+- リスク:
+  - A can mix worktrees if two products share basename and branch/id names overlap.
+- ベストプラクティス分析:
+  - Start with a simple default and add override when a concrete collision appears.
+- 推奨案:
+  - A for this issue. Keep namespace simple and human-readable; add override only if a real collision appears.
+- 未回答時の影響:
+  - Path contract cannot be finalized.
+- 回答欄:
+  - 2026-05-26 answer:
+    - A: Default namespace is repo basename only. No override in this issue.
+    - この repo では `spec-dock` を namespace とする。
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` path examples
+    - `design.md` namespace derivation
+  - 追加で作る discussion docs:
+    - none expected
+
+### 質問 4
+- 質問主題:
+  - Scope of local machine setup
+- 回答してほしいこと:
+  - この issue で実際に `/Users/iwasawayuuta/workspace/worktrees` の作成と `~/.zshrc` or `~/.zprofile` への export 追加まで行うか、それとも spec-dock tool/docs/tests の変更だけに留めるか。
+- なぜ質問するのか:
+  - Repository change と user-local machine configuration は lifecycle と commit 対象が違う。
+- 背景:
+  - User says this development environmentでは directory 作成と zsh profile export を行うつもり。
+- 回答案:
+  - A:
+    - This issue includes repo changes only; local shell setup is manual/documented.
+  - B:
+    - This issue also performs local machine setup, but does not commit shell profile changes to repo.
+  - C:
+    - Provide a setup command or script in repo that users run manually.
+- 推奨案:
+  - A for product scope, with optional separate local setup after requirement approval. If local setup is desired, record it as manual evidence, not repo diff.
+- 回答欄:
+  - 2026-05-26 answer:
+    - B: この issue に local machine setup も含める。
+    - 設定先は `.zshenv` がよい。`.zprofile` より `.zshenv` の方が適しているという認識。
+    - `/Users/iwasawayuuta/workspace/worktrees` の作成と shell env export 追加を含める。
+    - Workspace 外編集になるため、必要なタイミングで user approval を求める。
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` scope / out-of-scope
+    - `plan.md` manual verification or docs impact
+  - 追加で作る discussion docs:
+    - scratch/manual evidence if local setup is performed
+
+### 質問 5
+- 質問主題:
+  - Legacy sibling worktrees
+- 回答してほしいこと:
+  - Existing sibling worktrees such as `/Users/iwasawayuuta/workspace/tools/spec-dock-worktrees/spec-dock-delegated-authoring-architecture` should be left untouched, documented as legacy, or migrated manually?
+- なぜ質問するのか:
+  - Migration behavior affects safety and docs, but automatic moving of Git linked worktrees is riskier than changing future creation.
+- 背景:
+  - Current `git worktree list` shows an existing sibling worktree.
+- 回答案:
+  - A:
+    - Leave existing sibling worktrees untouched. New behavior applies only to future `worktree create`.
+  - B:
+    - Add manual migration guidance to docs.
+  - C:
+    - Implement migration or repair behavior now.
+- 推奨案:
+  - A。Future creation contract を変えるだけにし、既存 linked worktree は Git 管理下の既存成果物として触らない。
+- 回答欄:
+  - 2026-05-26 answer:
+    - A: Leave existing sibling worktrees untouched.
+    - Existing worktree migration / moving is not required.
+    - Backward compatibility for existing sibling-placement behavior is not required.
+    - New behavior only needs to apply to future worktrees created by the command.
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` scope / target-out
+    - `reference_worktree.md`
+  - 追加で作る discussion docs:
+    - none expected
+
+### 質問 6
+- 質問主題:
+  - `.zshenv` export format
+- 回答してほしいこと:
+  - `.zshenv` に追加する行は、既存 override を尊重する形式でよいか。
+- なぜ質問するのか:
+  - Literal absolute path と defaultable expression のどちらにするかで、将来の一時 override のしやすさが変わる。
+- 背景:
+  - `.zshenv` には既に root path 系 env var があり、`WORKSPACE_SECRETS_HOME="${WORKSPACE_SECRETS_HOME:-$HOME/.config/secrets}"` のように既存値を尊重する形式が使われている。
+- 回答案:
+  - A:
+    - `export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"`
+  - B:
+    - `export SPEC_DOCK_WORKTREE_ROOT="/Users/iwasawayuuta/workspace/worktrees"`
+- 推奨案:
+  - A。既存 `.zshenv` の pattern に合い、必要時に外側から override できる。
+- 回答欄:
+  - 推奨案 A を前提に要件化する。user が literal absolute path を希望する場合のみ変更する。
+- 回答後フォローアップ:
+  - 反映先:
+    - `requirement.md` local setup example
+    - `plan.md` local setup verification
+  - 追加で作る discussion docs:
+    - none expected
+
+## 図解（任意）
+```plantuml
+@startuml
+' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+@enduml
+```

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-research-existing-worktree-contract-research.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-research-existing-worktree-contract-research.md
@@ -1,0 +1,132 @@
+---
+種別: research
+ID: "20260526t081259z-research"
+タイトル: "Existing Worktree Contract Research"
+状態: "draft | completed | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "synthesized"
+derived_from: []
+reflected_to: []
+---
+
+# 20260526t081259z-research Existing Worktree Contract Research
+
+## 位置づけ
+- 用途: 外部仕様、実装事実、先例、制約など、検証可能な根拠を整理する。
+- authority default: `synthesized`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 調査結果が選択肢比較を必要とする場合は `disc`、長期判断を支える場合は `adr`、人間判断を必要とする場合は `interview` へつなぐ。
+- 事実、推測、未検証事項、判断への含意を混ぜない。
+
+## 調査目的 (必須)
+- 現行 `spec-dock worktree create` の placement / naming / bootstrap / failure contract を確認し、central worktree root 化でどの契約を変更する必要があるかを明らかにする。
+- この PC の directory layout と shell environment を確認し、`/Users/iwasawayuuta/workspace/worktrees` を default operational root とする妥当性と未設定 env var の扱いを整理する。
+
+## 調査方法 (必須)
+- Active context:
+  - `./spec-dock/scripts/spec-dock active show`
+  - `spec-dock/active/context-pack.md`
+  - `spec-dock/active/epic/{requirement.md,design.md,plan.md}`
+  - `spec-dock/active/issue/{requirement.md,design.md,plan.md}`
+- Current implementation / tests / docs:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `tests/cli_runtime/test_worktree.py`
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+- Local environment / filesystem:
+  - `git worktree list --porcelain`
+  - `find /Users/iwasawayuuta/workspace -maxdepth 2 -type d`
+  - `printenv | sort | rg 'WORKTREE|SPEC_DOCK|CODEX_HOME|WORKSPACE'`
+  - `rg -n 'WORKTREE|SPEC_DOCK|workspace|worktrees' ~/.zshrc ~/.zprofile ~/.zshenv`
+
+## 調査結果 (必須)
+- Active issue:
+  - Current active tuple is `init-local-00002` / `epic-00107` / `iss-00130`.
+  - `iss-00130` docs are still template-level draft at the start of this research.
+- Existing Epic contract:
+  - `epic-00107` is approved and currently states sibling placement as the required contract:
+    - container: main checkout parent / `<repo-basename>-worktrees`
+    - worktree path: `<repo-basename>-worktrees/<repo-basename>-<id>`
+    - branch: `<current-branch>-<id>`
+    - linked worktree execution normalizes placement to Git's main worktree path.
+  - Therefore `iss-00130` is a contract-changing issue, not just an implementation cleanup.
+- Current implementation:
+  - `application/worktree.py` computes:
+    - `main_worktree = records[0].path`
+    - `repo_basename = main_worktree.name`
+    - `container = main_worktree.parent / f"{repo_basename}-worktrees"`
+    - `worktree_path = container / f"{repo_basename}-{worktree_id}"`
+  - `WorktreeCreateRequest` currently only carries `label`; there is no env-derived root, explicit root, or namespace field.
+  - `WorktreeCreateResult` exposes `container_path` and `worktree_path`, so output and tests can observe the new root.
+  - `GitGateway` and `BootstrapGateway` do not currently expose environment lookup. Env lookup likely needs a new port/protocol or runtime configuration gateway rather than being embedded in CLI/parser code.
+- Current tests:
+  - `test_worktree_create_uses_sibling_container_auto_id_and_branch` asserts sibling path `target.parent / "sample-repo-worktrees" / "sample-repo-wt1"`.
+  - invalid labels currently assert that sibling container is not created.
+  - bootstrap success/failure tests assume sibling container when checking `.init-ran` and worktree existence.
+  - linked-worktree normalization test asserts that a nested call from an existing linked worktree creates another worktree in the same sibling container.
+  - Several unit-style fake gateway tests hard-code `Path(tmp) / "repo-worktrees" / "repo-wt1"` as the known record path.
+  - These tests will need to change from sibling placement to env-root placement and add missing-env failure coverage.
+- Current docs:
+  - `reference_worktree.md` explicitly states that the command creates `<repo-basename>-worktrees/` next to the main checkout and does not use nested `.worktrees/`.
+  - The docs explicitly separate spec-dock managed long-lived worktrees from Codex app `$CODEX_HOME/worktrees`.
+- Current local worktree state:
+  - `git worktree list --porcelain` currently shows main checkout at `/Users/iwasawayuuta/workspace/tools/spec-dock` and one linked worktree at `/Users/iwasawayuuta/workspace/tools/spec-dock-worktrees/spec-dock-delegated-authoring-architecture`.
+  - This is the exact sibling-container shape that causes Codex sandbox writable-root friction.
+- Local directory structure:
+  - Development checkouts are broadly under `/Users/iwasawayuuta/workspace/` with category directories such as `product`, `tools`, `project`, `python`, `rails`, `mcp`, `learning`, `javascript`.
+  - There is currently no `/Users/iwasawayuuta/workspace/worktrees` in the observed max-depth listing.
+  - `/Users/iwasawayuuta/.codex/worktrees` exists and contains Codex-managed short names like `79f3` and `c2d5`.
+- Current shell environment:
+  - No `WORKTREE`, `SPEC_DOCK`, `CODEX_HOME`, or `WORKSPACE` worktree-root env var was present in the current process environment.
+  - `~/.zshrc`, `~/.zprofile`, and `~/.zshenv` did not contain a worktree-root variable. `~/.zshrc` contains a workspace-related PATH entry only.
+
+## 推測 / 未検証事項 (必須)
+- 推測:
+  - Env lookup belongs in an application port or runtime config abstraction so tests can exercise missing/present/malformed env without mutating process-global environment in core unit tests.
+  - The user likely wants the new env var to be required only for `spec-dock worktree create`, not for unrelated spec-dock commands.
+  - `SPEC_DOCK_WORKTREE_ROOT` is safer than a generic `WORKTREE_ROOT` because it avoids colliding with other tools, but the user's phrase "worktree root" may imply a generic name. This needs interview confirmation.
+- 未検証:
+  - Whether the implementation should automatically create the env root directory when the env var is set but missing.
+  - Whether namespace should always be exactly `main_worktree.name`, or be configurable for repos whose directory basename is not the product name.
+  - Whether existing sibling worktrees should be migrated, left untouched, or only documented as legacy.
+  - Whether `spec-dock update .` should install or suggest shell profile configuration. Current user wording suggests local environment setup, but packaging cross-shell setup is not yet confirmed.
+
+## 判断への含意 (必須)
+- Requirements must explicitly supersede Epic E-RQ-002 for this issue: placement becomes env-root based rather than sibling container based.
+- Missing env var must be a fatal precondition failure for `worktree create`. It should not silently fallback to sibling placement, because fallback would recreate the sandbox-permission problem.
+- The central root should not be `$CODEX_HOME/worktrees` because current docs reserve that for Codex app managed short-lived worktrees and mixing lifecycles would blur ownership.
+- `/Users/iwasawayuuta/workspace/worktrees` is the best local operational value for this PC because it keeps development assets under the visible `workspace` tree while isolating temporary linked worktrees from normal product checkout lifecycles.
+- Namespace contract must be settled before canonical requirement promotion. Using only repo basename is simple and matches user preference for `spec-dock`, but can collide if multiple products share the same basename in different category directories.
+- Existing individual worktree id / branch naming can mostly remain unchanged; the main change is container path:
+  - before: `<main-parent>/<repo>-worktrees/<repo>-<id>`
+  - proposed: `$<env>/<namespace>/<repo>-<id>`
+
+## リスク/制約 (任意)
+- Changing the default placement breaks existing tests and docs by design.
+- Env-var-required behavior may be surprising for existing users unless docs and error text give a concrete setup example.
+- Generic env var naming may collide with other development tools; tool-specific naming reduces ambiguity.
+- Automatic directory creation is convenient but can hide typoed env var paths unless output clearly reports the root and created namespace.
+
+## 反映先 (任意)
+- reflected_to:
+  - `requirement.md` after interview answers.
+  - `design.md` for env gateway / namespace / path derivation.
+  - `plan.md` for test slices covering missing env, present env, namespace path, collision behavior, docs update.
+
+## 参考（References） (任意)
+- `spec-dock/active/context-pack.md`
+- `spec-dock/active/epic/requirement.md`
+- `spec-dock/active/epic/design.md`
+- `spec-dock/active/epic/plan.md`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+- `tests/cli_runtime/test_worktree.py`
+- `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081356z-disc-central-root-placement-options.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081356z-disc-central-root-placement-options.md
@@ -1,0 +1,140 @@
+---
+種別: disc
+ID: "20260526t081356z-disc"
+タイトル: "Central Root Placement Options"
+状態: "draft | proposed | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "proposed"
+derived_from: []
+reflected_to: []
+---
+
+# 20260526t081356z-disc Central Root Placement Options
+
+## 位置づけ
+- 用途: 集まった情報をもとに、論点、評価軸、選択肢、合意点/未合意点を整理する。
+- authority default: `proposed`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 人間から回答を引き出し、回答欄や未回答事項を管理する場合は `interview` を使う。
+- 生ログや未整理の思考は `scratch`、事実確認や外部根拠は `research`、長期判断の固定は `adr` に分ける。
+- doc が大きくなりすぎたら、質問回答は `interview`、事実調査は `research`、raw capture は `scratch`、長期決定は `adr` へ分割する。
+
+## 議題 (必須)
+- `spec-dock worktree create` の placement を、repo sibling container から environment-provided central root へ変える。
+- Central root 配下で product namespace をどう決めるか。
+- Missing env var をどう扱うか。
+- Existing per-worktree naming logic を維持するか、調整するか。
+
+## 背景 (必須)
+- User goal:
+  - Codex sandbox writable root を project ごとに手動追加する運用をなくす。
+  - 通常 product checkout と短命 linked worktree の lifecycle を分離し、すべての product の worktree を一箇所で見えるようにする。
+  - この PC では `/Users/iwasawayuuta/workspace/worktrees` を worktree root として用意し、zsh profile で shell environment variable に設定する。
+- Current contract:
+  - Existing placement is `<main-worktree-parent>/<repo-basename>-worktrees/<repo-basename>-<id>`.
+  - Existing branch naming is `<current-branch>-<id>`.
+  - Existing label/id logic is `wt1`, `wt2`, ... or `<label>`, `<label>2`, ...
+
+## 選択肢 (必須)
+- Option A: Tool-specific env var + central root
+  - Pros:
+    - Env var ownership is clear: `SPEC_DOCK_WORKTREE_ROOT`.
+    - Missing env var can fail-fast with exact setup guidance.
+    - Low risk of colliding with unrelated tools.
+  - Cons:
+    - Longer name; other tools will not automatically share it.
+- Option B: Generic env var + central root
+  - Pros:
+    - Env var is short: `WORKTREE_ROOT`.
+    - Could be shared by multiple local tools if the user wants one convention.
+  - Cons:
+    - Ownership and semantics are ambiguous.
+    - Higher collision risk with unrelated scripts.
+- Option C: Central root with fallback to sibling placement
+  - Pros:
+    - Backward-compatible for users who have not configured env vars.
+  - Cons:
+    - Missing env var recreates the exact sandbox-permission problem.
+    - User explicitly asked for no worktree creation when env var is missing.
+- Option D: Reuse `$CODEX_HOME/worktrees`
+  - Pros:
+    - Already exists on this machine.
+  - Cons:
+    - Current docs reserve it for Codex app managed short-lived worktrees.
+    - Mixes spec-dock managed manual worktrees with Codex app lifecycle and cleanup expectations.
+
+## 推奨案 (必須)
+- Recommended option: A, `SPEC_DOCK_WORKTREE_ROOT`.
+- Local setup example:
+  - `export SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees`
+- Proposed path shape:
+  - `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>`
+  - This repo:
+    - `/Users/iwasawayuuta/workspace/worktrees/spec-dock/spec-dock-<id>`
+  - Label example:
+    - `/Users/iwasawayuuta/workspace/worktrees/spec-dock/spec-dock-central-root`
+  - Branch remains:
+    - `<current-branch>-<id>`
+- Rationale:
+  - Solves the Codex writable-root problem with one stable editable root.
+  - Keeps spec-dock managed worktrees distinct from normal product checkouts and Codex app managed worktrees.
+  - Keeps individual worktree names and branch names familiar.
+
+## User-confirmed decisions
+- 2026-05-26:
+  - Env var name is `SPEC_DOCK_WORKTREE_ROOT`.
+  - Missing env var is fatal for `worktree create`.
+  - If env var is set but the root directory does not exist, the command may create the root and namespace directories.
+  - Namespace is the Git main worktree basename. This repo uses `spec-dock`.
+  - This issue includes local machine setup: create `/Users/iwasawayuuta/workspace/worktrees` and add the export to `.zshenv`, with user approval when editing outside workspace.
+  - Existing sibling worktrees are left untouched.
+  - Backward compatibility for future sibling placement is not required.
+
+## Namespace analysis
+- User preference:
+  - Namespace is product name as-is.
+  - For this repo, namespace is `spec-dock`.
+- Simple rule:
+  - Default namespace = Git main worktree basename.
+  - This yields `spec-dock` for `/Users/iwasawayuuta/workspace/tools/spec-dock`.
+- Collision risk:
+  - If two different products share the same basename, both map to the same namespace.
+  - Existing sibling placement avoided this by scoping the container to each repo parent; central root removes that implicit parent namespace.
+- Possible mitigation:
+  - Keep default namespace as repo basename for human readability.
+  - Add override only later if a real collision or product-name mismatch appears.
+  - Do not introduce `tools-spec-dock` now unless the user values collision avoidance more than product-name readability.
+
+## Individual worktree naming analysis
+- Keep existing id logic:
+  - no label: `wt1`, `wt2`, ...
+  - label: `<label>`, `<label>2`, ...
+- Keep existing worktree directory basename:
+  - `<repo-basename>-<id>`
+- Keep existing branch:
+  - `<current-branch>-<id>`
+- Rationale:
+  - Existing behavior is already covered by tests and docs.
+  - Changing placement is enough to solve the sandbox and lifecycle problem.
+  - Renaming individual worktrees beyond placement would increase migration and user relearning cost.
+
+## 未決事項 (任意)
+- Env var name:
+  - Resolved: `SPEC_DOCK_WORKTREE_ROOT`.
+- Root creation:
+  - Resolved: command may create root / namespace when env var is set.
+- Namespace:
+  - Resolved: strictly repo basename for this issue.
+- Legacy:
+  - Resolved: leave untouched; no migration.
+- Scope:
+  - Resolved: include local setup; use `.zshenv`; request user approval for workspace-external edit.
+
+## 次アクション (必須)
+- `requirement.md` / `design.md` / `plan.md` / `adr` へ反映する内容:
+  - After interview answers, promote accepted placement/env/namespace/failure requirements into `requirement.md`.
+  - Then design env lookup / path derivation and plan targeted tests.
+- 追加で作る discussion docs:
+  - ADR only if central-root placement becomes a long-lived architecture decision that should supersede Epic E-RQ-002 beyond this issue.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t082342z-research-shell-environment-setup-research.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t082342z-research-shell-environment-setup-research.md
@@ -1,0 +1,91 @@
+---
+種別: research
+ID: "20260526t082342z-research"
+タイトル: "Shell Environment Setup Research"
+状態: "draft | completed | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "synthesized"
+derived_from: []
+reflected_to: []
+---
+
+# 20260526t082342z-research Shell Environment Setup Research
+
+## 位置づけ
+- 用途: 外部仕様、実装事実、先例、制約など、検証可能な根拠を整理する。
+- authority default: `synthesized`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- 調査結果が選択肢比較を必要とする場合は `disc`、長期判断を支える場合は `adr`、人間判断を必要とする場合は `interview` へつなぐ。
+- 事実、推測、未検証事項、判断への含意を混ぜない。
+
+## 調査目的 (必須)
+- `SPEC_DOCK_WORKTREE_ROOT` をこの開発環境のどの zsh startup file に置くべきかを、既存 local configuration の役割から確認する。
+- Workspace 外編集が必要な場合に、要件・計画へどのように approval と evidence を組み込むべきかを整理する。
+
+## 調査方法 (必須)
+- Read-only inspection:
+  - `/Users/iwasawayuuta/.zshenv`
+  - `/Users/iwasawayuuta/.zprofile`
+  - `/Users/iwasawayuuta/.zshrc`
+- Secret hygiene:
+  - `.zshrc` contains secret-looking exports, so this research records only structural facts relevant to startup-file placement and does not copy secret values.
+
+## 調査結果 (必須)
+- `.zshenv`:
+  - Contains a small set of environment variables that should be available broadly to zsh sessions.
+  - Existing examples include cache/root path variables and `WORKSPACE_SECRETS_HOME`.
+  - This makes `.zshenv` a good fit for `SPEC_DOCK_WORKTREE_ROOT`, because `spec-dock worktree create` may be run from non-login shells or tool-launched shells where `.zprofile` is not sourced.
+- `.zprofile`:
+  - Contains login-shell setup such as PATH additions, Java path, Homebrew preference, and OrbStack shell integration.
+  - It is less suitable for a required env var that should be visible to CLI invocations independent of login shell behavior.
+- `.zshrc`:
+  - Contains interactive shell configuration and many user-specific exports.
+  - It is not the preferred target for this issue because `spec-dock worktree create` can be run from scripts or non-interactive contexts.
+- Current state:
+  - `SPEC_DOCK_WORKTREE_ROOT` is not yet defined.
+  - `/Users/iwasawayuuta/workspace/worktrees` was not observed in the workspace directory listing before setup.
+- User-confirmed setup scope:
+  - This issue should include local machine setup.
+  - The setup target should be `.zshenv`.
+  - Editing `.zshenv` is outside the repository workspace and requires user approval at execution time.
+
+## 推測 / 未検証事項 (必須)
+- 推測:
+  - Adding `export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"` to `.zshenv` is preferable to a hard-coded absolute home path because it preserves the user's existing override and remains readable.
+  - Creating `/Users/iwasawayuuta/workspace/worktrees` can be treated as local setup evidence, not as a repository artifact.
+- 未検証:
+  - Whether Codex Desktop sessions launched before `.zshenv` change will inherit the new env var without restart.
+  - Whether the user wants a literal absolute path export or `$HOME/workspace/worktrees` expression in `.zshenv`.
+
+## 判断への含意 (必須)
+- Requirement should state that this issue includes local setup for the current development machine:
+  - create `/Users/iwasawayuuta/workspace/worktrees`
+  - add `SPEC_DOCK_WORKTREE_ROOT` export to `.zshenv`
+  - request approval before editing outside workspace
+- Design should separate:
+  - runtime behavior: read required env var and derive central path
+  - local setup evidence: directory/profile update for this machine
+- Plan should include a manual/local setup step with approval and verification:
+  - inspect existing `.zshenv`
+  - update it after approval
+  - verify a new shell sees `SPEC_DOCK_WORKTREE_ROOT`
+  - verify directory exists
+- This local setup should not be treated as a checked-in repo file change.
+
+## リスク/制約 (任意)
+- Editing user shell startup files is outside the repo and can affect future shells. It must be explicit, narrow, and approval-gated.
+- `.zshenv` is sourced by many zsh invocations; the added line must be simple, fast, and side-effect free.
+- Do not place commands that create directories inside `.zshenv`; directory creation should be a one-time setup action, not a shell startup side effect.
+
+## 反映先 (任意)
+- reflected_to:
+  - `requirement.md` local setup scope / approval requirement.
+  - `design.md` environment and setup boundary.
+  - `plan.md` local setup step.
+
+## 参考（References） (任意)
+- `/Users/iwasawayuuta/.zshenv`
+- `/Users/iwasawayuuta/.zprofile`
+- `/Users/iwasawayuuta/.zshrc` structural inspection only; no secret values copied.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t083209z-draft-design-central-worktree-root-placement-design-guidance.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t083209z-draft-design-central-worktree-root-placement-design-guidance.md
@@ -1,0 +1,196 @@
+---
+種別: draft-design
+ID: "20260526t083209z-draft-design"
+タイトル: "Central Worktree Root Placement Design Guidance"
+状態: "draft"
+作成者: "doc-writer"
+最終更新: "2026-05-26"
+親: ["iss-00130", "epic-00107", "init-local-00002"]
+authority: "proposed"
+created_by_role: "doc-writer"
+scope_id: "iss-00130"
+source_paths:
+  - "spec-dock/active/context-pack.md"
+  - "spec-dock/active/issue/requirement.md"
+  - "spec-dock/active/issue/design.md"
+  - "spec-dock/active/issue/plan.md"
+  - "spec-dock/active/issue/discussions/20260526t081258z-scratch-user-input-capture.md"
+  - "spec-dock/active/issue/discussions/20260526t081259z-01-interview-requirement-interview.md"
+  - "spec-dock/active/issue/discussions/20260526t081259z-research-existing-worktree-contract-research.md"
+  - "spec-dock/active/issue/discussions/20260526t081356z-disc-central-root-placement-options.md"
+  - "spec-dock/active/issue/discussions/20260526t082342z-research-shell-environment-setup-research.md"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py"
+  - "src/spec_dock/assets/spec_dock/docs/reference_worktree.md"
+  - "tests/cli_runtime/test_worktree.py"
+intended_targets:
+  - "spec-dock/active/issue/design.md"
+  - "spec-dock/active/issue/plan.md"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py"
+  - "src/spec_dock/assets/spec_dock/docs/reference_worktree.md"
+  - "tests/cli_runtime/test_worktree.py"
+adoption_status: "unreviewed"
+reflected_to: []
+diff_guard_result: "2026-05-26: created this discussion draft only; canonical requirement/design/plan/report were not edited by doc-writer. git status also showed pre-existing/unrelated issue-local changes outside this draft."
+---
+
+# Central Worktree Root Placement Design Guidance
+
+## 位置づけ
+- This is a scope-local flat discussion draft for `iss-00130`.
+- It is not canonical `requirement.md`, `design.md`, `plan.md`, or `report.md`.
+- Parent orchestrator owns adoption, promotion, and canonical report ledger disposition.
+
+## 設計ゴール
+- Change future `spec-dock worktree create` placement from an implicit sibling container to an explicit central root.
+- Require `SPEC_DOCK_WORKTREE_ROOT` for `worktree create`; missing env var is fatal and must not fall back to sibling placement.
+- Derive namespace from the Git main worktree basename.
+- Keep current id, directory basename suffix, and branch naming logic.
+- Leave existing sibling worktrees untouched; no migration or backward compatibility path for future sibling placement is required.
+- Treat local `.zshenv` setup as verification evidence only. Repository implementation should not edit user shell startup files.
+
+## Current Contract
+- `application/worktree.py` currently computes:
+  - `main_worktree = records[0].path`
+  - `repo_basename = main_worktree.name`
+  - `container = main_worktree.parent / f"{repo_basename}-worktrees"`
+  - `worktree_path = container / f"{repo_basename}-{worktree_id}"`
+  - `branch_name = f"{branch_prefix}-{worktree_id}"`
+- `WorktreeCreateRequest` carries only `label`.
+- `WorktreeCreateResult` already exposes `container_path` and `worktree_path`.
+- `reference_worktree.md` documents sibling placement.
+- `tests/cli_runtime/test_worktree.py` asserts sibling placement in CLI integration tests and unit-style fake gateway tests.
+
+## Target Placement Contract
+- Required env var:
+  - `SPEC_DOCK_WORKTREE_ROOT`
+- Missing env var:
+  - Fatal precondition failure before any worktree path, branch, Git worktree, or bootstrap side effect.
+  - Error text should name `SPEC_DOCK_WORKTREE_ROOT` and state that it is required for `worktree create`.
+- Env var present but root directory missing:
+  - The command may create the root and namespace directories.
+  - Creation should be explicit in the implementation path, not a shell startup side effect.
+- Namespace:
+  - `namespace = <Git main worktree basename>`
+  - For this repo: `spec-dock`.
+- Worktree path:
+  - `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>`
+  - For this repo with `id=wt1`: `/Users/iwasawayuuta/workspace/worktrees/spec-dock/spec-dock-wt1`
+- Id and branch:
+  - Keep existing id rules: `wt1`, `wt2`, ... or `<label>`, `<label>2`, ...
+  - Keep existing branch rule: `<current-branch>-<id>`.
+- Linked worktree invocation:
+  - Continue using Git's main worktree record for `repo_basename` and namespace.
+  - Continue using the executing checkout's current branch for `branch_prefix`, matching existing behavior.
+
+## Boundary Recommendation
+- Put env lookup behind an application-facing runtime/environment boundary rather than reading `os.environ` directly inside parser or CLI command code.
+- Keep `commands/worktree.py` responsible for CLI args only.
+- Keep `application/worktree.py` responsible for placement derivation and fatal precondition behavior.
+- Add the minimal port or bootstrap-provided value needed so unit tests can simulate missing and present env without relying on process-global environment.
+- Do not add a CLI flag for root override in this issue; the accepted contract is env-var based.
+- Do not add namespace override in this issue; collision mitigation is a future extension only if a real basename collision appears.
+
+## Suggested Data Flow
+```text
+CLI parser
+  -> WorktreeCreateRequest(label)
+  -> application worktree_create
+      -> require SPEC_DOCK_WORKTREE_ROOT via environment/config port
+      -> git worktree list to find main worktree basename
+      -> namespace = main_worktree.name
+      -> container = env_root / namespace
+      -> worktree_path = container / f"{repo_basename}-{id}"
+      -> branch = f"{current_branch}-{id}"
+      -> preflight collision
+      -> mkdir env_root/namespace as needed
+      -> git worktree add
+      -> make init bootstrap
+```
+
+## Module Dependency Diagram
+```plantuml
+@startuml
+top to bottom direction
+
+rectangle "commands/worktree.py\nCLI args only" as CMD
+rectangle "application/contracts.py\nWorktree request/result" as CONTRACTS
+rectangle "application/ports.py\nEnv/config boundary" as PORTS
+rectangle "application/worktree.py\nplacement + creation use case" as APP
+rectangle "cli/bootstrap.py\nruntime port implementation" as BOOT
+rectangle "infra/git_cli.py\nGit worktree operations" as GIT
+rectangle "infra/make_cli.py\nmake init bootstrap" as MAKE
+rectangle "presentation/cli_text.py\nsuccess output" as TEXT
+
+CMD --> CONTRACTS
+CMD --> APP
+APP --> CONTRACTS
+APP --> PORTS
+APP --> GIT
+APP --> MAKE
+BOOT --> PORTS
+TEXT --> CONTRACTS
+@enduml
+```
+
+## File Change Guidance
+```text
+src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/
+|-- application/
+|   |-- worktree.py      # change placement derivation and missing-env failure
+|   |-- contracts.py     # add only if request/result/port contract needs a new typed field
+|   `-- ports.py         # add a narrow environment/config protocol if no existing port fits
+|-- cli/
+|   `-- bootstrap.py     # wire real env lookup into Ports
+|-- commands/
+|   `-- worktree.py      # likely no behavior change beyond keeping args unchanged
+`-- presentation/
+    `-- cli_text.py      # change only if output should expose root/container explicitly
+
+src/spec_dock/assets/spec_dock/docs/
+`-- reference_worktree.md # update shipped user-facing placement docs
+
+tests/
+`-- cli_runtime/
+    `-- test_worktree.py # update sibling assertions and add env-required coverage
+```
+
+## Test Strategy
+- CLI integration:
+  - Missing `SPEC_DOCK_WORKTREE_ROOT` fails with a clear error and creates no sibling container, no central namespace, no worktree branch, and no bootstrap side effect.
+  - Present env var creates worktree under `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>`.
+  - Present env var with missing root creates root/namespace as needed.
+  - Invalid label still fails before placement creation.
+  - `make init` success/failure/detection-failure tests use central-root expected paths.
+  - Linked worktree invocation normalizes namespace/path from Git main worktree basename while preserving executing checkout branch prefix.
+- Application/unit-style tests:
+  - Fake environment/config port can return missing and present values.
+  - Non-retryable `git worktree add` failures still report artifact state for the central path.
+  - Retryable collisions still advance id/branch candidates without changing naming rules.
+- Docs verification:
+  - `reference_worktree.md` no longer states sibling placement as current behavior.
+  - Docs distinguish spec-dock managed central root from Codex app `$CODEX_HOME/worktrees`.
+- Local setup evidence:
+  - Verification may record that a fresh zsh sees `SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees`.
+  - Verification may record whether `/Users/iwasawayuuta/workspace/worktrees` exists before/after command execution.
+  - No repository change should depend on editing `.zshenv` during implementation.
+
+## Canonical Promotion Notes
+- Requirement should explicitly supersede the approved Epic sibling-placement contract for future `worktree create`.
+- Design should state that existing sibling worktrees remain valid Git worktrees but are not migrated or reused by new placement.
+- Plan should include a docs update step because shipped `reference_worktree.md` currently documents sibling placement.
+- Report should treat this draft as unreviewed input until the parent orchestrator adopts or rejects it.
+
+## Material Decisions / Open Questions
+- No remaining material design question is required to draft the implementation shape from the provided facts.
+- The durable decision to promote central-root placement over the Epic's existing sibling-placement contract still belongs to the parent orchestrator and canonical artifacts.
+- Optional future follow-up, out of scope for this issue:
+  - namespace override for repos with colliding basenames.
+  - list/remove/prune commands for centrally placed worktrees.
+  - migration guide for existing sibling worktrees.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t083220z-draft-plan-central-worktree-root-placement-implementation-plan-guidance.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t083220z-draft-plan-central-worktree-root-placement-implementation-plan-guidance.md
@@ -1,0 +1,253 @@
+---
+種別: draft-plan
+ID: "20260526t083220z-draft-plan"
+タイトル: "Central Worktree Root Placement Implementation Plan Guidance"
+状態: "draft"
+作成者: "doc-writer"
+最終更新: "2026-05-26"
+親: ["iss-00130"]
+関連: []
+authority: "proposed"
+derived_from:
+  - "spec-dock/active/context-pack.md"
+  - "spec-dock/active/issue/requirement.md"
+  - "spec-dock/active/issue/design.md"
+  - "spec-dock/active/issue/plan.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-01-interview-requirement-interview.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-research-existing-worktree-contract-research.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081356z-disc-central-root-placement-options.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t082342z-research-shell-environment-setup-research.md"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py"
+  - "tests/cli_runtime/test_worktree.py"
+  - "src/spec_dock/assets/spec_dock/docs/reference_worktree.md"
+reflected_to: []
+created_by_role: "doc-writer"
+scope_id: "iss-00130"
+source_paths:
+  - "spec-dock/active/context-pack.md"
+  - "spec-dock/active/issue/requirement.md"
+  - "spec-dock/active/issue/design.md"
+  - "spec-dock/active/issue/plan.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-01-interview-requirement-interview.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081259z-research-existing-worktree-contract-research.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t081356z-disc-central-root-placement-options.md"
+  - "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/discussions/20260526t082342z-research-shell-environment-setup-research.md"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/worktree.py"
+  - "src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py"
+  - "tests/cli_runtime/test_worktree.py"
+  - "src/spec_dock/assets/spec_dock/docs/reference_worktree.md"
+intended_targets:
+  - "spec-dock/active/issue/plan.md"
+  - "spec-dock/active/issue/report.md"
+adoption_status: "unreviewed"
+diff_guard_result: "created this discussion draft only; current worktree also contains requirement.md/design.md diffs outside this doc-writer edit scope"
+---
+
+# 20260526t083220z-draft-plan Central Worktree Root Placement Implementation Plan Guidance
+
+## Position
+- This is a scope-local flat discussion draft for `iss-00130`.
+- Canonical `requirement.md`, `design.md`, `plan.md`, and `report.md` remain parent-orchestrator owned and are not edited by this draft.
+- This guidance assumes the latest user-provided facts:
+  - required env var: `SPEC_DOCK_WORKTREE_ROOT`
+  - missing env var is fatal for `worktree create`
+  - env set but root missing may create the root and namespace directories
+  - namespace is the Git main worktree basename
+  - path is `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>`
+  - current id and branch naming stay unchanged
+  - no migration or backward compatibility for future sibling placement
+  - existing sibling worktrees are untouched
+  - local `.zshenv` setup has already been performed by the user and should be verification evidence only
+
+## Current Implementation Summary
+- `application/worktree.py` currently derives placement from the Git main worktree:
+  - `main_worktree = records[0].path`
+  - `repo_basename = main_worktree.name`
+  - `container = main_worktree.parent / f"{repo_basename}-worktrees"`
+  - `worktree_path = container / f"{repo_basename}-{worktree_id}"`
+- `WorktreeCreateRequest` currently only carries `label`.
+- `WorktreeCreateResult` already exposes `container_path` and `worktree_path`.
+- `commands/worktree.py` should not need a new CLI option; env root is configuration, not user command input.
+- `ports.py` does not currently define an environment/config port.
+- `tests/cli_runtime/test_worktree.py` currently hard-codes sibling placement in integration and fake-gateway tests.
+- `reference_worktree.md` documents sibling placement and must be updated when the runtime contract changes.
+
+## Recommended Behavior Slices
+
+### S01 - Fatal Missing Env Var
+- Behavior goal:
+  - `worktree create` fails before directory creation or Git mutation when `SPEC_DOCK_WORKTREE_ROOT` is unset or blank.
+- Recommended implementation scope:
+  - Add a narrow env/config boundary available to `application/worktree.py`.
+  - Prefer an application port such as `EnvironmentGateway.getenv(name: str) -> str | None` or an equivalent small runtime config port over direct `os.environ` reads in the use case.
+  - Wire the concrete implementation in `cli/bootstrap.py`.
+- Test obligation:
+  - Add a unit-level or CLI-runtime test that runs `worktree create` without `SPEC_DOCK_WORKTREE_ROOT`.
+  - Assert non-zero exit, error text naming `SPEC_DOCK_WORKTREE_ROOT`, and no worktree root / namespace / sibling container creation.
+- Verification command:
+  - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree.<missing-env-test> -v`
+- Closure notes:
+  - This slice should close the fail-fast contract before any path behavior is changed.
+
+### S02 - Central Root Path Derivation and Directory Creation
+- Behavior goal:
+  - With `SPEC_DOCK_WORKTREE_ROOT` set, future worktrees are created at `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>`.
+  - Namespace is the Git main worktree basename.
+  - Env root and namespace directories may be created if missing.
+- Recommended implementation scope:
+  - Replace sibling `container` derivation with env-root container derivation.
+  - Keep `repo_basename = main_worktree.name`.
+  - Set `container = Path(env_value).expanduser() / repo_basename`.
+  - Keep `worktree_path = container / f"{repo_basename}-{worktree_id}"`.
+  - Preserve existing container mkdir error handling and artifact-state reporting, but update wording if "container" now means namespace directory.
+- Test obligation:
+  - Update the main success test to pass `SPEC_DOCK_WORKTREE_ROOT=<tmp>/central-root`.
+  - Assert path `<tmp>/central-root/sample-repo/sample-repo-wt1`.
+  - Assert the root and namespace are created when they did not exist before.
+  - Assert no sibling `sample-repo-worktrees` directory is created.
+- Verification command:
+  - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_uses_central_root_auto_id_and_branch -v`
+
+### S03 - Preserve Existing ID, Label, Branch, Collision, and Bootstrap Behavior
+- Behavior goal:
+  - Only placement changes. Current id and branch naming remain:
+    - auto id: `wt1`, `wt2`, ...
+    - label id: `<label>`, `<label>2`, ...
+    - branch: `<current-branch>-<id>`
+  - Existing collision retry and bootstrap semantics remain unchanged.
+- Recommended implementation scope:
+  - Keep `_candidate_id`, label validation, branch naming, retryable Git collision handling, and `make init` handling intact.
+  - Update tests that compute expected paths from sibling placement to central placement.
+- Test obligation:
+  - Retain or update:
+    - label collision retry
+    - auto id collision retry
+    - invalid label rejection
+    - branch prefix with slash
+    - make init success/failure/detection failure
+    - non-retryable Git add failure
+    - retryable Git add collision
+  - For tests using fake worktree records, update known paths from `repo-worktrees/repo-wt1` to the central root namespace path where relevant.
+- Verification command:
+  - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree -v`
+
+### S04 - Linked Worktree Normalization Uses Main Worktree Namespace
+- Behavior goal:
+  - Running `worktree create` from an existing linked worktree still derives namespace and repo basename from Git's main worktree, not from the current linked worktree directory.
+  - Branch prefix still uses the current checkout branch, preserving current behavior.
+- Recommended implementation scope:
+  - Keep `records[0].path` as the main worktree source, subject to the existing Git record ordering assumption.
+  - Do not introduce migration or discovery of old sibling worktrees.
+- Test obligation:
+  - Update linked-worktree test to create both outer and inner worktrees under the central root namespace:
+    - `<root>/sample-repo/sample-repo-outer`
+    - `<root>/sample-repo/sample-repo-inner`
+  - Assert old sibling container is untouched or absent for new command output.
+- Verification command:
+  - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_normalizes_container_from_linked_worktree -v`
+
+### S05 - Documentation Impact Resolution
+- Behavior goal:
+  - Shipped reference docs describe the required env var, fatal missing-env behavior, new path shape, namespace rule, and legacy boundary.
+- Recommended docs scope:
+  - Update `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`.
+  - Consider whether generated dogfooding `spec-dock/docs/reference_worktree.md` should be refreshed by the normal update/sync flow rather than edited directly.
+- Required content:
+  - Setup example:
+    - `export SPEC_DOCK_WORKTREE_ROOT="$HOME/workspace/worktrees"`
+  - Layout:
+    - `$SPEC_DOCK_WORKTREE_ROOT/spec-dock/spec-dock-wt1`
+  - Missing env var:
+    - fatal; no fallback to sibling placement.
+  - Existing sibling worktrees:
+    - untouched legacy worktrees; no migration in this issue.
+  - Codex app worktrees:
+    - remain distinct from spec-dock managed manual worktrees.
+- Verification:
+  - Inspect docs diff for removal of sibling placement as the future creation contract.
+  - Run `spec-reviewer` docs/spec alignment before adopting into canonical report.
+
+### S06 - Local Environment Verification Evidence Only
+- Behavior goal:
+  - The repo implementation does not edit local `.zshenv`; the user's setup is only verified as evidence.
+- Recommended verification evidence:
+  - Confirm the current shell environment exposes `SPEC_DOCK_WORKTREE_ROOT`.
+  - Confirm the value points to `/Users/iwasawayuuta/workspace/worktrees` or the user-approved equivalent.
+  - Confirm the directory exists or is creatable by the command in a disposable/manual smoke flow.
+- Suggested commands:
+  - `printenv SPEC_DOCK_WORKTREE_ROOT`
+  - `test -d "$SPEC_DOCK_WORKTREE_ROOT"`
+  - A disposable fixture smoke test with explicit env:
+    - `SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees <fixture>/spec-dock/scripts/spec-dock worktree create central-root-smoke`
+- Boundary:
+  - Do not edit `/Users/iwasawayuuta/.zshenv` in this issue unless the parent orchestrator records a new explicit approval and updates the plan.
+
+### S99 - Final Quality Gate
+- Required automated verification:
+  - Targeted worktree suite:
+    - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree -v`
+  - Broader runtime safety, if feasible:
+    - `python -m unittest discover -v`
+  - spec-dock validation:
+    - `./spec-dock/scripts/spec-dock validate`
+    - `./spec-dock/scripts/spec-dock sync`
+- Required reviews:
+  - Per-step `code-reviewer` for runtime/tests/scaffold behavior changes.
+  - `spec-reviewer` for docs/spec alignment after docs impact resolution.
+  - Final `qa-reviewer`, issue-wide `code-reviewer`, and final `spec-reviewer` per issue workflow.
+- Required report evidence:
+  - Missing-env fatal behavior evidence.
+  - Central-root path and namespace evidence.
+  - Existing naming/collision/bootstrap behavior evidence.
+  - Linked-worktree normalization evidence.
+  - Docs impact resolution evidence.
+  - Local env verification evidence only; no local shell profile diff.
+
+## Closure Index Draft
+
+| ID | Slice | Type | Locked Expectation | Observable Input / State | Bug Class Prevented | Evidence Level |
+|---|---|---|---|---|---|---|
+| wt-root-001 | S01 | negative | Missing or blank `SPEC_DOCK_WORKTREE_ROOT` is fatal and creates no worktree path | CLI runtime env without variable | silent fallback to sibling placement | red-required |
+| wt-root-002 | S02 | acceptance | Worktree path is `$SPEC_DOCK_WORKTREE_ROOT/<main-basename>/<main-basename>-<id>` | env set to missing temp root | wrong placement / root not created | red-required |
+| wt-root-003 | S03 | regression | id, label retry, branch naming, bootstrap semantics remain unchanged | existing worktree tests with central-root env | unnecessary naming or bootstrap regression | covered-existing plus updates |
+| wt-root-004 | S04 | regression | linked worktree invocation uses Git main worktree basename namespace | command run from linked worktree | nested or linked-worktree-derived namespace drift | red-required |
+| wt-root-005 | S05 | docs | reference docs describe env root, fatal missing env, no migration | shipped docs diff | user-facing contract drift | inspect-only |
+| wt-root-006 | S06 | local evidence | local setup is verified, not edited by repo implementation | shell env / directory check | hidden workspace-external mutation | manual-required |
+
+## Affected Files and Tests
+- Expected runtime files:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py` only if result/request naming needs additional clarity
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py` only if output should expose `container_path` or root/namespace explicitly
+- Expected docs:
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+  - generated dogfooding docs under `spec-dock/docs/` only through the normal scaffold refresh flow if the parent plan requires it
+- Expected tests:
+  - `tests/cli_runtime/test_worktree.py`
+- Explicitly out of scope:
+  - migration or moving existing sibling worktrees
+  - fallback to sibling placement
+  - changing id generation
+  - changing branch naming
+  - adding namespace override config
+  - editing `.zshenv` as part of implementation
+
+## Open Plan Risks / Parent-Orchestrator Decisions
+- Env/config boundary:
+  - Recommendation: use a small port/config gateway so `worktree_create` can be tested without process-global env mutation.
+  - Risk: direct `os.environ` in the use case is simpler but weaker for isolated tests and boundary consistency.
+- Output wording:
+  - Recommendation: existing success output can remain path-focused, but fatal missing-env error must name `SPEC_DOCK_WORKTREE_ROOT`.
+  - Optional: include root/namespace in error diagnostics only; do not expand success output unless needed.
+- Dogfooding refresh:
+  - Recommendation: update provider-side docs first and let normal update/sync decide generated dogfooding diffs.
+  - Risk: directly editing generated docs can hide scaffold drift.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/plan.md
@@ -3,267 +3,1035 @@
 ID: "iss-00130"
 タイトル: "Central Worktree Root Placement"
 関連GitHub: ["#130"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-26"
+最終更新: "2026-05-27"
 依存: ["requirement.md", "design.md"]
 親: ["epic-00107", "init-local-00002"]
 ---
 
 # iss-00130 Central Worktree Root Placement — 実装計画（実行契約 / Execution Contract）
 
-> このテンプレートは最小 scaffold です。`plan.md` は計画済み契約（planned contract）を所有し、実装者が step を上から順に実行できる command queue として書く。実行結果、逸脱、発見された tests、reviewer verdict、commit/no-op evidence は `report.md` の観測証跡台帳（observed evidence ledger）に記録する。実行 policy は `workflow_issue.md`、Issue 計画の書き方は `phase_plan_issue.md` と `docs/authoring/issue-plan.md` を正本にする。
-
 ## この計画で満たす要件ID
 - AC:
-  - ...
+  - AC-001: env var missing / blank の fatal failure
+  - AC-002: central root placement
+  - AC-003: env root / namespace directory auto creation
+  - AC-004: path validation
+  - AC-005: existing naming and collision behavior is preserved
+  - AC-006: linked worktree invocation normalization
+  - AC-007: bootstrap behavior preservation
+  - AC-008: docs and dogfooding parity
+  - AC-009: local setup evidence
 - EC:
-  - ...
+  - EC-001: invalid label
+  - EC-002: valid env var but root path creation fails
+  - EC-003: namespace directory already exists
+  - EC-004: same basename repository collision
+  - EC-005: existing sibling worktrees
 - 制約:
-  - ...
+  - Missing / blank `SPEC_DOCK_WORKTREE_ROOT` で sibling placement fallback しない。
+  - Existing sibling worktrees を migrate / remove しない。
+  - Namespace override、list/remove/prune、`$CODEX_HOME/worktrees` mixing は scope 外。
+  - Parent Epic の sibling placement は future behavior として残さない。
 
 ## 依存関係から導く実装順序
 - 依存関係の正本:
-  - `design.md` の依存関係、図、ファイル変更計画
+  - `design.md` の `依存関係分析`、`Module Dependency Diagram`、`ディレクトリ / ファイル変更計画`。
 - 順序ルール:
-  - prerequisite / lower-dependency slice から先に閉じる
-  - downstream slice は前提が固定されてから置く
+  - Env/config port を先に固定する。
+  - Missing / invalid env の fatal behavior を placement change より先に閉じる。
+  - Central placement を実装してから、既存 naming / collision / bootstrap / linked-worktree regression を中央 root に合わせて閉じる。
+  - Docs / parent Epic update は runtime behavior と tests のあとに実施する。
 - step 依存サマリー:
   - S01:
-    - 依存:
-    - unblock:
-    - 対象ファイル:
+    - 依存: requirement/design pass
+    - unblock: S02, S03
+    - 対象ファイル: `ports.py`, `bootstrap.py`, `worktree.py`, `test_worktree.py`
+  - S02:
+    - 依存: S01 env boundary
+    - unblock: S03
+    - 対象ファイル: `worktree.py`, `test_worktree.py`
+  - S03:
+    - 依存: S01, S02
+    - unblock: S04, S05
+    - 対象ファイル: `worktree.py`, `test_worktree.py`
+  - S04:
+    - 依存: S03
+    - unblock: S99
+    - 対象ファイル: `worktree.py`, `test_worktree.py`
+  - S05:
+    - 依存: S03
+    - unblock: S99
+    - 対象ファイル: `worktree.py`, `test_worktree.py`
+  - S06:
+    - 依存: none on runtime implementation
+    - unblock: S99 local evidence
+    - 対象: report evidence only
+  - S90:
+    - 依存: S03-S05 runtime contract
+    - unblock: S99
+    - 対象ファイル: shipped docs, dogfooding docs, parent Epic docs
+  - S99:
+    - 依存: S01-S06, S90
+    - 対象: final validation / reviewers / report ledger
+  - S100:
+    - 依存: S99 final quality reviews and implementation/report ledger readiness
+    - 対象: PR Delivery Gate / Merge Preparation Gate / delivery evidence commit / issue finish readiness
 
 ## ステップ一覧
 - S01:
-  - 観測可能な振る舞い:
-  - 依存:
-  - unblock:
-  - 対象ファイル:
-  - 閉じる要件:
-  - レビューゲート:
+  - 観測可能な振る舞い: missing / blank `SPEC_DOCK_WORKTREE_ROOT` が副作用なしで fatal になる。
+  - レビューゲート: code-reviewer
 - S02:
-  - ...
+  - 観測可能な振る舞い: invalid root path は副作用なしで fatal、valid `~` absolute / directory symlink は許可される。
+  - レビューゲート: code-reviewer
+- S03:
+  - 観測可能な振る舞い: valid env root で central root namespace に worktree が作られ、旧 sibling container は使われない。
+  - レビューゲート: code-reviewer
+- S04:
+  - 観測可能な振る舞い: id / label / branch / collision / bootstrap behavior が placement 変更後も維持される。
+  - レビューゲート: code-reviewer
+- S05:
+  - 観測可能な振る舞い: linked worktree からの実行でも main worktree basename を namespace に使う。
+  - レビューゲート: code-reviewer
+- S06:
+  - 観測可能な振る舞い: local setup は report evidence として確認され、repo artifact に混ざらない。
+  - レビューゲート: read-only evidence; repo diff がなければ reviewer 不要
+- S90:
+  - 観測可能な振る舞い: shipped docs / dogfooding docs / parent Epic docs が central root contract と整合する。
+  - レビューゲート: spec-reviewer docs/spec alignment
+- S99:
+  - 観測可能な振る舞い: issue-wide diff が requirement / design / plan / report / tests / docs と整合する。
+  - レビューゲート: qa-reviewer, issue-wide code-reviewer, final spec-reviewer
+- S100:
+  - 観測可能な振る舞い: PR delivery と merge-preparation evidence が report / external delivery に揃い、delivery evidence commit と latest-head monitor により `issue finish` 前提が満たされる。
+  - レビューゲート: github-pr-merge-preparer / PR monitor evidence
 
 ## 要件 ↔ ステップ対応
 - AC-001 -> S01
-- EC-001 -> S02
+- AC-002 -> S03, S90
+- AC-003 -> S03
+- AC-004 -> S02
+- AC-005 -> S04
+- AC-006 -> S05
+- AC-007 -> S04
+- AC-008 -> S90, S99
+- AC-009 -> S06
+- EC-001 -> S04
+- EC-002 -> S02
+- EC-003 -> S03, S04
+- EC-004 -> S04, S90
+- EC-005 -> S03, S90
 
 ## 仕様固定クロージャ索引（Spec-Locked Closure Index）
 
-> これは Issue 全体のテスト一覧ではなく、仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の step-local obligation と concrete seeds は各 implementation step の `具体テストケース一覧` に置く。
-
 | 識別子（ID） | ステップ（step） | スライス（slice） | 種別（type） | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル（evidence level） | クロージャ証跡（closure evidence） |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | 受け入れ（acceptance） | AC-001 | ... | ... | 仕様 drift（spec drift） | yes | red-required | ステップ完了証跡（report step closure） |
-| tc-002 | S01 | <behavior> | 否定系（negative） | EC-001 | ... | ... | 沈黙失敗（silent failure） | yes | inspect-only | ステップ完了証跡（report step closure） |
-
-- 証跡レベル（evidence level）:
-  - red-required: 実装前に失敗する新規 test / characterization を固定する。
-  - covered-existing: 既存 test が対象 behavior を検出できる根拠を固定する。
-  - inspect-only: docs / template / config などを inspection、structural assertion、review evidence で閉じる。
-  - manual-required: 自動化できない確認手順、期待結果、記録先を固定する。
-- 詳細化方針:
-  - 件数ではなく、AC、changed contract、failure mode、regression risk、invariant、manual / integration risk から必要な obligation を決める。
-  - private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+| slci-001 | S01 | missing-env-fatal | negative | AC-001 / non-negotiable no fallback | missing / blank env is fatal before Git, branch, directory, bootstrap side effects | valid repo + unset/blank `SPEC_DOCK_WORKTREE_ROOT` | silent fallback to sibling placement | yes | red-required | Step/Test Contract Closure |
+| slci-002 | S02 | invalid-root-fatal | negative | AC-004 / EC-002 | invalid root is fatal with var name, raw/resolved path, cause, absolute setup example | relative/file/broken symlink/non-directory root | unclear remediation / unsafe path use | yes | red-required | Step/Test Contract Closure |
+| slci-003 | S02 | valid-root-forms | acceptance | AC-004 | `~` absolute expansion and directory symlink are accepted | env var with `~` or directory symlink | over-strict root rejection | yes | red-required | Step/Test Contract Closure |
+| slci-004 | S03 | central-placement | acceptance | AC-002 / AC-003 | path is `$SPEC_DOCK_WORKTREE_ROOT/<main-basename>/<main-basename>-<id>` and root/namespace may be created | valid env root, missing namespace | wrong placement / root not created | yes | red-required | Step/Test Contract Closure |
+| slci-005 | S03 / S90 | no-sibling-future | negative | AC-002 / EC-005 | new creates do not use or migrate old sibling placement | old sibling path absent or existing | legacy fallback / unintended migration | yes | red-required / inspect-only | Step/Test Contract Closure |
+| slci-006 | S04 | existing-naming-collision | regression | AC-005 / EC-001 / EC-003 / EC-004 | label/id/branch/collision rules stay unchanged; no namespace override/config is added | labels, branch prefixes, path/branch/record collisions | behavior regression / scope creep | yes | covered-existing / red-required | Step/Test Contract Closure |
+| slci-007 | S04 | bootstrap-preservation | regression | AC-007 | `make init` success/skipped/failed/detection_failed remains non-fatal | Makefile success/failure/missing/detection failure | bootstrap fatality regression | yes | covered-existing | Step/Test Contract Closure |
+| slci-008 | S05 | linked-worktree-normalization | regression | AC-006 | linked worktree run uses Git main worktree basename for namespace and current checkout branch for branch prefix | command run from linked worktree | nested namespace / wrong branch prefix | yes | red-required | Step/Test Contract Closure |
+| slci-009 | S06 | local-setup-evidence | manual | AC-009 | `.zshenv` / user-local root are evidence only, not repo-managed artifacts | shell env and filesystem inspection | hidden workspace-external mutation | yes | manual-required | Report evidence |
+| slci-010 | S90 | docs-parent-supersession | docs | AC-008 / parent Epic supersession | shipped docs, dogfooding docs, parent Epic docs no longer present sibling placement as future behavior | docs diff | stale user-facing contract | yes | inspect-only | Docs review evidence |
+| slci-011 | S90 / S99 | scope-boundary-docs | docs | out-of-scope / Codex boundary | docs and diff contain no list/remove/prune feature, no Codex app worktree mixing | docs and code diff | scope creep | yes | inspect-only | Docs/final review evidence |
+| slci-012 | S90 / S99 | provider-dogfooding-parity | integration | provider-side source of truth | provider asset changes and dogfooding workspace parity are verified | update/sync/parity evidence | scaffold drift | yes | command evidence | Final quality evidence |
+| slci-013 | S100 | pr-delivery-merge-prep | delivery | workflow_issue.md PR Delivery Gate / Merge Preparation Gate | PR delivery and merge-preparation evidence are recorded before `issue finish` | final committed branch and PR state | premature issue finish / missing delivery evidence | yes | command / monitor evidence | PR Delivery Gate / Merge Preparation Gate |
 
 ## レビュー / QA ゲート方針
 - RG1 step review:
-  - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only）
-  - pass 条件: review_status: pass
+  - Runtime / tests / scaffold behavior steps use `code-reviewer`.
+  - Docs-only / parent spec docs alignment uses `spec-reviewer`.
 - QG1 final QA:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage、missing high-value tests、manual / integration test 要否
+  - `qa-reviewer` checks test sufficiency, missing high-value tests, and integration/manual evidence.
+- CG1 issue-wide code review:
+  - `code-reviewer` checks integrated runtime/test structure and regression risk.
 - SG1 final spec review:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / docs 整合
+  - `spec-reviewer` checks requirement / design / plan / report / docs / implementation / tests consistency.
 
 ## 実行ルール（全ステップ共通）
-- 各 implementation step は原則として 1 behavior slice / 1 review scope / 1 commit boundary とする。
-- `plan.md` には planned requirements、evidence destination、closure 条件だけを書く。observed result は `report.md` に書く。
-- docs-only / inspect-only / manual-required step は code test 前提にせず、代替 evidence path と rationale を implementation 前に固定する。
-- implementation 中に新しい仕様、bug class、外部 contract risk、未計画の closure が見つかった場合は、report 記録だけで足りるか、plan amendment と re-review が必要かを判断する。
+- 各 implementation step は 1 behavior slice / 1 review scope / 1 commit boundary を標準にする。
+- Observed result は `report.md` に記録し、`plan.md` に戻さない。
+- Worker は material decision があれば Ledger Note を返し、なければ `No material implementation decisions beyond the approved plan.` と明示する。
+- Reviewer fail の修正は bounded delegated follow-up とし、fresh reviewer pass まで回す。
+- 実装前にこの plan をユーザーへ提出し、approval を得る。
 
 ## 実装ステップ
 
-### 実装ステップ S01 — <観測可能な振る舞い>
-- 振る舞いの目標（behavior goal）:
-  - ...
+### 実装ステップ S01 — Missing / Blank Env Fatal
+- 振る舞いの目標:
+  - `SPEC_DOCK_WORKTREE_ROOT` が unset / empty / whitespace-only の場合、`worktree create` は副作用なしで fatal になる。
 - design 参照:
-  - ...
+  - `インターフェース契約`, `シーケンス差分`, `要件 → 設計マッピング`
 - 依存:
-  - ...
+  - requirement/design reviewer pass
 - unblock:
-  - ...
+  - S02, S03
 - 対象ファイル:
-  - ...
-- 計画済み契約（planned contract）:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `tests/cli_runtime/test_worktree.py`
+- 計画済み契約:
   - scope:
-    - 実装・文書化する範囲:
-  - テスト義務（test obligation）:
-    - closure id:
-      - tc-001
+    - `EnvironmentGateway.getenv(name)` protocol を追加する。
+    - `cli/bootstrap.py` に `os.environ.get` backed adapter を追加する。
+    - `worktree_create` は port 経由で env var を読み、missing / blank を fatal にする。
+  - テスト義務:
+    - closure id: slci-001
     - coverage rationale:
-      - AC / changed contract / failure mode / regression risk / invariant / manual risk から必要性を書く:
+      - Silent fallback to sibling placement が本 issue の中心 bug class なので red-required。
   - Red / 代替証跡の要件:
-    - red-required / covered-existing:
-      - 実装前に確認する failing test、characterization、または既存 test sensitivity:
-    - docs-only / inspect-only / manual-required:
-      - code test を置かない理由:
-      - 代替 evidence path:
-      - manual 手順と期待結果:
-  - 実装範囲（implementation scope）:
-    - allowed paths:
-      - ...
-    - forbidden changes:
-      - ...
+    - red-required:
+      - 実装前に missing env test が現行実装の sibling success または別 failure として失敗することを確認する。
+  - 実装範囲:
+    - allowed paths: 対象ファイルのみ。
+    - forbidden changes: CLI root flag、request root field、direct `os.environ` read in command/use case、docs update、sibling fallback。
   - Green 検証:
-    - command / inspection / manual evidence:
-      - ...
+    - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree.<missing-env-test> -v`
   - Refactor / cleanup ガードレール:
-    - 目的:
-    - 禁止する広がり:
-  - closure 証跡要件:
-    - Step Contract Closure:
-    - Test Contract Closure:
-    - Closure Coverage:
+    - Env boundary 以外の runtime architecture refactor をしない。
   - report 証跡の記録先:
-    - `report.md` の対象 section / ledger:
-  - amendment trigger（plan amendment が必要になる契機）:
-    - plan amendment と re-review が必要になる発見:
+    - TDD evidence, Step Contract Closure, Test Contract Closure, Closure Coverage, Implementation Delegation Gate。
+  - amendment trigger:
+    - Required env var を `WorktreeCreateRequest` field や CLI flag に変更する必要が出た場合。
 
 #### 委任契約（delegation contract）
-- 委任ロール（delegated role）:
-  - dev-coder / doc-writer / other named worker / N/A
+- 委任ロール:
+  - dev-coder
 - 入力 docs:
-  - `requirement.md`
-  - `design.md`
-  - `plan.md`
-  - workflow / authoring docs:
-  - current target files:
+  - `requirement.md`, `design.md`, `plan.md`, `workflow_issue.md`
 - 許可 paths:
-  - ...
+  - S01 対象ファイルのみ。
 - 禁止 changes:
-  - ...
+  - docs / parent specs / shell profile / namespace override / sibling fallback。
 - 受け入れ条件:
-  - closure id / step close condition:
-- 必須 tests または docs-only verification:
-  - targeted command / inspection / docs diff / manual evidence:
+  - slci-001 が pass。
+- 必須 tests:
+  - missing / blank env targeted tests。
 - reviewer focus:
-  - code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only docs/spec alignment）
-- 必須出力（output required）:
-  - changed files:
-  - verification result:
-  - report evidence to update:
-  - unresolved risks:
-- 停止条件（stop conditions）:
-  - input docs conflict / path outside allowed scope / verification cannot run / acceptance cannot be met:
+  - code-reviewer: env port boundary, no side effects, no scope creep。
+- 必須出力:
+  - changed files, verification result, unresolved risks, Ledger Note or no-decision statement。
+- 停止条件:
+  - Env lookup boundary cannot be added without changing command surface。
 
 #### 具体テストケース一覧
 
-> この欄は full test inventory ではありません。step-local obligation と concrete red / characterization / inspect / manual seeds を、実装前に固定するための欄です。
+- `tc-s01-001` negative: unset env fails before side effects
+  - 前提: temp Git repo is on a named branch and `SPEC_DOCK_WORKTREE_ROOT` is absent.
+  - 操作: `spec-dock worktree create` を実行する。
+  - 期待結果: non-zero exit; stderr names `SPEC_DOCK_WORKTREE_ROOT` and includes absolute-path setup example.
+  - 失敗検出: missing env silently creates sibling or central worktree.
+  - 検証方法: `tests/cli_runtime/test_worktree.py` targeted CLI runtime test。
+  - 関連 closure id: slci-001
 
-- `tc-s01-001` acceptance: <短い説明>
-  - 前提: ...
-  - 操作: ...
-  - 期待結果: ...
-  - 失敗検出: ...
-  - 検証方法: ...
-  - 関連 closure id: tc-001
+- `tc-s01-002` negative: blank env fails before side effects
+  - 前提: temp Git repo is valid and `SPEC_DOCK_WORKTREE_ROOT` is empty or whitespace-only.
+  - 操作: `spec-dock worktree create` を実行する。
+  - 期待結果: non-zero exit; no sibling container, central namespace, branch, or bootstrap artifact is created.
+  - 失敗検出: blank value is treated as current directory or fallback placement.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-001
 
-- `tc-s01-002` inspect-only / manual-required: <短い説明>
-  - テスト不要理由: <自動テスト不要の理由>
-  - 代替検証方法: <確認手順>
-  - 期待結果: <期待される状態>
-  - 記録先: <証跡の保存先>
-  - 関連 closure id: tc-002
-
-#### ステップ完了契約（step closure contract）
+#### ステップ完了契約
 - closure id:
-  - tc-001
+  - slci-001
 - close 条件:
-  - ...
-- 検証 evidence:
-  - targeted command / inspection / manual evidence:
+  - Red / Green evidence が report に残り、targeted tests と code-reviewer が pass。
 - report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-  - Closure Delta:
+  - Step Contract Closure, Test Contract Closure, Closure Coverage, Step Commit Gate。
 - 残リスク:
-  - ...
+  - None if no direct env read and no fallback remain.
 
-#### ステップゲート（step gate）
+#### ステップゲート
 - step reviewer gate:
-  - reviewer:
-  - review 範囲:
+  - reviewer: code-reviewer
   - pass 条件: review_status: pass
-  - re-review rule: 指摘を修正し pass まで再実行
 - commit / no-op gate:
-  - closure 状態: committed / approved-no-op
-  - commit 範囲:
-  - no-op の場合の確認対象、差分なし確認コマンド、read-only evidence:
+  - closure 状態: committed
+  - commit 範囲: S01 target files only
 
-### 実装ステップ Sxx — <次に観測可能な振る舞い>
-- S01 の subsections を複製して記入する。
-- `planned contract`、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`step gate` がない implementation step は implementation-ready ではない。
+### 実装ステップ S02 — Root Path Validation
+- 振る舞いの目標:
+  - Invalid root values fail before mutation; valid `~` absolute and directory symlink are accepted.
+- design 参照:
+  - `Error contract`, `AC-004`, `EC-002`
+- 依存:
+  - S01
+- unblock:
+  - S03
+- 対象ファイル:
+  - `application/worktree.py`
+  - `tests/cli_runtime/test_worktree.py`
+- 計画済み契約:
+  - scope:
+    - `_resolve_worktree_root` / `_validate_worktree_root` 相当の helper を追加する。
+    - Error message includes env var name, raw value, resolved path, cause, and absolute setup example。
+  - テスト義務:
+    - closure id: slci-002, slci-003
+    - coverage rationale:
+      - Root validation は filesystem mutation 前の safety boundary であり negative path が中心。
+  - Red / 代替証跡:
+    - red-required for invalid root forms and accepted valid forms。
+  - 実装範囲:
+    - allowed paths: target files。
+    - forbidden changes: shell profile edit, namespace override, config file。
+  - Green 検証:
+    - Targeted path validation tests。
+  - Refactor / cleanup ガードレール:
+    - Path helper は worktree create 専用に留める。
+  - report 証跡の記録先:
+    - TDD evidence and closure ledgers。
+  - amendment trigger:
+    - Path validation requires persistent config or platform-specific branch not in design。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md`, `design.md`, S01 result。
+- 許可 paths:
+  - `application/worktree.py`, `tests/cli_runtime/test_worktree.py`
+- 禁止 changes:
+  - env var name change, shell profile edits, docs updates。
+- 受け入れ条件:
+  - slci-002 and slci-003 pass。
+- 必須 tests:
+  - relative, file, broken symlink, directory symlink, `~` expansion, namespace mkdir failure。
+- reviewer focus:
+  - code-reviewer: mutation ordering and error guidance completeness。
+- 必須出力:
+  - changed files, verification result, risks, Ledger Note/no-decision。
+- 停止条件:
+  - Test environment cannot create symlink fixture。
+
+#### 具体テストケース一覧
+
+- `tc-s02-001` negative: relative root is fatal
+  - 前提: `SPEC_DOCK_WORKTREE_ROOT=relative/worktrees`.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: non-zero exit; stderr includes env var name, raw/resolved path, cause, setup example; no mutation.
+  - 失敗検出: cwd-dependent worktree root is accepted.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-002
+
+- `tc-s02-002` negative: file root is fatal
+  - 前提: env var points to an existing file.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: fatal error with path/cause/setup example; no Git or bootstrap mutation.
+  - 失敗検出: file path is overwritten or treated as directory.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-002
+
+- `tc-s02-003` negative: broken symlink is fatal
+  - 前提: env var points to a broken symlink.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: fatal error before mutation.
+  - 失敗検出: broken symlink is auto-repaired or hidden.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-002
+
+- `tc-s02-004` acceptance: directory symlink is accepted
+  - 前提: env var points to a symlink whose target is a directory.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: command can use that directory as central root.
+  - 失敗検出: valid symlink root is over-rejected.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-003
+
+- `tc-s02-005` acceptance: `~` expands to absolute path
+  - 前提: env var contains `~/...` and expanded path is absolute and usable.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: command uses expanded absolute path.
+  - 失敗検出: `~` path is rejected or treated literally.
+  - 検証方法: CLI runtime or app-level test。
+  - 関連 closure id: slci-003
+
+- `tc-s02-006` negative: namespace mkdir failure reports guidance
+  - 前提: env root is valid but namespace path cannot be created because of file conflict or permission-like fixture.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: fatal error includes env var, resolved root, namespace/container path, cause, setup example.
+  - 失敗検出: mkdir failure emits vague path error.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-002
+
+#### ステップ完了契約
+- closure id:
+  - slci-002, slci-003
+- close 条件:
+  - All path validation tests pass and code-reviewer passes。
+- report evidence:
+  - Step/Test Contract Closure, Closure Coverage, Step Commit Gate。
+- 残リスク:
+  - Platform-specific symlink behavior; record if a test is skipped with reason.
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+  - pass 条件: review_status: pass
+- commit / no-op gate:
+  - closure 状態: committed
+
+### 実装ステップ S03 — Central Root Placement
+- 振る舞いの目標:
+  - Valid env root creates worktree under central namespace and does not create old sibling container.
+- design 参照:
+  - `container = env_root / repo_basename`
+- 依存:
+  - S01, S02
+- unblock:
+  - S04, S05
+- 対象ファイル:
+  - `application/worktree.py`
+  - `tests/cli_runtime/test_worktree.py`
+- 計画済み契約:
+  - scope:
+    - Replace sibling container derivation with env-root namespace derivation。
+    - `WorktreeCreateResult.container_path` means namespace directory。
+  - テスト義務:
+    - closure id: slci-004, slci-005
+  - Red / 代替証跡:
+    - red-required central path assertion。
+  - 実装範囲:
+    - allowed paths: target files。
+    - forbidden changes: migration, result expansion unless needed。
+  - Green 検証:
+    - central-root targeted tests。
+  - amendment trigger:
+    - Result contract must change beyond `container_path` meaning。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md` AC-002 / AC-003 / EC-005
+  - `design.md` central placement and directory / file change plan
+  - S01 / S02 implementation results
+- 許可 paths:
+  - `application/worktree.py`, `tests/cli_runtime/test_worktree.py`
+- 禁止 changes:
+  - existing sibling worktree migration, namespace override。
+- 受け入れ条件:
+  - slci-004 and S03 part of slci-005 pass。
+- 必須 tests または docs-only verification:
+  - `tc-s03-001`, `tc-s03-002`, `tc-s03-003`
+  - targeted central-root CLI runtime test command
+- reviewer focus:
+  - code-reviewer: path derivation, no fallback, no migration。
+- 必須出力:
+  - changed files
+  - central-root targeted verification result
+  - confirmation that `WorktreeCreateResult.container_path` still fits namespace directory semantics
+  - Ledger Note or no-decision statement
+- 停止条件:
+  - implementation needs a request/root CLI flag
+  - result contract must change beyond the approved design
+  - old sibling worktree migration appears necessary
+
+#### 具体テストケース一覧
+
+- `tc-s03-001` acceptance: create under central root
+  - 前提: valid env root points to missing temp root; repo basename is `sample-repo`.
+  - 操作: labelなしで `worktree create` を実行する。
+  - 期待結果: path is `<root>/sample-repo/sample-repo-wt1`; branch is `<current>-wt1`; stdout shows absolute path.
+  - 失敗検出: sibling `sample-repo-worktrees` remains target.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-004
+
+- `tc-s03-002` negative: old sibling container is not created
+  - 前提: valid env root and no existing sibling container.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: old sibling container does not exist after command.
+  - 失敗検出: compatibility fallback creates sibling container.
+  - 検証方法: filesystem assertion in central-root test。
+  - 関連 closure id: slci-005
+
+- `tc-s03-003` acceptance: existing namespace directory is accepted
+  - 前提: `<root>/sample-repo` already exists and is a directory.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: command creates candidate under existing namespace.
+  - 失敗検出: existing namespace is treated as collision by itself.
+  - 検証方法: CLI runtime test。
+  - 関連 closure id: slci-004
+
+#### ステップ完了契約
+- closure id:
+  - slci-004, slci-005
+- close 条件:
+  - central placement tests pass and code-reviewer passes。
+- report evidence:
+  - Step/Test Contract Closure, Closure Coverage, Step Commit Gate。
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+- commit / no-op gate:
+  - closure 状態: committed
+
+### 実装ステップ S04 — Naming / Collision / Bootstrap Preservation
+- 振る舞いの目標:
+  - Placement 以外の existing behavior を維持する。
+- design 参照:
+  - `AC-005`, `AC-007`, `EC-001`, `EC-003`, `EC-004`
+- 依存:
+  - S03
+- unblock:
+  - S99
+- 対象ファイル:
+  - `application/worktree.py` if needed
+  - `tests/cli_runtime/test_worktree.py`
+- 計画済み契約:
+  - scope:
+    - Existing tests を central root expected path に更新し、必要な regression seed を追加する。
+  - テスト義務:
+    - closure id: slci-006, slci-007
+  - Red / 代替証跡:
+    - covered-existing plus red-required for any missing regression。
+  - forbidden changes:
+    - label grammar, branch naming, retry ceiling, bootstrap fatality。
+  - Green 検証:
+    - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree -v` or focused equivalent。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md` AC-005 / AC-007 / EC-001 / EC-003 / EC-004
+  - `design.md` preservation and regression mapping
+  - S03 implementation result
+- 許可 paths:
+  - `application/worktree.py`, `tests/cli_runtime/test_worktree.py`
+- 禁止 changes:
+  - Bootstrap behavior changes, namespace config, list/remove/prune。
+- 受け入れ条件:
+  - slci-006 and slci-007 pass.
+- 必須 tests または docs-only verification:
+  - `tc-s04-001`..`tc-s04-006`
+  - full or focused `tests.cli_runtime.test_worktree.TestCliWorktree` command
+- reviewer focus:
+  - code-reviewer: regression preservation and scope discipline。
+- 必須出力:
+  - changed files
+  - verification result for naming/collision/bootstrap regression tests
+  - unresolved regression risks
+  - Ledger Note or no-decision statement
+- 停止条件:
+  - preserving existing behavior requires changing label grammar, branch naming, retry ceiling, or bootstrap fatality
+  - new namespace override / config seems necessary
+  - regression tests cannot isolate central root placement from existing behavior
+
+#### 具体テストケース一覧
+
+- `tc-s04-001` regression: label collision retry remains
+  - 前提: valid env root and label `feature` used twice.
+  - 操作: `worktree create feature` を2回実行する。
+  - 期待結果: ids are `feature` and `feature2`; branches keep current prefix.
+  - 失敗検出: placement change breaks retry naming.
+  - 検証方法: updated existing CLI test。
+  - 関連 closure id: slci-006
+
+- `tc-s04-002` regression: auto id retry remains
+  - 前提: valid env root and label omitted.
+  - 操作: `worktree create` を2回実行する。
+  - 期待結果: ids are `wt1` and `wt2`.
+  - 失敗検出: central namespace collision changes id sequence.
+  - 検証方法: updated existing CLI test。
+  - 関連 closure id: slci-006
+
+- `tc-s04-003` negative: invalid labels remain side-effect-free
+  - 前提: invalid labels are provided.
+  - 操作: `worktree create <invalid>` を実行する。
+  - 期待結果: invalid label error; no env root namespace or sibling path side effects.
+  - 失敗検出: invalid label reaches placement creation.
+  - 検証方法: updated existing CLI test。
+  - 関連 closure id: slci-006
+
+- `tc-s04-004` regression: branch prefix with slash remains
+  - 前提: current branch is `feature/base`.
+  - 操作: `worktree create slice` を実行する。
+  - 期待結果: branch is `feature/base-slice`.
+  - 失敗検出: branch name sanitization drift.
+  - 検証方法: updated existing CLI test。
+  - 関連 closure id: slci-006
+
+- `tc-s04-005` regression: bootstrap statuses remain non-fatal
+  - 前提: Makefile success, failure, detection failure, missing target cases exist.
+  - 操作: `worktree create` を実行する。
+  - 期待結果: `succeeded` / `failed` / `detection_failed` / `skipped` are observable; failure remains exit 0 after worktree creation.
+  - 失敗検出: bootstrap failure becomes fatal or warnings disappear.
+  - 検証方法: updated existing bootstrap tests。
+  - 関連 closure id: slci-007
+
+- `tc-s04-006` regression: non-retryable git add failure reports central path artifact state
+  - 前提: fake Git gateway raises non-retryable add failure.
+  - 操作: app-level `worktree_create` を実行する。
+  - 期待結果: error is non-retryable and artifact state refers to central candidate path.
+  - 失敗検出: git failure is swallowed as retryable or reports stale sibling path.
+  - 検証方法: updated fake gateway test。
+  - 関連 closure id: slci-006
+
+#### ステップ完了契約
+- closure id:
+  - slci-006, slci-007
+- close 条件:
+  - Existing behavior regression suite passes and code-reviewer passes。
+- report evidence:
+  - Step/Test Contract Closure, Closure Coverage, Step Commit Gate。
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+- commit / no-op gate:
+  - closure 状態: committed
+
+### 実装ステップ S05 — Linked Worktree Normalization
+- 振る舞いの目標:
+  - Linked worktree から実行しても namespace / repo basename は Git main worktree basename を使う。
+- design 参照:
+  - `AC-006`
+- 依存:
+  - S03
+- unblock:
+  - S99
+- 対象ファイル:
+  - `application/worktree.py` if needed
+  - `tests/cli_runtime/test_worktree.py`
+- 計画済み契約:
+  - scope:
+    - `records[0].path` as main worktree source を維持する。
+    - Old sibling container を discovery / migration しない。
+  - テスト義務:
+    - closure id: slci-008
+  - Red / 代替証跡:
+    - red-required linked-worktree test。
+  - Green 検証:
+    - linked-worktree targeted test。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md` AC-006
+  - `design.md` linked worktree normalization decision
+  - S03 implementation result
+- 許可 paths:
+  - `application/worktree.py`, `tests/cli_runtime/test_worktree.py`
+- 禁止 changes:
+  - linked worktree basename based namespace, migration behavior。
+- 受け入れ条件:
+  - slci-008 passes.
+- 必須 tests または docs-only verification:
+  - `tc-s05-001`
+  - linked-worktree targeted CLI runtime test
+- reviewer focus:
+  - code-reviewer: main worktree normalization and current branch prefix。
+- 必須出力:
+  - changed files
+  - linked-worktree verification result
+  - confirmation that old sibling container is not inspected or migrated
+  - Ledger Note or no-decision statement
+- 停止条件:
+  - Git worktree list ordering cannot reliably identify main worktree in current implementation
+  - linked worktree test requires migration/discovery behavior outside approved design
+
+#### 具体テストケース一覧
+
+- `tc-s05-001` regression: linked worktree creates inner under main namespace
+  - 前提: outer linked worktree exists under central root; command runs from outer.
+  - 操作: outer の `spec-dock/scripts/spec-dock worktree create inner` を実行する。
+  - 期待結果: inner path is `<root>/sample-repo/sample-repo-inner`; branch is `<current-linked-branch>-inner`.
+  - 失敗検出: namespace becomes linked worktree basename or nested path.
+  - 検証方法: updated linked-worktree CLI runtime test。
+  - 関連 closure id: slci-008
+
+#### ステップ完了契約
+- closure id:
+  - slci-008
+- close 条件:
+  - linked-worktree test passes and code-reviewer passes。
+- report evidence:
+  - Step/Test Contract Closure, Closure Coverage, Step Commit Gate。
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+- commit / no-op gate:
+  - closure 状態: committed
+
+### 実装ステップ S06 — Local Setup Evidence Only
+- 振る舞いの目標:
+  - Local setup is verified as evidence only and not committed as product artifact.
+- design 参照:
+  - `AC-009`
+- 依存:
+  - none
+- unblock:
+  - S99
+- 対象:
+  - report evidence only
+- 計画済み契約:
+  - scope:
+    - Verify shell env and root existence / creatability.
+  - テスト義務:
+    - closure id: slci-009
+  - Red / 代替証跡:
+    - manual-required。
+  - forbidden changes:
+    - Workspace-external shell profile edits unless new explicit approval and plan amendment exist.
+  - Green 検証:
+    - `printenv SPEC_DOCK_WORKTREE_ROOT`
+    - read-only `.zshenv` inspection for override-respecting export
+    - `test -d "$SPEC_DOCK_WORKTREE_ROOT"` or command-created root evidence。
+  - report 証跡の記録先:
+    - Session log, Step Contract Closure, Test Contract Closure, Closure Coverage。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - N/A; parent orchestrator read-only verification
+- 入力 docs:
+  - `requirement.md` AC-009
+  - `design.md` local setup evidence boundary
+  - `plan.md` S06
+- 許可 paths:
+  - none
+- 禁止 changes:
+  - `/Users/iwasawayuuta/.zshenv` edits, local directory deletion, repo artifact mutation。
+- 受け入れ条件:
+  - `SPEC_DOCK_WORKTREE_ROOT` is visible in current shell or documented as unavailable.
+  - `/Users/iwasawayuuta/.zshenv` contains an override-respecting export or report records blocker/next action.
+  - Root directory exists or is proven creatable by runtime behavior.
+- 必須 tests または docs-only verification:
+  - `printenv SPEC_DOCK_WORKTREE_ROOT`
+  - read-only inspection of `/Users/iwasawayuuta/.zshenv`
+  - `test -d "$SPEC_DOCK_WORKTREE_ROOT"` or runtime-created root evidence
+- reviewer focus:
+  - N/A unless repo diff exists。
+- 必須出力:
+  - command outputs summarized in `report.md`
+  - no repo diff for shell profile
+  - unresolved local setup risks, if any
+- 停止条件:
+  - shell env is unavailable and no approved equivalent evidence exists
+  - `.zshenv` inspection is denied or shows missing export
+  - root path is unusable and runtime behavior cannot create it
+
+#### 具体テストケース一覧
+
+- `tc-s06-001` manual-required: shell env is visible
+  - 前提: current shell session is available.
+  - 操作: `printenv SPEC_DOCK_WORKTREE_ROOT`
+  - 期待結果: value is `/Users/iwasawayuuta/workspace/worktrees` or user-approved equivalent.
+  - 失敗検出: local smoke cannot use required env.
+  - 検証方法: command evidence in report。
+  - 関連 closure id: slci-009
+
+- `tc-s06-002` manual-required: root exists or is creatable
+  - 前提: env var value is valid.
+  - 操作: `test -d "$SPEC_DOCK_WORKTREE_ROOT"` or observe command-created root during runtime smoke.
+  - 期待結果: root exists or is created by valid `worktree create` behavior.
+  - 失敗検出: env points to unusable local root.
+  - 検証方法: command evidence in report。
+  - 関連 closure id: slci-009
+
+- `tc-s06-003` manual-required: `.zshenv` contains override-respecting export
+  - 前提: local shell startup file is readable.
+  - 操作: inspect `/Users/iwasawayuuta/.zshenv` for `SPEC_DOCK_WORKTREE_ROOT`.
+  - 期待結果: file contains an override-respecting export such as `export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"`.
+  - 失敗検出: env is only transient in current shell and not represented in shell startup config.
+  - 検証方法: read-only command evidence in report; no file edit.
+  - 関連 closure id: slci-009
+
+#### ステップ完了契約
+- closure id:
+  - slci-009
+- close 条件:
+  - Report records local evidence and no repo diff is introduced for shell profile.
+- report evidence:
+  - Step/Test Contract Closure, Closure Coverage。
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: N/A unless repo diff exists
+- commit / no-op gate:
+  - closure 状態: approved-no-op if no repo diff
 
 ### ドキュメント影響の解消ステップ S90（docs impact resolution / docs refresh）
 - 対象:
-  - docs / templates / README / workflow / skill / migration notes / none
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+  - `spec-dock/docs/reference_worktree.md`
+  - `spec-dock/active/epic/requirement.md`
+  - `spec-dock/active/epic/design.md`
+  - `spec-dock/active/epic/plan.md`
 - 対応:
-  - ...
+  - Provider docs を central root contract に更新する。
+  - Dogfooding docs を normal update / parity path で同期または差分理由付きで確認する。
+  - Parent Epic docs から sibling placement を future behavior として残さない。
+  - Existing sibling worktrees は legacy / historical context として扱う。
 - doc update owner:
-  - doc-writer when updates are required
+  - doc-writer for shipped docs。
+  - parent orchestrator for canonical parent spec docs。
+- 委任契約:
+  - delegated role: doc-writer for shipped docs。
+  - input docs: `requirement.md`, `design.md`, `plan.md`, `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`, parent Epic docs。
+  - allowed paths: listed docs only。
+  - forbidden changes: runtime/tests, new commands, `$CODEX_HOME/worktrees` mixing。
+  - acceptance criteria: slci-010, slci-011, slci-012 docs-related expectations。
+  - required tests or docs-only verification: docs diff inspection, provider/dogfooding parity evidence, spec-reviewer docs/spec alignment。
+  - stop conditions: docs require runtime behavior outside approved design, parent Epic cannot be reconciled without requirement change, parity update fails without documented blocker。
+  - output required: changed docs, verification result, rejected/unchanged docs rationale, Ledger Note or no-decision statement。
+- 具体テストケース一覧:
+  - `tc-s90-001` inspect-only: docs mention required env root
+    - 前提: docs updated.
+    - 操作: inspect docs.
+    - 期待結果: docs mention `SPEC_DOCK_WORKTREE_ROOT`, fatal missing env, layout `$SPEC_DOCK_WORKTREE_ROOT/spec-dock/spec-dock-wt1`.
+    - 失敗検出: stale sibling placement remains current behavior.
+    - 検証方法: docs diff inspection。
+    - 関連 closure id: slci-010
+  - `tc-s90-002` inspect-only: legacy sibling boundary is explicit
+    - 前提: docs updated.
+    - 操作: inspect docs.
+    - 期待結果: existing sibling worktrees are not migrated; future creates use central root.
+    - 失敗検出: docs imply migration or fallback.
+    - 検証方法: docs diff inspection。
+    - 関連 closure id: slci-005, slci-010
+  - `tc-s90-003` inspect-only: parent Epic no longer conflicts
+    - 前提: parent Epic docs updated.
+    - 操作: inspect parent Epic requirement/design/plan.
+    - 期待結果: sibling placement is not future contract; central root supersession is clear.
+    - 失敗検出: upstream and issue specs remain contradictory.
+    - 検証方法: spec diff inspection。
+    - 関連 closure id: slci-010
+  - `tc-s90-004` command/inspect: provider-dogfooding parity
+    - 前提: provider docs updated.
+    - 操作: run update/sync/parity test or record explicit parity rationale.
+    - 期待結果: provider and dogfooding docs align.
+    - 失敗検出: shipped asset and dogfooding workspace drift.
+    - 検証方法: parity test / update evidence / diff inspection。
+    - 関連 closure id: slci-012
 - spec/doc review:
   - reviewer: spec-reviewer
-  - pass 条件: docs が requirement / design / plan と整合し、未解決の必須 docs 影響が残っていない
+  - pass 条件: docs align with requirement / design / plan and no docs scope creep.
+- report 証跡の記録先:
+  - `report.md` Session log for docs changes and verification commands。
+  - Step Contract Closure for slci-010, slci-011, slci-012。
+  - Test Contract Closure for `tc-s90-001`..`tc-s90-004`。
+  - Closure Coverage and Closure Delta。
+  - Reviewer Gate Status for S90 docs/spec alignment review。
+- amendment trigger:
+  - Parent Epic docs cannot be reconciled without changing approved requirement/design meaning beyond iss-00130 supersession。
+  - Provider/dogfooding parity cannot be achieved or intentionally left divergent without new rationale。
+  - Docs update requires adding worktree list/remove/prune, namespace override, or Codex app worktree management scope。
+  - Runtime behavior discovered during docs update contradicts requirement/design。
+- ステップ完了契約:
+  - closure id:
+    - slci-010
+    - slci-011
+    - slci-012
+  - close 条件:
+    - Shipped docs, dogfooding docs, and parent Epic docs have no unresolved sibling-placement conflict.
+    - Docs/spec alignment reviewer returns pass.
+    - Report records docs diff, parity/update evidence or accepted no-op rationale, and closure coverage.
+  - 検証 evidence:
+    - docs diff inspection
+    - parity/update command evidence or explicit no-op rationale
+    - spec-reviewer pass
+  - 残リスク:
+    - Generated dogfooding docs may require normal scaffold refresh; if refresh is blocked, report must classify the issue as blocked / 未完了 rather than complete.
+- step gate:
+  - closure 状態: committed or approved-no-op with evidence.
 
 ### 最終品質ゲートステップ S99（final quality gate）
 - branch diff 範囲:
-  - ...
+  - Runtime, tests, shipped docs, dogfooding docs, parent Epic docs, active issue report。
 - 必須 validation:
-  - ...
+  - `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree -v`
+  - `python -m unittest discover -v` if feasible
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync`
 - final QA gate:
   - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage と integration test 要否
+  - 範囲: Issue 全体の obligation coverage と integration/manual evidence。
   - pass 条件: reviewer pass
 - final code review ゲート:
   - reviewer: code-reviewer
-  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性
+  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性。
   - pass 条件: review_status: pass
 - final spec review ゲート:
   - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合
+  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合。
   - pass 条件: reviewer pass
+- 具体テストケース一覧:
+  - `tc-s99-001` command: targeted worktree suite
+    - 前提: all implementation/docs steps complete.
+    - 操作: `python -m unittest tests.cli_runtime.test_worktree.TestCliWorktree -v`
+    - 期待結果: pass.
+    - 失敗検出: worktree behavior regression remains.
+    - 検証方法: command evidence。
+    - 関連 closure id: slci-001..slci-008
+  - `tc-s99-002` command: broader test baseline
+    - 前提: targeted suite passes.
+    - 操作: `python -m unittest discover -v`
+    - 期待結果: pass or documented blocker if infeasible.
+    - 失敗検出: cross-runtime regression.
+    - 検証方法: command evidence。
+    - 関連 closure id: slci-012
+  - `tc-s99-003` command: spec-dock validation and sync
+    - 前提: docs/spec changes complete.
+    - 操作: `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync`
+    - 期待結果: pass.
+    - 失敗検出: spec tree or generated state drift.
+    - 検証方法: command evidence。
+    - 関連 closure id: slci-012
+  - `tc-s99-004` inspect: final clean state after final commit
+    - 前提: final report ledger and commit complete.
+    - 操作: `git status --short`
+    - 期待結果: no unintended staged / unstaged changes.
+    - 失敗検出: untracked or unstaged implementation residue.
+    - 検証方法: command evidence。
+    - 関連 closure id: slci-012
 - final commit gate:
   - commit 範囲:
+    - final report ledger and remaining issue-wide changes after all required reviews pass.
   - final report ledger:
+    - all required closure ids pass / approved-no-op.
   - post-commit external evidence destination:
+    - final response / PR description / issue comment.
+
+### 送達準備ステップ S100（PR delivery / merge preparation gate）
+- 振る舞いの目標:
+  - `issue finish` 前に PR delivery と merge-preparation evidence を揃え、report evidence が dirty state や stale head SHA を残さないようにする。
+- workflow 参照:
+  - `workflow_issue.md` の PR Delivery Gate / Merge Preparation Gate。
+- 依存:
+  - S99 final quality reviews pass。
+  - Implementation / docs step commits are complete。
+  - Final report ledger is ready for delivery evidence.
+- 対象:
+  - report evidence, PR state, external delivery evidence。
+- 計画済み契約:
+  - scope:
+    - `github-pr-merge-preparer` を使い、PR 作成または既存 PR 再利用、base branch、head SHA、issue linkage、draft/ready 判断を記録する。
+    - PR open state、latest monitored head SHA、checks、blocking reviews、merge conflicts、unresolved blockers、final merge-prepared decision を記録する。
+    - S100 で `report.md` に PR / merge-preparation evidence を追記した場合、その report update は delivery evidence commit として commit / push する。
+    - Delivery evidence commit が head SHA を変えた場合、merge-preparation monitor は更新後の latest pushed head SHA に対して再実行する。
+    - 最終的に report / external delivery evidence は latest monitored head SHA と current pushed head SHA の一致を示し、local worktree に意図しない staged / unstaged change を残さない。
+  - テスト義務:
+    - closure id: slci-013
+  - Red / 代替証跡:
+    - command / monitor evidence。PR が作成不能または monitor 不能な場合は `blocked` / `未完了` として report に reason と next action を残す。
+  - 実装範囲:
+    - allowed paths: `report.md` delivery gate sections and external delivery evidence。
+    - forbidden changes: unreviewed code/docs changes, merge execution, issue finish without delivery evidence。
+  - Green 検証:
+    - PR Delivery Gate evidence present。
+    - Merge Preparation Gate evidence present。
+    - Any S100 report update is committed and pushed before final monitor decision。
+    - Latest monitored head SHA equals latest pushed head SHA。
+  - report 証跡の記録先:
+    - `report.md` PR Delivery Gate / Merge Preparation Gate sections。
+  - amendment trigger:
+    - Required PR/merge evidence cannot be produced and workflow policy needs waiver or scope change。
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - github-pr-merge-preparer
+- 入力 docs:
+  - `requirement.md`, `design.md`, `plan.md`, `report.md`, final commit evidence。
+- 許可 paths:
+  - `report.md` PR Delivery Gate / Merge Preparation Gate sections。
+  - external delivery evidence such as PR description/comment/final response。
+  - PR creation/push after S99 quality gates。
+- 禁止 changes:
+  - merge the PR, bypass failed checks, close issue without gates, implement new product changes。
+- 受け入れ条件:
+  - slci-013 pass。
+- 必須 verification:
+  - PR URL / base / head branch / head SHA / issue linkage / PR open state / check status / blocker status / final merge-prepared decision。
+  - If S100 commits report evidence, re-push and re-monitor latest head SHA。
+- reviewer focus:
+  - PR delivery and merge-preparation evidence completeness。
+- 必須出力:
+  - PR URL, branch, head SHA, monitor result, unresolved blockers, final merge-prepared decision。
+- 停止条件:
+  - push/PR creation denied, checks unavailable, merge conflict, unresolved blocking review, stale head SHA。
+
+#### 具体テストケース一覧
+
+- `tc-s100-001` delivery: PR Delivery Gate evidence exists
+  - 前提: final commit is complete and branch is ready to publish.
+  - 操作: run `github-pr-merge-preparer` / PR creation workflow.
+  - 期待結果: report records PR URL, selected base, base-resolution source, draft/ready decision, head branch, head SHA, issue linkage, reuse/new decision.
+  - 失敗検出: issue finish proceeds without PR delivery context.
+  - 検証方法: PR Delivery Gate evidence in report / external delivery.
+  - 関連 closure id: slci-013
+
+- `tc-s100-002` monitor: Merge Preparation Gate evidence exists
+  - 前提: PR exists and latest head SHA is known.
+  - 操作: monitor PR checks/reviews/mergeability.
+  - 期待結果: report records open state, latest monitored head SHA, required/non-required checks, blocking review status, merge conflict status, unresolved blockers, final merge-prepared decision.
+  - 失敗検出: stale or incomplete monitor result is treated as merge-prepared.
+  - 検証方法: Merge Preparation Gate evidence in report / external delivery.
+  - 関連 closure id: slci-013
+
+- `tc-s100-003` delivery: report evidence commit does not stale the monitor result
+  - 前提: S100 writes PR / merge-preparation evidence to `report.md`.
+  - 操作: commit and push the S100 report update, then re-monitor the PR head.
+  - 期待結果: latest monitored head SHA equals latest pushed head SHA; `git status --short` has no unintended changes.
+  - 失敗検出: PR is marked merge-prepared for a stale pre-report head.
+  - 検証方法: push/monitor evidence and clean-state command.
+  - 関連 closure id: slci-013
+
+#### ステップ完了契約
+- closure id:
+  - slci-013
+- close 条件:
+  - PR Delivery Gate and Merge Preparation Gate are recorded as pass for the latest pushed head, or report records blocked / 未完了 with reason and next action.
+- report evidence:
+  - PR Delivery Gate, Merge Preparation Gate, delivery evidence commit, latest-head monitor evidence。
+- 残リスク:
+  - GitHub checks may change after monitor; report must record monitored head SHA.
+
+#### ステップゲート
+- delivery gate:
+  - role: github-pr-merge-preparer
+  - pass 条件: PR delivery and merge-preparation evidence complete.
+- issue finish gate:
+  - `issue finish` may run only after S100 pass and workflow completion conditions are met.
+
+## ロールバック / 互換
+- Rollback:
+  - Runtime path derivation、docs、tests を previous sibling placement に revert する。
+  - Existing sibling worktrees は移動していないため migration rollback は不要。
+- Compatibility:
+  - Future `worktree create` requires env root。
+  - Existing sibling worktrees remain valid Git worktrees but are not migrated or managed by this issue。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 推奨案:
-  - 影響範囲:
+- なし。
 
 ## 最終完了条件
 - AC/EC 達成:
-  - ...
+  - slci-001..slci-013 が Step Contract Closure / Test Contract Closure / Closure Coverage で pass または approved-no-op として閉じている。
 - docs 影響解決:
-  - ...
+  - S90 が spec-reviewer pass。
 - 全 implementation step 完了:
-  - committed / approved-no-op:
+  - S01-S05, S90 are committed。
+  - S06 is committed if repo diff exists, otherwise approved-no-op with evidence。
 - final quality gate pass:
-  - qa-reviewer:
-  - issue-wide code-reviewer:
-  - spec-reviewer:
+  - qa-reviewer: pass
+  - issue-wide code-reviewer: pass
+  - final spec-reviewer: pass
 - final commit 完了:
-  - ...
-- 必須 closure id 完了:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
+  - final implementation/report ledger commit is complete before S100.
+  - if S100 adds PR / merge-preparation report evidence, that update is committed and pushed as delivery evidence.
+- PR / merge-preparation:
+  - S100 PR Delivery Gate and Merge Preparation Gate pass for the latest pushed head before `issue finish`.
 - final clean state:
-  - no unintended staged / unstaged changes:
+  - no unintended staged / unstaged changes after final implementation commit and after any S100 delivery evidence commit.
+- handoff:
+  - 実装開始前に、requirement / design / plan をユーザーに提出し、approval を得る。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/report.md
@@ -3,9 +3,9 @@
 ID: "iss-00130"
 タイトル: "Central Worktree Root Placement"
 関連GitHub: ["#130"]
-状態: "draft | approved"
+状態: "in_progress"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-26"
+最終更新: "2026-05-27"
 依存: ["requirement.md", "design.md", "plan.md"]
 親: ["epic-00107", "init-local-00002"]
 ---
@@ -18,10 +18,7 @@ ID: "iss-00130"
 
 `report.md` は実装中・文書更新中に発生した material な仕様解釈、判断、plan 逸脱、tradeoff、open question、promotion / follow-up を記録する audit trail でもある。worker の raw note や作業 transcript を貼る場所ではなく、orchestrator が source docs、diff、tests、reviewer output と照合して issue-level の canonical entry に統合する。
 
-Material な判断がない場合もこの section は残し、次を明示する。
-
-- No material interpretation changes.
-- No decision entries.
+Material な判断がない場合はその旨を明示する。本 issue では D-001 の operational decision を記録しており、未解決の decision entry はない。
 
 Ledger entry は次の契約値を使う。
 
@@ -49,7 +46,8 @@ Disposition ごとの必須証跡:
 
 | 識別子（ID） | 状態（Status） | 種別（Type） | 起票元（Raised By） | 契機 / 差分（Gap） | 検討した選択肢 | 判断 / 解釈 | 根拠（Rationale） | 処置（Disposition） | 証跡（Evidence） | フォローアップ（Follow-up） |
 |---|---|---|---|---|---|---|---|---|---|---|
-| D-001 | 未解決 / 解決済み / 置換済み（open / resolved / superseded） | 解釈 / 範囲 / 実装 / 互換性 / テスト戦略 / 運用 / 逸脱 / フォローアップ（interpretation / scope / implementation / compatibility / test-strategy / operation / deviation / follow-up） | 起票元（orchestrator / reviewer / worker source） | 計画の曖昧さ / 実装制約 / レビュー指摘 / 発見リスク（plan ambiguity / implementation constraint / reviewer finding / discovered risk） | 選択肢 A; 選択肢 B; 対応なし（option A; option B; no action） | ... | ... | 採用 / 却下 / design 昇格 / ADR 昇格 / plan 昇格 / follow-up 化 / 延期 / 対応なし / 置換済み（applied / rejected / promoted_to_design / promoted_to_adr / promoted_to_plan / converted_to_followup / deferred / no_action / superseded） | `path` / コマンド / reviewer 指摘 / discussion（path / command / reviewer finding / discussion） | 対象 artifact / issue / discussion / 置換先 entry / 理由付き対応なし（target artifact / issue / discussion / replacement entry / none with reason） |
+| D-001 | resolved | operation | orchestrator | `uvx --from . spec-dock update .` produced broad dogfooding scaffold churn outside the central-root scope. | Keep full update; revert generated churn; manually mirror only relevant dogfooding runtime/docs files. | Reverted broad generated churn and mirrored only `reference_worktree.md`, `application/ports.py`, `application/worktree.py`, and `cli/bootstrap.py` into the dogfooding workspace. | Keeps provider-side authority while avoiding unrelated scaffold deletion/rename churn in this issue. | applied | `git status --short --branch`; copied relevant provider files to `spec-dock/` dogfooding paths. | none |
+| D-002 | resolved | compatibility | code-reviewer | CLI help still advertised sibling placement after runtime/docs switched to central root. | Leave help unchanged because detailed docs are correct; update help in provider and dogfooding parser. | Updated `worktree create` help to say central-root Git worktree in both provider and dogfooding runtime parser files. | CLI help is a user-facing scaffold contract and should not contradict required `SPEC_DOCK_WORKTREE_ROOT` placement. | applied | `rg -n "Create a sibling Git worktree|Create a central-root Git worktree" ...`; mirror parity test passed. | none |
 
 ## 証跡採用台帳（Evidence Adoption Ledger / 必須）
 
@@ -63,7 +61,12 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 
 | 識別子（ID） | 採用状態（adoption_status） | 出所（source） | 対象（target） | 判断理由（rationale） | 証跡（evidence） | 次アクション（next_action） |
 |---|---|---|---|---|---|---|
-| EAL-001 | 採用（`adopted`） / 部分採用（`partially_adopted`） / 棄却（`rejected`） / 延期（`deferred`） / stale（`stale`） / blocked（`blocked`） | サブエージェント（`sub-agent`） / レビュアー（`reviewer`） / 議論（`discussion`） / コマンド（`command`） / 調査（`research`） | 成果物（`artifact`） / Issue（`issue`） / フォローアップ（`follow-up`） | ... | `path` / コマンド / レビュアー指摘 | なし / フォローアップ（`follow-up`） / 再レビュー（`re-review`） / 再訪条件（`revisit condition`） |
+| EAL-001 | `adopted` | `sub-agent` repo-analyst | runtime / tests / docs implementation | Read-only analysis matched approved S01-S05/S90 plan and identified the exact current-code conflicts and test-harness unset-env risk. | subagent notification for repo-analyst `Avicenna`; `tests/cli_runtime/test_worktree.py` exact-env helper | なし |
+| EAL-002 | `adopted` | `command` / tests | issue evidence | Targeted worktree runtime tests prove S01-S05 behavior and regression preservation. | `uv run python -m unittest tests.cli_runtime.test_worktree -v` -> OK, 22 tests | なし |
+| EAL-003 | `adopted` | `sub-agent` code-reviewer | final code review | Integrated diff reviewer found no P0/P1 issues and confirmed provider/dogfooding mirror parity for changed runtime/docs files. | code-reviewer `Halley` -> `review_status: pass` | なし |
+| EAL-004 | `adopted` | `sub-agent` qa-reviewer | test coverage / report cleanup | QA gate passed with P2 recommendations; invalid-label central-root side-effect coverage and decision-ledger cleanup were adopted and targeted tests passed. | qa-reviewer `Locke` -> `review_status: pass`; `uv run python -m unittest tests.cli_runtime.test_worktree -v` -> OK, 22 tests | なし |
+| EAL-005 | `adopted` | `sub-agent` code-reviewer | CLI help contract cleanup | Fresh code review passed with P2 stale help wording; provider and dogfooding parser help were updated to central-root wording and parity verified. | code-reviewer `Newton` -> `review_status: pass`; `rg` stale-help check; mirror parity test -> OK | なし |
+| EAL-006 | `adopted` | `sub-agent` qa-reviewer | post-cleanup QA review | Fresh QA review passed with only evidence-ledger cleanup; EAL-004 was closed and targeted tests had already passed. | qa-reviewer `Herschel` -> `review_status: pass` | なし |
 
 ## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
 - 委任 authoring の使用:
@@ -107,157 +110,321 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 | 委任使用主張に対する証跡不足（missing draft evidence when delegated use is claimed） | incomplete | 証跡を追加する、または委任使用 claim を外す | この section | ineligible |
 | reviewer 利用不可 / 拒否 / waiver / provisional（reviewer unavailable/denied/waived/provisional） | blocked / incomplete | fresh な passed reviewer を取得する、または昇格なしの risk acceptance を記録する | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
 
+## 仕様準備ゲート（Pre-Implementation Spec Authoring Gate）
+
+### 状態
+- 実装は未着手。
+- `requirement.md`、`design.md`、`plan.md` を作成済み。
+- 実装開始はユーザー承認待ち。
+
+### 参照した入力
+- active issue の `discussions/` 配下にある既存議論、調査、ドラフトを読み込み、環境変数必須化、root directory 作成可否、path validation、namespace policy、local shell setup scope を仕様へ反映した。
+- 音声入力由来の誤りは `要件定義書` と解釈して補正した。
+
+### 委任と採用
+| 識別子 | 採用状態 | 出所 | 対象 | 判断理由 | 証跡 | 次アクション |
+|---|---|---|---|---|---|---|
+| EAL-PRE-001 | `adopted` | discussions / research | `requirement.md` | active issue の過去議論とユーザー回答から、worktree root policy の契約を確定できた。 | `discussions/` 配下の調査・ドラフト群 | なし |
+| EAL-PRE-002 | `adopted` | `system-architect` | `design.md` | layered runtime architecture に沿い、env lookup boundary と path validation / placement の責務境界を設計へ反映した。 | subagent design draft summary | なし |
+| EAL-PRE-003 | `adopted` | `implementation-planner` | `plan.md` | requirement / design の AC・EC を Spec-Locked Closure Index と実装順序へ分解した。 | subagent plan draft summary | なし |
+| EAL-PRE-004 | `adopted` | `spec-reviewer` | `requirement.md`, `design.md`, `plan.md` | reviewer findings は canonical docs へ反映し、各フェーズで fresh pass を取得した。 | reviewer pass summaries | なし |
+
+### レビューゲート
+| フェーズ | レビュアー | 鮮度 | 状態 | 対応内容 |
+|---|---|---|---|---|
+| requirement | `spec-reviewer` | fresh | passed | 親 Epic の sibling-placement supersession と local setup evidence scope を追記して再レビューを通過した。 |
+| design | `spec-reviewer` | fresh | passed | invalid-root / mkdir failure の error guidance に env var 名、解決後 path、原因、setup 例を明記して再レビューを通過した。 |
+| plan | `spec-reviewer` | fresh | passed | PR delivery gate、`.zshenv` inspection、S03-S05 / S06 / S90 の delegation contract と report evidence ordering を補強して再レビューを通過した。 |
+
 ## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+- `worktree create` の配置先を required `SPEC_DOCK_WORKTREE_ROOT` based central root に変更した。
+- `EnvironmentGateway` port を追加し、missing / blank / invalid root を Git mutation 前に fatal にする runtime boundary と tests を追加した。
+- Provider docs、dogfooding docs、親 Epic docs を central root contract に更新し、legacy sibling placement を future fallback ではなく historical boundary として明示した。
 
-## 実装記録（セッションログ） (必須)
-
-### セッションログ（2026-05-26 HH:MM - HH:MM）
+### セッションログ（2026-05-27 実装 / S01-S06 / S90）
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
+- Step: S01, S02, S03, S04, S05, S06, S90
+- AC/EC: AC-001..AC-009, EC-001..EC-005
 - 計画上の出典（Planned source）:
-  - `plan.md` section:
-  - closure ids:
+  - `plan.md` section: `実装ステップ S01` .. `S90`
+  - closure ids: slci-001 .. slci-012
 
 #### 実施内容
-- ...
+- S01:
+  - `EnvironmentGateway.getenv(name)` を追加し、runtime bootstrap で `os.environ.get` adapter を wiring した。
+  - `SPEC_DOCK_WORKTREE_ROOT` missing / blank は Git / directory / bootstrap side effect 前に fatal とした。
+- S02:
+  - `~` expansion、absolute path validation、file / broken symlink rejection、directory symlink acceptance、namespace mkdir failure guidance を追加した。
+- S03:
+  - placement を `$SPEC_DOCK_WORKTREE_ROOT/<main-worktree-basename>/<main-worktree-basename>-<id>` に変更した。
+  - old sibling container fallback は実装していない。
+- S04:
+  - label / id / branch naming、retryable collision、non-retryable failure、bootstrap status behavior を central root 配置で維持した。
+- S05:
+  - linked worktree からの実行でも main worktree basename を namespace に使い、branch prefix は実行元 current branch を維持するテストを更新した。
+- S06:
+  - `printenv SPEC_DOCK_WORKTREE_ROOT` は `/Users/iwasawayuuta/workspace/worktrees`。
+  - `/Users/iwasawayuuta/.zshenv` に `export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"` が存在する。
+  - `/Users/iwasawayuuta/workspace/worktrees` は現時点では未作成。runtime tests により valid env root / namespace は command が作成可能であることを確認した。
+- S90:
+  - `reference_worktree.md`、親 Epic requirement/design/plan、dogfooding runtime mirror を central root contract に更新した。
 
 #### 実行コマンド / 結果
 ```bash
-<command>
+uv run python -m unittest tests.cli_runtime.test_worktree -v
 
-<result>
+Ran 22 tests in 9.964s
+OK
+```
+
+```bash
+git worktree add /private/tmp/specdock-iss130-red HEAD
+cp tests/cli_runtime/test_worktree.py /private/tmp/specdock-iss130-red/tests/cli_runtime/test_worktree.py
+uv run python -m unittest \
+  tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_requires_env_without_side_effects \
+  tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_rejects_relative_root_without_side_effects \
+  tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_uses_central_root_auto_id_and_branch \
+  tests.cli_runtime.test_worktree.TestCliWorktree.test_worktree_create_normalizes_container_from_linked_worktree \
+  -v
+
+FAILED (failures=3, errors=1)
+```
+
+Red evidence details:
+- old HEAD returned exit code `0` for missing `SPEC_DOCK_WORKTREE_ROOT`.
+- old HEAD returned exit code `0` for relative `SPEC_DOCK_WORKTREE_ROOT`.
+- old HEAD output used sibling `/sample-repo-worktrees/sample-repo-wt1` instead of central root.
+- old HEAD did not create the expected central-root linked checkout for linked-worktree invocation.
+
+```bash
+./spec-dock/scripts/spec-dock validate
+
+spec-dock: ok (validate) nodes=67
+```
+
+```bash
+./spec-dock/scripts/spec-dock sync
+
+spec-dock: sync: active unchanged (matched id in branch: iss-00130)
+spec-dock: ok (sync) wrote=spec-dock/.agent/index-all.json,spec-dock/.agent/tree-all.json,spec-dock/.agent/index.json,spec-dock/.agent/tree.json,spec-dock/tree-all.puml,spec-dock/tree.puml,spec-dock/.agent/deps-issues.json,spec-dock/deps-issues.puml,spec-dock/dashboard.md
+```
+
+```bash
+uv run python -m unittest discover -v
+
+Ran 959 tests in 513.104s
+FAILED (failures=10)
+```
+
+Full suite failure classification:
+- All 10 failures are build / isolated wheel tests that invoke `.venv/bin/python3 -m pip`.
+- `uv run python -m pip --version` returns `No module named pip`.
+- `python -m pip --version` succeeds with pip 24.1.2.
+- This is local uv-managed `.venv` tooling state, not observed central-root runtime behavior.
+
+```bash
+python -m unittest discover -v
+
+Ran 959 tests in 507.809s
+OK
+```
+
+Full suite follow-up classification:
+- Re-running the same unittest discovery through system Python passed.
+- The earlier `uv run` failure is therefore classified as local `.venv` pip state, not a regression in the central-root implementation.
+
+```bash
+python -m unittest discover -v
+
+Ran 959 tests in 498.210s
+OK
+```
+
+Post-cleanup full suite:
+- Re-running after invalid-label coverage and parser help cleanup still passed.
+
+```bash
+printenv SPEC_DOCK_WORKTREE_ROOT
+
+/Users/iwasawayuuta/workspace/worktrees
+```
+
+```bash
+sed -n '1,80p' /Users/iwasawayuuta/.zshenv
+
+export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"
+```
+
+```bash
+ls -ld /Users/iwasawayuuta/workspace/worktrees
+
+ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 ```
 
 #### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
 | ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
 |---|---|---|---|---|---|---|
-| S01 | 赤フェーズ / 代替証跡（Red / alternative） | red-required / covered-existing / inspect-only / manual-required | ... | `command` / 文書点検（docs inspection） / 手動記録（manual record） | pass / approved-no-op / fail / blocked | ... |
-| S01 | 緑フェーズ（Green） | ... | ... | `command` / 点検（inspection） / 手動記録（manual record） | pass / fail / blocked | ... |
-| S01 | リファクタリング（Refactor） | guardrail satisfied / no refactor needed | ... | 差分点検（diff inspection） / command | pass / approved-no-op / fail / blocked | ... |
-
-#### 発見されたテスト / リスク（Discovered Tests）
-| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
-|---|---|---|---|---|---|---|
-| S01 | none / ... | implementation / review / QA / user report | recorded / added test / deferred / amended plan | tc-001 / new | yes / no | ... |
+| S01-S05 | Red | slci-001..slci-008 | old HEAD + current tests 4 件が expected failure | temporary HEAD worktree + copied current test file | pass | missing env / relative root / central placement / linked normalization が旧 sibling 実装で失敗することを確認 |
+| S01-S05 | Green | slci-001..slci-008 | worktree runtime tests 22 件成功 | `uv run python -m unittest tests.cli_runtime.test_worktree -v` | pass | Missing/blank env、path validation、central placement、collision、bootstrap、linked-worktree normalization を含む |
+| S06 | Manual | slci-009 | env export present; configured root currently absent but valid root auto-creation is covered by runtime tests | shell inspection / test evidence | pass | user-local path は commit 対象外 |
+| S90 | Docs inspection | slci-010..slci-012 | provider docs / dogfooding docs / parent Epic docs updated; stale future sibling contract search limited to legacy wording | `rg` inspection | pass | broad `spec-dock update .` churn は D-001 として抑制 |
+| S99 | Validation | slci-012 | validate and sync passed on current working tree | `./spec-dock/scripts/spec-dock validate`; `./spec-dock/scripts/spec-dock sync` | pass | code-reviewer reported a sync failure in a parallel context, but parent rerun succeeded |
+| S99 | Full suite | slci-012 | full unittest discover passed through system Python after classifying local `.venv` pip state and after post-QA cleanup | `python -m unittest discover -v` | pass | latest run: 959 tests in 498.210s OK |
 
 #### ステップ契約の完了証跡（Step Contract Closure）
 | ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
 |---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved-no-op / fail / blocked | ... |
+| S01 | slci-001 | missing / blank env fatal before side effects | `test_worktree_create_requires_env_without_side_effects`, `test_worktree_create_rejects_blank_env_without_side_effects` | pass | exact-env helper added for true unset env |
+| S02 | slci-002, slci-003 | invalid roots fatal; `~` and directory symlink accepted | relative/file/broken symlink/dir symlink/tilde tests | pass | error text includes var name, raw/resolved path, cause, setup example |
+| S03 | slci-004, slci-005 | central placement and no sibling fallback | central placement test and sibling absence assertions | pass | root/namespace auto-created |
+| S04 | slci-006, slci-007 | naming/collision/bootstrap preserved | collision, label, branch slash, bootstrap success/failure/detection tests | pass | bootstrap remains non-fatal |
+| S05 | slci-008 | linked invocation normalization | linked worktree runtime test | pass | namespace uses main worktree basename |
+| S06 | slci-009 | local setup evidence only | shell env and `.zshenv` inspection | pass | no repo-managed user-local artifact |
+| S90 | slci-010..slci-012 | docs/spec parity and scope boundary | docs updates and targeted `rg` inspection | pass | sibling only remains as legacy/future-not wording |
 
-#### テスト契約の完了証跡（Test Contract Closure）
+## 実装記録（セッションログ） (必須)
+
+### 発見されたテスト / リスク（Discovered Tests）
+| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
+|---|---|---|---|---|---|---|
+| S04 | invalid label test should also prove no central-root side effects | qa-reviewer | valid central root を渡し、namespace / worktree / branch / bootstrap side effect がないことを追加確認 | slci-006 | no | `tests/cli_runtime/test_worktree.py` |
+| S99 | `uv run` full suite failed because local `.venv` lacks pip | command | system Python で同じ unittest discovery を再実行して pass を確認 | slci-012 | no | `python -m unittest discover -v` -> OK |
+
+### テスト契約の完了証跡（Test Contract Closure）
 | クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
 |---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required / covered-existing / inspect-only / manual-required | ... | ... | pass / approved-no-op / fail / blocked | ... |
+| slci-001 | S01 | yes | red-required | old HEAD current-test run failed as expected | `test_worktree_create_requires_env_without_side_effects`; `test_worktree_create_rejects_blank_env_without_side_effects` | pass | missing / blank env fatal before side effects |
+| slci-002 | S02 | yes | red-required | old HEAD current-test run failed as expected | relative/file/broken-symlink root tests | pass | invalid root errors include env var, raw/resolved path, cause, setup example |
+| slci-003 | S02 | yes | red-required | covered by new tests | directory symlink and tilde root tests | pass | accepted valid root variants |
+| slci-004 | S03 | yes | red-required | old HEAD current-test run failed as expected | `test_worktree_create_uses_central_root_auto_id_and_branch` | pass | central namespace path created |
+| slci-005 | S03/S90 | yes | red-required / inspect-only | old HEAD current-test run failed as expected | sibling absence assertions and docs inspection | pass | no new sibling fallback or migration |
+| slci-006 | S04 | yes | covered-existing / red-required | existing label/collision tests updated | invalid label, collision, branch prefix tests | pass | naming and collision rules preserved under central root |
+| slci-007 | S04 | yes | covered-existing | existing bootstrap tests updated | bootstrap success/failure/detection/skipped tests | pass | bootstrap remains non-fatal |
+| slci-008 | S05 | yes | red-required | old HEAD current-test run failed as expected | linked worktree normalization test | pass | main worktree basename drives namespace |
+| slci-009 | S06 | yes | manual-required | N/A | `printenv`, `.zshenv` inspection, root creatability via runtime tests | pass | local setup is evidence only |
+| slci-010 | S90 | yes | inspect-only | N/A | docs and parent Epic inspection | pass | central root is future contract |
+| slci-011 | S90/S99 | yes | inspect-only | N/A | diff/docs inspection | pass | no list/remove/prune, no `$CODEX_HOME/worktrees` mixing |
+| slci-012 | S90/S99 | yes | command evidence | N/A | `validate`, `sync`, targeted and full unittest discovery | pass | provider/dogfooding parity covered by tests |
+| slci-013 | S100 | yes | PR evidence | N/A | PR Delivery Gate / Merge Preparation Gate | pending | PR creation and monitoring happen after initial commit/push |
 
-- `closure id / test id` は Spec-Locked Closure Index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
-
-#### クロージャ網羅（Closure Coverage）
+### クロージャ網羅（Closure Coverage）
 | クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
 |---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved-no-op / fail / blocked | ... |
+| slci-001 | S01 | targeted worktree tests | pass | missing/blank env |
+| slci-002 | S02 | targeted worktree tests | pass | invalid root variants |
+| slci-003 | S02 | targeted worktree tests | pass | accepted symlink / `~` root |
+| slci-004 | S03 | targeted worktree tests | pass | central root path |
+| slci-005 | S03/S90 | targeted tests + docs inspection | pass | no sibling fallback |
+| slci-006 | S04 | targeted worktree tests | pass | label/id/collision rules |
+| slci-007 | S04 | targeted worktree tests | pass | bootstrap semantics |
+| slci-008 | S05 | targeted worktree tests | pass | linked invocation |
+| slci-009 | S06 | local shell inspection | pass | env export present; root creatability tested |
+| slci-010 | S90 | docs/spec inspection | pass | future contract updated |
+| slci-011 | S90/S99 | diff/docs inspection | pass | scope exclusions preserved |
+| slci-012 | S90/S99 | `validate`, `sync`, unittest | pass | full system-Python suite OK |
+| slci-013 | S100 | PR URL / monitor evidence | pending | to be recorded after PR creation |
 
-#### クロージャ差分（Closure Delta）
+### クロージャ差分（Closure Delta）
 | 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
 |---|---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no | yes / no |
+| none | slci-001..slci-013 | N/A | same | plan closure ids are used directly | no | no |
 
-#### ワークフロー委任同意の証跡（Workflow Delegation Consent）
-`workflow_issue.md` is the policy source for workflow-scoped delegation consent. This report records observed consent, boundary, expiry, and denied / unavailable handling only.
-
+### ワークフロー委任同意の証跡（Workflow Delegation Consent）
 | 同意元（consent source） | リポジトリ / worktree（repo/worktree） | 対象課題（active issue） | セッション（session） | 指名ロール（named roles） | 境界（boundary） | 期限 / 無効化条件（expires / invalidation condition） | 拒否 / 利用不可理由（denied / unavailable reason） | 次アクション（next action） |
 |---|---|---|---|---|---|---|---|---|
-| user instruction / explicit approval / none | ... | iss-00130 | current session / ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | same repo, active issue, session, named role; no destructive action / publishing / credentialed access / scope expansion / write-capable delegation / private external system use | issue complete / session end / scope change / host policy conflict / user revocation | none / denied / unavailable / host conflict | proceed / ask user / block gate / record waiver request |
+| user instruction | `/Users/iwasawayuuta/workspace/tools/spec-dock` | iss-00130 | current session | repo-analyst / system-architect / implementation-planner / spec-reviewer / code-reviewer / qa-reviewer | same repo, active issue, workflow-scoped; parent owns canonical docs and final closure | issue complete / scope change / user revocation | none | proceed |
 
-#### 実装委任ゲート（Implementation Delegation Gate）
-`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records observed evidence only.
-
+### 実装委任ゲート（Implementation Delegation Gate）
 | ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
+| S01-S05/S90 | parent implementation with delegated review | tightly coupled runtime/docs/report integration after approved specs | repo-analyst / code-reviewer / qa-reviewer / spec-reviewer | read-only analysis and review gates | active issue requirement/design/plan | parent edited provider, dogfooding mirror, tests, docs, report | worker direct canonical edits | targeted tests, full suite, validate/sync, reviewer gates | P1 reviewer fail / validation fail | pass/fail findings and ledger notes | pass with P2 QA follow-up adopted |
 
-#### 委任 worker 証跡（Delegated Worker Evidence）
+### 委任 worker 証跡（Delegated Worker Evidence）
 | ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
 |---|---|---|---|---|---|---|---|
-| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
+| S01-S05/S90 | repo-analyst | implementation surfaces and test-harness risks identified | none | read-only | accepted | none | adopted in EAL-001 |
+| S99 | code-reviewer | integrated diff satisfies central-root contract and mirror parity | none | read-only diff/test review | pass | none | adopted in EAL-003 |
+| S99 | qa-reviewer | no P0/P1 coverage gaps; P2 invalid-label/report cleanup noted | none | read-only QA review | pass | P2 addressed locally | adopted in EAL-004 |
+| S99/S100 | spec-reviewer | final report closure and PR evidence gaps found | none | read-only spec review | fail | S100 pending until PR exists | report closure updated; PR evidence deferred to post-PR commit |
 
-#### 親実装例外（Parent Implementation Exception）
+### 親実装例外（Parent Implementation Exception）
 | ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
 |---|---|---|---|---|---|---|---|---|
-| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
+| S01-S05/S90 | canonical docs/report and tightly coupled runtime/test/docs integration remained parent-owned per workflow | user instructed workflow execution with subagent use; no waiver | changed files in this issue diff | parent edited canonical specs/report, provider runtime/docs, dogfooding mirror, tests | revert central-root runtime/docs/tests to previous sibling placement | targeted tests, full suite, validate/sync | code-reviewer pass; qa-reviewer pass; spec-reviewer pending S100 | none |
 
-#### レビューゲート状態（Reviewer Gate Status）
+### レビューゲート状態（Reviewer Gate Status）
 | ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
 |---|---|---|---|---|---|---|---|
-| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
+| S99 | final code review | code-reviewer | fresh | passed | N/A | proceed | no findings |
+| S99 | final QA review | qa-reviewer | fresh | passed | N/A | proceed after P2 cleanup | invalid-label central side-effect coverage added |
+| S99 | final code review follow-up | code-reviewer | fresh | passed | N/A | proceed after P2 cleanup | central-root help wording updated |
+| S99 | final QA review follow-up | qa-reviewer | fresh | passed | N/A | proceed | EAL follow-up closed |
+| S99/S100 | final spec review | spec-reviewer | fresh | failed | no | incomplete until PR evidence recorded | report placeholders and S100 evidence gap identified; non-PR report gaps fixed here |
 
-#### ステップ commit ゲート（Step Commit Gate）
+### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S01 | committed / approved-no-op | ... | <hash or final ledger reference> | `git status --short` -> clean | ... | ... | ... | ... |
+| S01-S99 | pending initial commit | runtime, tests, docs, specs, report, discussions | pending | pending | N/A | N/A | N/A | N/A |
+| S100 | pending post-PR evidence commit | PR delivery / merge-prep evidence in report | pending | pending | N/A | N/A | N/A | N/A |
 
-#### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
+### 変更したファイル
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py` - env gateway port を追加。
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py` - required central root validation and placement を実装。
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py` - env gateway を runtime ports に wiring。
+- `tests/cli_runtime/test_worktree.py` - central root, invalid env/root, linked invocation, bootstrap/collision preservation tests を更新。
+- `src/spec_dock/assets/spec_dock/docs/reference_worktree.md` / `spec-dock/docs/reference_worktree.md` - user-facing central-root contract を更新。
+- `spec-dock/active/issue/*.md` / parent Epic docs / `discussions/` - requirement/design/plan/report evidence and supersession context を記録。
 
-#### コミット
-- <hash> <message>
-
-#### メモ
-- ...
-
----
-
-### セッションログ（2026-05-26 HH:MM - HH:MM）
-
-#### 対象
-- Step: ...
-- AC/EC: ...
-
-#### 実施内容
-- ...
-
----
+### コミット
+- pending
 
 ## 最終品質ゲート（Final Quality Gate / 必須）
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
 | 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
 |---|---|---|---|---|
-| docs / templates / README / workflow / skill / migration notes | yes / no | doc-writer / N/A | ... | pass / fail / blocked |
+| provider/dogfooding reference docs and parent Epic docs | yes | parent orchestrator | docs updated; `validate` and `sync` pass | pending final S100 rerun |
 
 ### 最終 QA ゲート（Final QA Gate）
 | レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | added / already sufficient / not applicable | ... | pass / fail / blocked |
+| qa-reviewer `Locke` | whole issue obligation coverage | targeted + full suite sufficient with one P2 coverage improvement | `review_status: pass`; P2 invalid-label coverage adopted | pass |
 
 ### 最終コードレビューゲート（Final Code Review Gate）
 | レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
 |---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | ... | 0 | pass / fail / blocked |
+| code-reviewer `Halley` | issue-wide integrated diff | no findings | 1 | pass |
 
 ### 最終 spec review ゲート（Final Spec Review Gate）
 | レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
 |---|---|---|---|---|
-| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | ... | 0 | pass / fail / blocked |
+| spec-reviewer `Kepler` | requirement / design / plan / report / implementation / tests / docs alignment | report closure placeholders and S100 PR evidence missing; non-PR report gaps fixed here | 1 | pending rerun after PR evidence |
+
+### PR Delivery Gate / Merge Preparation Gate（S100）
+| 項目 | 証跡 | 結果 |
+|---|---|---|
+| PR URL / base / head / issue linkage | pending until PR creation | pending |
+| latest pushed head SHA and monitored head match | pending until push / PR monitor | pending |
+| CI / PR checks / Codex review state | pending until PR monitor | pending |
+| S100 report evidence commit and re-push | pending after PR evidence is recorded | pending |
 
 ### 最終 commit（Final Commit）
 | 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
 |---|---|---|---|
-| ... | ... | final response / PR / issue comment / other external delivery evidence | ready / blocked |
+| S01-S99 evidence recorded; S100 pending PR creation | initial implementation commit pending | PR body / final response / report S100 update | pending |
 
 ## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
+- 問題: `uvx --from . spec-dock update .` が central-root scope 外の dogfooding scaffold churn を発生させた。
+  - 解決: D-001 として記録し、広範な生成差分を戻して relevant runtime/docs mirror だけを手動同期した。
+- 問題: `uv run python -m unittest discover -v` が local `.venv` の pip 欠落で失敗した。
+  - 解決: `python -m unittest discover -v` で同じ suite が成功することを確認し、local tooling state として分類した。
 
 ## 学んだこと (任意)
-- ...
+- worktree placement の contract 変更は provider runtime、dogfooding mirror、reference docs、parent Epic docs、issue docs を同時に閉じる必要がある。
 
 ## 今後の推奨事項 (任意)
-- ...
+- S100 は PR 作成後に PR URL、head SHA、checks / review 状態、delivery-evidence commit を report に追記してから final spec review を rerun する。
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/report.md
@@ -67,6 +67,8 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 | EAL-004 | `adopted` | `sub-agent` qa-reviewer | test coverage / report cleanup | QA gate passed with P2 recommendations; invalid-label central-root side-effect coverage and decision-ledger cleanup were adopted and targeted tests passed. | qa-reviewer `Locke` -> `review_status: pass`; `uv run python -m unittest tests.cli_runtime.test_worktree -v` -> OK, 22 tests | なし |
 | EAL-005 | `adopted` | `sub-agent` code-reviewer | CLI help contract cleanup | Fresh code review passed with P2 stale help wording; provider and dogfooding parser help were updated to central-root wording and parity verified. | code-reviewer `Newton` -> `review_status: pass`; `rg` stale-help check; mirror parity test -> OK | なし |
 | EAL-006 | `adopted` | `sub-agent` qa-reviewer | post-cleanup QA review | Fresh QA review passed with only evidence-ledger cleanup; EAL-004 was closed and targeted tests had already passed. | qa-reviewer `Herschel` -> `review_status: pass` | なし |
+| EAL-007 | `adopted` | `command` / PR monitor | S100 PR delivery and merge-preparation evidence | PR #133 exists against `main`, closes #130, initial head checks passed, merge state is clean, and GraphQL reviewThreads returned zero threads. | `gh pr view 133 --json ...`; `gh pr checks 133 --watch=false`; `gh api graphql ... reviewThreads.totalCount=0` | Final post-report push monitor remains external evidence because recording that push inside this report would change the head again. |
+| EAL-008 | `adopted` | `sub-agent` spec-reviewer | final S100 report review | Fresh spec review passed with a P2 recommendation to name S100 gate fields explicitly; the S100 table was expanded with ready/draft, PR reuse, open state, monitor status, fix-loop count, blockers, and merge-prepared decision fields. | spec-reviewer `Carver` -> `review_status: pass` | なし |
 
 ## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
 - 委任 authoring の使用:
@@ -306,7 +308,7 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 | slci-010 | S90 | yes | inspect-only | N/A | docs and parent Epic inspection | pass | central root is future contract |
 | slci-011 | S90/S99 | yes | inspect-only | N/A | diff/docs inspection | pass | no list/remove/prune, no `$CODEX_HOME/worktrees` mixing |
 | slci-012 | S90/S99 | yes | command evidence | N/A | `validate`, `sync`, targeted and full unittest discovery | pass | provider/dogfooding parity covered by tests |
-| slci-013 | S100 | yes | PR evidence | N/A | PR Delivery Gate / Merge Preparation Gate | pending | PR creation and monitoring happen after initial commit/push |
+| slci-013 | S100 | yes | PR evidence | N/A | PR Delivery Gate / Merge Preparation Gate | pass for initial implementation head | PR #133 exists, closes #130, initial head checks passed, merge state is clean, reviewThreads totalCount is 0; final report-evidence push monitor remains external evidence |
 
 ### クロージャ網羅（Closure Coverage）
 | クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
@@ -323,7 +325,7 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 | slci-010 | S90 | docs/spec inspection | pass | future contract updated |
 | slci-011 | S90/S99 | diff/docs inspection | pass | scope exclusions preserved |
 | slci-012 | S90/S99 | `validate`, `sync`, unittest | pass | full system-Python suite OK |
-| slci-013 | S100 | PR URL / monitor evidence | pending | to be recorded after PR creation |
+| slci-013 | S100 | PR URL / checks / merge-state / reviewThreads evidence | pass for initial implementation head | final report-evidence push monitor remains external evidence |
 
 ### クロージャ差分（Closure Delta）
 | 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
@@ -346,12 +348,13 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 | S01-S05/S90 | repo-analyst | implementation surfaces and test-harness risks identified | none | read-only | accepted | none | adopted in EAL-001 |
 | S99 | code-reviewer | integrated diff satisfies central-root contract and mirror parity | none | read-only diff/test review | pass | none | adopted in EAL-003 |
 | S99 | qa-reviewer | no P0/P1 coverage gaps; P2 invalid-label/report cleanup noted | none | read-only QA review | pass | P2 addressed locally | adopted in EAL-004 |
-| S99/S100 | spec-reviewer | final report closure and PR evidence gaps found | none | read-only spec review | fail | S100 pending until PR exists | report closure updated; PR evidence deferred to post-PR commit |
+| S99/S100 | spec-reviewer | final report closure and PR evidence gaps found | none | read-only spec review | fail before S100 update | S100 evidence now recorded; fresh rerun required | report closure updated; PR evidence recorded in S100 gate |
+| S100 | spec-reviewer | S100 report evidence is sufficient; P2 explicit field naming recommended | none | read-only spec review | pass | P2 field naming adopted | adopted in EAL-008 |
 
 ### 親実装例外（Parent Implementation Exception）
 | ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
 |---|---|---|---|---|---|---|---|---|
-| S01-S05/S90 | canonical docs/report and tightly coupled runtime/test/docs integration remained parent-owned per workflow | user instructed workflow execution with subagent use; no waiver | changed files in this issue diff | parent edited canonical specs/report, provider runtime/docs, dogfooding mirror, tests | revert central-root runtime/docs/tests to previous sibling placement | targeted tests, full suite, validate/sync | code-reviewer pass; qa-reviewer pass; spec-reviewer pending S100 | none |
+| S01-S05/S90 | canonical docs/report and tightly coupled runtime/test/docs integration remained parent-owned per workflow | user instructed workflow execution with subagent use; no waiver | changed files in this issue diff | parent edited canonical specs/report, provider runtime/docs, dogfooding mirror, tests | revert central-root runtime/docs/tests to previous sibling placement | targeted tests, full suite, validate/sync | code-reviewer pass; qa-reviewer pass; spec-reviewer pass after S100 evidence update | none |
 
 ### レビューゲート状態（Reviewer Gate Status）
 | ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
@@ -360,13 +363,14 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 | S99 | final QA review | qa-reviewer | fresh | passed | N/A | proceed after P2 cleanup | invalid-label central side-effect coverage added |
 | S99 | final code review follow-up | code-reviewer | fresh | passed | N/A | proceed after P2 cleanup | central-root help wording updated |
 | S99 | final QA review follow-up | qa-reviewer | fresh | passed | N/A | proceed | EAL follow-up closed |
-| S99/S100 | final spec review | spec-reviewer | fresh | failed | no | incomplete until PR evidence recorded | report placeholders and S100 evidence gap identified; non-PR report gaps fixed here |
+| S99/S100 | final spec review | spec-reviewer | fresh before S100 update | failed before S100 update | no | rerun required after S100 evidence update | report placeholders and S100 evidence gap identified; S100 evidence recorded here for rerun |
+| S100 | final spec review follow-up | spec-reviewer | fresh | passed | N/A | proceed after P2 field naming cleanup | no P0/P1 blocker; S100 external-evidence loop note accepted |
 
 ### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S01-S99 | pending initial commit | runtime, tests, docs, specs, report, discussions | pending | pending | N/A | N/A | N/A | N/A |
-| S100 | pending post-PR evidence commit | PR delivery / merge-prep evidence in report | pending | pending | N/A | N/A | N/A | N/A |
+| S01-S99 | closed and committed | runtime, tests, docs, specs, report, discussions | `50154d98b9c7d55e3fea7081afc2c0a8f13b192b` | `git status --short --branch` clean before S100 report update | N/A | N/A | N/A | N/A |
+| S100 | report evidence update pending commit | PR delivery / merge-prep evidence in report | pending S100 evidence commit | pending post-commit clean check | N/A | N/A | N/A | final latest-head PR monitor will be recorded outside this report to avoid an endless evidence-commit loop |
 
 ### 変更したファイル
 - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py` - env gateway port を追加。
@@ -377,14 +381,15 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 - `spec-dock/active/issue/*.md` / parent Epic docs / `discussions/` - requirement/design/plan/report evidence and supersession context を記録。
 
 ### コミット
-- pending
+- `50154d98b9c7d55e3fea7081afc2c0a8f13b192b` - initial implementation / docs / tests / report commit.
+- S100 evidence report update commit: pending.
 
 ## 最終品質ゲート（Final Quality Gate / 必須）
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
 | 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
 |---|---|---|---|---|
-| provider/dogfooding reference docs and parent Epic docs | yes | parent orchestrator | docs updated; `validate` and `sync` pass | pending final S100 rerun |
+| provider/dogfooding reference docs and parent Epic docs | yes | parent orchestrator | docs updated; `validate` and `sync` pass | fresh S100 spec review passed |
 
 ### 最終 QA ゲート（Final QA Gate）
 | レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
@@ -399,20 +404,27 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 ### 最終 spec review ゲート（Final Spec Review Gate）
 | レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
 |---|---|---|---|---|
-| spec-reviewer `Kepler` | requirement / design / plan / report / implementation / tests / docs alignment | report closure placeholders and S100 PR evidence missing; non-PR report gaps fixed here | 1 | pending rerun after PR evidence |
+| spec-reviewer `Kepler`, spec-reviewer `Carver` | requirement / design / plan / report / implementation / tests / docs alignment | Kepler found report closure placeholders and missing S100 PR evidence; Carver passed the S100 update with one P2 explicit-field recommendation, which is adopted here | 2 | pass |
 
 ### PR Delivery Gate / Merge Preparation Gate（S100）
 | 項目 | 証跡 | 結果 |
 |---|---|---|
-| PR URL / base / head / issue linkage | pending until PR creation | pending |
-| latest pushed head SHA and monitored head match | pending until push / PR monitor | pending |
-| CI / PR checks / Codex review state | pending until PR monitor | pending |
-| S100 report evidence commit and re-push | pending after PR evidence is recorded | pending |
+| PR creation / reuse decision | Created new PR #133 because no existing PR for branch `iss-00130-central-worktree-root-placement` was reused in this workflow. | pass |
+| Draft / ready decision | PR #133 is `isDraft=false`; this issue is intended for human merge judgment after monitor gates pass. | pass |
+| PR open state | `gh pr view 133 --json state,isDraft` returned `state=OPEN`, `isDraft=false`. | pass |
+| PR URL / base / head / issue linkage | PR #133: `https://github.com/chemitaro/spec-dock/pull/133`; base `main`; head `iss-00130-central-worktree-root-placement`; `Closes #130`; `closingIssuesReferences` includes issue #130 | pass |
+| latest pushed head SHA and monitored head match | Initial PR head `50154d98b9c7d55e3fea7081afc2c0a8f13b192b`; `gh pr view 133 --json headRefOid,mergeStateStatus,mergeable` returned the same head, `MERGEABLE`, `CLEAN` | pass for initial implementation head; S100 evidence commit will require post-push external monitor |
+| CI / PR checks / review state | `gh pr checks 133 --watch=false` returned `provider-tests` pass x2 and `validate` pass x2; GraphQL `reviewThreads.totalCount=0`; `reviewDecision` empty | pass |
+| Monitor status | Initial PR monitor result is clean: all observed checks completed successfully, merge state `CLEAN`, no review threads. | pass for initial implementation head |
+| Fix-loop count / history | PR monitor fix loops: 0. No post-PR code fix was required before this report-evidence update. | pass |
+| Unresolved blockers | None observed on initial PR head. Post-report evidence commit must be monitored after push. | pass for initial implementation head |
+| Final merge-prepared decision | Initial PR head is merge-prepared for human judgment. The final merge-prepared decision for the report-evidence head is delegated to the post-push PR monitor / final response. | pass for initial implementation head |
+| S100 report evidence commit and re-push | This report update records PR evidence. The act of committing and pushing it will create a new head, so latest-head CI / merge-state evidence is delivered through the final PR monitor and final response rather than another report edit. | pending post-report push monitor |
 
 ### 最終 commit（Final Commit）
 | 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
 |---|---|---|---|
-| S01-S99 evidence recorded; S100 pending PR creation | initial implementation commit pending | PR body / final response / report S100 update | pending |
+| S01-S99 and initial S100 PR evidence recorded | S100 report evidence update commit pending | final PR monitor / final response | pending post-report push monitor |
 
 ## 遭遇した問題と解決 (任意)
 - 問題: `uvx --from . spec-dock update .` が central-root scope 外の dogfooding scaffold churn を発生させた。
@@ -424,7 +436,7 @@ ls: /Users/iwasawayuuta/workspace/worktrees: No such file or directory
 - worktree placement の contract 変更は provider runtime、dogfooding mirror、reference docs、parent Epic docs、issue docs を同時に閉じる必要がある。
 
 ## 今後の推奨事項 (任意)
-- S100 は PR 作成後に PR URL、head SHA、checks / review 状態、delivery-evidence commit を report に追記してから final spec review を rerun する。
+- S100 report evidence commit 後は head が変わるため、latest-head の CI / merge-state / reviewThreads は final PR monitor と最終報告に記録する。
 
 ## 省略/例外メモ (必須)
 - 該当なし

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/issues/iss-00130-central-worktree-root-placement/requirement.md
@@ -3,97 +3,356 @@
 ID: "iss-00130"
 タイトル: "Central Worktree Root Placement"
 関連GitHub: ["#130"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
-最終更新: "2026-05-26"
+最終更新: "2026-05-27"
 親: ["epic-00107", "init-local-00002"]
 ---
 
 # iss-00130 Central Worktree Root Placement — 要件定義（何を、なぜ行うか）
 
 ## 目的
-- （1〜3行）...
+- `spec-dock worktree create` が作成する linked worktree の配置先を、repo sibling container から環境変数で指定する central root へ変更する。
+- Codex sandbox の writable root を product ごとに手動追加する運用を避け、全 product の spec-dock managed worktree を 1 つの許可済み root 配下に集約できるようにする。
+- 既存の id / directory basename / branch naming / bootstrap behavior は維持し、placement contract だけを安全に置き換える。
 
 ## 背景・現状
 - 現状の挙動:
-  - ...
+  - `epic-00107` の既存契約では、worktree は Git main worktree の親 directory に `<repo-basename>-worktrees/` container を作り、その配下に `<repo-basename>-<id>` として作成される。
+  - この repository では `/Users/iwasawayuuta/workspace/tools/spec-dock-worktrees/...` のような sibling container が既に使われている。
+  - `reference_worktree.md` と runtime tests も sibling placement を現行仕様として扱っている。
 - 現状の課題:
-  - ...
-- 再現手順:
-  1. ...
-  2. ...
-- 観測点:
-  - UI:
-  - HTTP:
-  - DB:
-  - ログ:
+  - Codex sandbox を有効にした環境では、sibling container が現在の project writable root の外になりやすい。
+  - product ごとに Codex writable root を手動追加する運用は、設定漏れと human error の原因になる。
+  - 通常の product checkout と linked worktree は lifecycle が異なる。linked worktree は短命の開発 surface であり、通常 checkout と同列の場所へ増え続けると管理しづらい。
+- 代表的な問題の流れ:
+  1. maintainer が `spec-dock worktree create` を実行する。
+  2. command が repo sibling の `<repo-basename>-worktrees/` に linked worktree を作成する。
+  3. Codex sandbox から見ると、その sibling path は project writable root 外になり、追加の手動許可が必要になる。
 - 情報源:
-  - ...
+  - `spec-dock/active/epic/requirement.md`
+  - `spec-dock/active/issue/discussions/20260526t081258z-scratch-user-input-capture.md`
+  - `spec-dock/active/issue/discussions/20260526t081259z-01-interview-requirement-interview.md`
+  - `spec-dock/active/issue/discussions/20260526t081259z-research-existing-worktree-contract-research.md`
+  - `spec-dock/active/issue/discussions/20260526t081356z-disc-central-root-placement-options.md`
+  - `spec-dock/active/issue/discussions/20260526t082342z-research-shell-environment-setup-research.md`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py`
+  - `src/spec_dock/assets/spec_dock/docs/reference_worktree.md`
+  - `tests/cli_runtime/test_worktree.py`
 
-## 対象ユーザー / 利用シナリオ（必要時）
+## 対象ユーザー / 利用シナリオ
 - 主な利用者:
-  - ...
+  - spec-dock maintainer。
+  - Codex sandbox を使いながら、複数 issue / branch を linked worktree で並行開発する operator。
 - 代表シナリオ:
-  - ...
+  - maintainer が `SPEC_DOCK_WORKTREE_ROOT=$HOME/workspace/worktrees` を設定した環境で `spec-dock worktree create` を実行し、central root 配下に dedicated worktree を作る。
+  - maintainer が `spec-dock` 以外の product checkout でも同じ `SPEC_DOCK_WORKTREE_ROOT` を使い、product ごとの namespace 配下に worktree を集約する。
+  - Codex sandbox 側では central root だけを writable root として許可し、project ごとの sibling worktree path を個別追加しない。
 
 ## スコープ
 - 必須:
-  - ...
+  - `spec-dock worktree create` の future placement を `SPEC_DOCK_WORKTREE_ROOT` based central root に変更する。
+  - この issue は `epic-00107` の既存 sibling placement 契約を、future `worktree create` について明示的に supersede する。対象は Epic requirement の sibling container placement clauses と `reference_worktree.md` の user-facing placement contract である。
+  - `SPEC_DOCK_WORKTREE_ROOT` は `worktree create` に必須とし、未設定・空文字・空白のみの場合は fatal error にする。
+  - central root 配下の namespace は Git main worktree basename とする。この repository では `spec-dock` である。
+  - worktree path は `$SPEC_DOCK_WORKTREE_ROOT/<namespace>/<repo-basename>-<id>` とする。
+  - env var が設定済みで root / namespace directory が存在しない場合、command が必要な directory を作成できる。
+  - `~` 展開後に絶対パスになる env var 値は許可する。
+  - 相対パスは fatal error にする。
+  - 通常 directory と directory を指す symlink は root として許可する。
+  - file、directory 以外、壊れた symlink、作成不能な path は fatal error にする。
+  - missing / invalid env var の error は、変数名、原因、絶対パスを使う設定例を含める。
+  - 既存の id 生成、label validation、branch naming、collision retry、`make init` bootstrap semantics を維持する。
+  - shipped docs と tests を新しい placement contract に合わせる。
+  - この開発機では local setup evidence として、`.zshenv` に `SPEC_DOCK_WORKTREE_ROOT` export があり、`/Users/iwasawayuuta/workspace/worktrees` が root として利用可能であることを確認する。
 - 禁止:
-  - ...
+  - `SPEC_DOCK_WORKTREE_ROOT` が missing / blank の場合に旧 sibling placement へ fallback すること。
+  - 既存 sibling worktree を自動移動・削除・migration すること。
+  - この issue で namespace override 用の flag / config / env var を追加すること。
+  - Codex app が `$CODEX_HOME/worktrees` 配下に作る short-lived worktree を spec-dock managed worktree と混在させること。
+  - worktree list / remove / prune / cleanup command をこの issue の scope に含めること。
 - 対象外:
-  - ...
+  - 既存 sibling worktree の migration guide 実装。
+  - central root 配下 namespace の owner metadata 管理。
+  - 同 basename repository の collision を完全に防ぐ namespace 設計。
+  - shell profile を自動編集する setup command。
+  - Codex sandbox 設定そのものの自動変更。
+  - local setup evidence を repo-managed product artifact として扱うこと。
 
 ## 境界
 - 常に行う:
-  - ...
+  - `worktree create` 実行時に `SPEC_DOCK_WORKTREE_ROOT` を確認する。
+  - env var 値を `~` 展開し、absolute path contract を検証する。
+  - Git main worktree basename から namespace と repo basename を導出する。
+  - 作成予定 path / branch / Git worktree record の collision を既存方針どおり検出する。
+  - 成功時は absolute worktree path、id、branch、bootstrap status を観測可能にする。
 - 判断が必要:
-  - ...
+  - 将来、同 basename repository が central root で衝突した場合に namespace override を追加するか。
+  - 将来、central root 配下の worktree list / remove / prune を spec-dock command として追加するか。
 - 行わない:
-  - ...
+  - 旧 sibling placement を backward-compatible fallback として残す。
+  - namespace directory に repository owner metadata を置く。
+  - `.zshenv` / `.zprofile` / `.zshrc` を runtime command が変更する。
 
 ## 非交渉制約
-- ...
+- `SPEC_DOCK_WORKTREE_ROOT` missing / blank は worktree 作成成功として扱わない。
+- Missing / blank env var 時は Git mutation、branch 作成、directory 作成、bootstrap を行わない。
+- Central root は `$CODEX_HOME/worktrees` ではなく、operator が指定する spec-dock managed worktree root とする。
+- Existing linked worktree の lifecycle を尊重し、自動移動・自動削除しない。
+- Provider-side source of truth は `src/spec_dock/assets/spec_dock/...` とし、dogfooding workspace は検証・反映対象として扱う。
+- Parent Epic の sibling placement 記述は、この issue の完了時に future behavior として残してはならない。親 Epic / shipped docs / dogfooding docs のどこに sibling placement が残る場合も、legacy boundary または historical context として明示する。
 
 ## 前提
-- ...
+- `epic-00107` で定義済みの `worktree create [LABEL]` command surface は維持する。
+- `LABEL` の許可文字は lowercase letters、digits、hyphen のみであり、uppercase、underscore、dot、space、slash、shell metacharacters は拒否する。
+- id 生成は label なしなら `wt1`, `wt2`, ...、label ありなら `<label>`, `<label>2`, ... を維持する。
+- branch naming は `<current-branch>-<id>` を維持する。
+- linked worktree から実行した場合も、namespace / repo basename は Git main worktree basenameを使い、branch prefix は実行元 checkout の current branch を使う。
+- `make init` bootstrap は optional / non-fatal のまま維持する。
+- この開発機では `SPEC_DOCK_WORKTREE_ROOT` の想定値は `/Users/iwasawayuuta/workspace/worktrees` である。
+- `.zshenv` export は `export SPEC_DOCK_WORKTREE_ROOT="${SPEC_DOCK_WORKTREE_ROOT:-$HOME/workspace/worktrees}"` のように既存値を尊重する形式を推奨する。
 
 ## 受け入れ条件
-- AC-001:
+- AC-001: env var missing / blank の fatal failure
   - アクター:
+    - maintainer
   - 前提:
+    - Git repo 内の named branch checkout である。
+    - `SPEC_DOCK_WORKTREE_ROOT` が未設定、空文字、または空白のみである。
   - 操作:
+    - maintainer が `spec-dock worktree create` を実行する。
   - 期待結果:
+    - command は fatal error で終了する。
+    - error message は `SPEC_DOCK_WORKTREE_ROOT` が必須であることと設定例を示す。
+    - 旧 sibling container、central root directory、worktree path、branch、bootstrap side effect は作成されない。
   - 観測点:
-- AC-002:
-  - ...
+    - CLI runtime test。
+    - filesystem / Git branch / Git worktree record assertion。
+
+- AC-002: central root placement
+  - アクター:
+    - maintainer
+  - 前提:
+    - Git main worktree basename が `sample-repo` である。
+    - current branch が `main` である。
+    - `SPEC_DOCK_WORKTREE_ROOT` が `/tmp/worktrees` のような absolute path に設定されている。
+  - 操作:
+    - maintainer が label なしで `spec-dock worktree create` を実行する。
+  - 期待結果:
+    - command は `/tmp/worktrees/sample-repo/sample-repo-wt1` に linked worktree を作成する。
+    - branch は `main-wt1` になる。
+    - 旧 sibling container `/tmp/.../sample-repo-worktrees` は新規作成先として使われない。
+  - 観測点:
+    - CLI runtime test。
+    - `git worktree list --porcelain` assertion。
+
+- AC-003: env root / namespace directory auto creation
+  - アクター:
+    - maintainer
+  - 前提:
+    - `SPEC_DOCK_WORKTREE_ROOT` は absolute path に設定されている。
+    - その root directory または namespace directory はまだ存在しない。
+  - 操作:
+    - maintainer が `spec-dock worktree create` を実行する。
+  - 期待結果:
+    - command は root / namespace directory を必要に応じて作成する。
+    - 作成済み worktree は central root 配下に配置される。
+  - 観測点:
+    - filesystem assertion。
+    - CLI runtime test。
+
+- AC-004: path validation
+  - アクター:
+    - maintainer
+  - 前提:
+    - `SPEC_DOCK_WORKTREE_ROOT` に `~/workspace/worktrees`、absolute path、relative path、file path、壊れた symlink、directory symlink のいずれかが設定される。
+  - 操作:
+    - maintainer が `spec-dock worktree create` を実行する。
+  - 期待結果:
+    - `~` 展開後に absolute path になる値と directory symlink は許可される。
+    - relative path、file path、壊れた symlink、directory として使えない path は fatal error になる。
+    - invalid root の場合、Git mutation、branch 作成、directory 作成、bootstrap は行われない。
+  - 観測点:
+    - path validation tests。
+    - filesystem / Git assertion。
+
+- AC-005: existing naming and collision behavior is preserved
+  - アクター:
+    - maintainer
+  - 前提:
+    - `SPEC_DOCK_WORKTREE_ROOT` は valid absolute path に設定されている。
+    - label なし、valid label あり、directory / branch / Git worktree record collision が発生する case がある。
+  - 操作:
+    - maintainer が `spec-dock worktree create [LABEL]` を実行する。
+  - 期待結果:
+    - id 生成は既存どおり `wt1`, `wt2`, ... または `<label>`, `<label>2`, ... になる。
+    - branch は `<current-branch>-<id>` になる。
+    - retryable collision は次候補へ進む。
+    - non-retryable failure は作成成功として扱わない。
+  - 観測点:
+    - existing worktree tests の central root 対応後の regression。
+
+- AC-006: linked worktree invocation normalization
+  - アクター:
+    - maintainer
+  - 前提:
+    - command が既存 linked worktree から実行される。
+    - Git main worktree basename は `sample-repo` である。
+    - 実行元 current branch は `main-outer` である。
+    - `SPEC_DOCK_WORKTREE_ROOT` は valid absolute path に設定されている。
+  - 操作:
+    - maintainer が linked worktree から `spec-dock worktree create inner` を実行する。
+  - 期待結果:
+    - namespace / repo basename は Git main worktree basename `sample-repo` から導出される。
+    - path は `$SPEC_DOCK_WORKTREE_ROOT/sample-repo/sample-repo-inner` になる。
+    - branch は実行元 current branch を基点に `main-outer-inner` になる。
+    - linked worktree basename 由来の nested namespace は作られない。
+  - 観測点:
+    - linked worktree CLI runtime test。
+
+- AC-007: bootstrap behavior preservation
+  - アクター:
+    - maintainer
+  - 前提:
+    - `SPEC_DOCK_WORKTREE_ROOT` は valid absolute path に設定されている。
+    - 作成先 worktree には `make init` success / failure / missing / detection failure の各 case がある。
+  - 操作:
+    - maintainer が `spec-dock worktree create` を実行する。
+  - 期待結果:
+    - `make init` success は `succeeded` として表示される。
+    - `make init` missing は `skipped` として表示される。
+    - `make init` failure / detection failure は warning として観測可能だが、worktree 作成成功を取り消さない。
+    - placement はすべて central root 配下になる。
+  - 観測点:
+    - bootstrap CLI runtime tests。
+
+- AC-008: docs and dogfooding parity
+  - アクター:
+    - maintainer
+  - 前提:
+    - provider-side docs / runtime / tests を更新する。
+  - 操作:
+    - maintainer が shipped docs、dogfooding docs、runtime tests、validation を確認する。
+  - 期待結果:
+    - `reference_worktree.md` は `SPEC_DOCK_WORKTREE_ROOT`、fatal missing env、central root layout、namespace rule、legacy sibling boundary、Codex app worktree boundary を説明する。
+    - `epic-00107` の sibling placement 記述は、future `worktree create` の正本として残らず、central root contract または legacy context へ更新される。
+    - provider-side source of truth と dogfooding workspace の relevant docs / runtime contract が一致する。
+  - 観測点:
+    - docs inspection。
+    - parity test または update / validation evidence。
+
+- AC-009: local setup evidence
+  - アクター:
+    - maintainer
+  - 前提:
+    - この開発機で `spec-dock worktree create` を実用する。
+  - 操作:
+    - maintainer が shell environment と central root directory を確認する。
+  - 期待結果:
+    - `SPEC_DOCK_WORKTREE_ROOT` が `/Users/iwasawayuuta/workspace/worktrees` または user-approved equivalent を指している。
+    - `.zshenv` には既存 override を尊重する export がある。
+    - root directory は存在するか、valid env var を使った `worktree create` により作成可能である。
+    - `.zshenv` や user-local directory の状態は repo-managed product artifact として commit 対象にしない。
+  - 観測点:
+    - shell env inspection。
+    - filesystem inspection。
+    - report evidence。
 
 ## 例外・エッジケース
-- EC-001:
+- EC-001: invalid label
   - 条件:
+    - label に uppercase、underscore、dot、space、slash、shell metacharacter が含まれる。
   - 期待:
+    - command は invalid label として fatal error になる。
+    - env root / namespace / worktree / branch / bootstrap side effect は作成されない。
   - 観測点:
-- EC-002:
-  - ...
+    - existing invalid label tests。
 
-## 入力→出力例（必要時）
-- EX-001:
+- EC-002: valid env var but root path creation fails
+  - 条件:
+    - `SPEC_DOCK_WORKTREE_ROOT` は absolute path だが、permission error、file conflict、broken symlink などで root / namespace を directory として使えない。
+  - 期待:
+    - command は fatal error になる。
+    - 作成成功として扱わない。
+    - error は対象 path と原因を追える情報を含む。
+  - 観測点:
+    - path failure tests。
+
+- EC-003: namespace directory already exists
+  - 条件:
+    - `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>` が既に存在する。
+  - 期待:
+    - directory として使える場合、それ自体では fatal にしない。
+    - 作成予定 worktree path / branch / Git worktree record が衝突する場合のみ既存 collision rule で扱う。
+  - 観測点:
+    - collision tests。
+
+- EC-004: same basename repository collision
+  - 条件:
+    - 別 repository が同じ Git main worktree basename を持ち、同じ central namespace を使う。
+  - 期待:
+    - この issue では namespace owner metadata や override は導入しない。
+    - 通常の path / branch / Git worktree record collision で検出できる範囲だけ扱う。
+    - 追加の namespace 設計は future extension とする。
+  - 観測点:
+    - scope inspection。
+
+- EC-005: existing sibling worktrees
+  - 条件:
+    - `/Users/iwasawayuuta/workspace/tools/spec-dock-worktrees/...` のような既存 sibling worktree が残っている。
+  - 期待:
+    - command は既存 sibling worktree を移動・削除しない。
+    - future `worktree create` は central root を使う。
+  - 観測点:
+    - docs inspection。
+    - runtime does not migrate existing path。
+
+## 入力→出力例
+- EX-001: label なし
   - 入力:
+    - `SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees`
+    - main worktree: `/Users/iwasawayuuta/workspace/tools/spec-dock`
+    - current branch: `main`
+    - command: `./spec-dock/scripts/spec-dock worktree create`
   - 出力:
+    - id: `wt1`
+    - path: `/Users/iwasawayuuta/workspace/worktrees/spec-dock/spec-dock-wt1`
+    - branch: `main-wt1`
+
+- EX-002: label あり
+  - 入力:
+    - `SPEC_DOCK_WORKTREE_ROOT=/Users/iwasawayuuta/workspace/worktrees`
+    - main worktree: `/Users/iwasawayuuta/workspace/tools/spec-dock`
+    - current branch: `iss-00130-central-worktree-root-placement`
+    - command: `./spec-dock/scripts/spec-dock worktree create central-root`
+  - 出力:
+    - id: `central-root`
+    - path: `/Users/iwasawayuuta/workspace/worktrees/spec-dock/spec-dock-central-root`
+    - branch: `iss-00130-central-worktree-root-placement-central-root`
+
+- EX-003: missing env var
+  - 入力:
+    - `SPEC_DOCK_WORKTREE_ROOT` unset
+    - command: `./spec-dock/scripts/spec-dock worktree create`
+  - 出力:
+    - fatal error:
+      - `SPEC_DOCK_WORKTREE_ROOT` is required for `worktree create`
+      - setup example uses an absolute path such as `export SPEC_DOCK_WORKTREE_ROOT="$HOME/workspace/worktrees"`
+    - no worktree / branch / directory side effect
 
 ## 用語（ドメイン語彙）
-- TERM-001:
-  - ...
+- TERM-001: central root
+  - `SPEC_DOCK_WORKTREE_ROOT` が指す、spec-dock managed linked worktree を集約する root directory。
+- TERM-002: namespace
+  - central root 直下の product / repository scope directory。この issue では Git main worktree basename を使う。
+- TERM-003: repo basename
+  - Git main worktree path の basename。worktree directory basename と namespace の導出元になる。
+- TERM-004: spec-dock managed worktree
+  - `spec-dock worktree create` が作成する、operator が手動管理する長命寄りの linked worktree。
+- TERM-005: Codex app managed worktree
+  - Codex app が `$CODEX_HOME/worktrees` 配下に作成する短命 worktree。この issue の管理対象ではない。
+- TERM-006: sibling placement
+  - 旧仕様の `<main-worktree-parent>/<repo-basename>-worktrees/<repo-basename>-<id>` 形式の配置。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/plan.md
@@ -15,7 +15,7 @@ ID: "epic-00107"
 ## この計画で閉じる E-RQ / E-AC
 - E-RQ:
   - E-RQ-001: runtime worktree creation command
-  - E-RQ-002: sibling `<repo-basename>-worktrees/` placement and linked-worktree normalization
+  - E-RQ-002: required `SPEC_DOCK_WORKTREE_ROOT` central placement and linked-worktree normalization
   - E-RQ-003: id / directory / branch naming
   - E-RQ-004: label validation
   - E-RQ-005: collision detection and retry
@@ -135,7 +135,7 @@ ID: "epic-00107"
   3. Docs / dogfooding parity / final verification.
 - 契約 / docs 更新:
   - Add a worktree command section to shipped workflow/reference docs.
-  - Mention sibling container placement and no nested `.worktrees/`.
+  - Mention required `SPEC_DOCK_WORKTREE_ROOT`, central root namespace placement, legacy sibling boundary, and no nested `.worktrees/`.
   - Mention optional / non-fatal `make init`.
   - Mention future extensions: list/status/remove/prune are out of scope.
 
@@ -156,7 +156,7 @@ ID: "epic-00107"
   - `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync` pass.
 - docs 影響解決:
   - Provider docs and dogfooding docs show the same command contract.
-  - No stale wording suggests nested `.worktrees/` or Codex-managed worktree replacement.
+  - No stale wording suggests sibling placement as future behavior, nested `.worktrees/`, or Codex-managed worktree replacement.
 
 ## 依存 / ブロッカー
 - D-001:

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/requirement.md
@@ -18,7 +18,7 @@ ID: "epic-00107"
   - `Metric-001` の「feature value 中心の portfolio」に対して、runtime command で実用できる operator value を追加する。
 - この epic が提供する能力:
   - repo-local SpecDock runtime command から、現在 checkout に紐づく linked worktree と新規 branch を作成できる。
-  - 作成先は main checkout の中ではなく、main checkout と同じ親 directory に作る `<repo-basename>-worktrees/` container 配下へ集約できる。
+  - 作成先は main checkout の中ではなく、`SPEC_DOCK_WORKTREE_ROOT` で指定した central root 配下の `<repo-basename>/` namespace へ集約できる。
   - worktree directory name / initial branch name は、既に実用している `taikyohiyou_project` の naming UX を踏襲して自動合成できる。
   - worktree 作成後に、project-local bootstrap interface として worktree root の `make init` を optional / non-fatal に呼び出せる。
   - Codex app が管理する短命 worktree とは別に、開発者が自分で管理する長命 worktree を作る導線を提供する。
@@ -40,14 +40,16 @@ ID: "epic-00107"
 - E-RQ-001:
   - SpecDock は repo-local runtime command として worktree 作成 capability を提供し、maintainer が `git worktree add` の naming / collision handling / bootstrap を毎回手作業で組み立てなくてよいこと。
 - E-RQ-002:
-  - 作成先 container は main checkout の内側ではなく、main checkout の親 directory 直下の `<repo-basename>-worktrees/` とすること。
-  - container 名は lowercase path policy に従い、dot suffix ではなく hyphen suffix を標準とすること。
-  - 例: `/Users/.../spec-dock` から作る場合、container は `/Users/.../spec-dock-worktrees/` であること。
-  - command が既存 linked worktree から実行された場合も、container placement と repo basename は Git が認識する main worktree を基準に正規化すること。
+  - 作成先 namespace は main checkout の内側ではなく、必須環境変数 `SPEC_DOCK_WORKTREE_ROOT` で指定した central root 直下の `<repo-basename>/` とすること。
+  - `SPEC_DOCK_WORKTREE_ROOT` が未設定、空文字、空白のみ、relative path、file、壊れた symlink、directory として使えない path の場合は fail-fast すること。
+  - 通常 directory と directory を指す symlink は root として許可し、root / namespace directory は必要に応じて作成できること。
+  - 例: `/Users/.../spec-dock` から `SPEC_DOCK_WORKTREE_ROOT=/Users/.../worktrees` を使う場合、namespace は `/Users/.../worktrees/spec-dock/` であること。
+  - command が既存 linked worktree から実行された場合も、namespace と repo basename は Git が認識する main worktree を基準に正規化すること。
+  - 過去の sibling `<repo-basename>-worktrees/` placement は legacy context とし、future `worktree create` の fallback として使わないこと。
 - E-RQ-003:
   - 個別 worktree directory name と initial branch name は、参照プロダクトの実用 naming を踏襲すること。
   - label 省略時の id は `wt1`, `wt2`, ... とし、label 指定時の id は `<label>`, `<label>2`, ... とすること。
-  - 個別 worktree directory は `<repo-basename>-<id>` を基本とし、container 配下に作ること。
+  - 個別 worktree directory は `<repo-basename>-<id>` を基本とし、central root namespace 配下に作ること。
   - initial branch は `<current-branch>-<id>` を基本とすること。
 - E-RQ-004:
   - label は lowercase alphanumeric と hyphen のみを許可し、uppercase、underscore、dot、space、slash、shell metacharacter を拒否すること。
@@ -75,11 +77,12 @@ ID: "epic-00107"
 - E-AC-001:
   - 前提:
     - Git repo の main checkout が `/tmp/example/spec-dock` にあり、current branch が `main` である
-    - `../spec-dock-worktrees/` は存在しない、または空である
+    - `SPEC_DOCK_WORKTREE_ROOT` が `/tmp/worktrees` に設定されている
+    - `/tmp/worktrees/spec-dock/` は存在しない、または空である
   - 操作:
     - maintainer が worktree 作成 command を label なしで実行する
   - 期待結果:
-    - `/tmp/example/spec-dock-worktrees/spec-dock-wt1` が linked worktree として作成される
+    - `/tmp/worktrees/spec-dock/spec-dock-wt1` が linked worktree として作成される
     - `main-wt1` branch が作成され、その worktree で checkout される
     - command output が id / path / branch / bootstrap result を表示する
   - 観測点:
@@ -92,7 +95,7 @@ ID: "epic-00107"
     - maintainer が label なしで再度 worktree 作成 command を実行する
   - 期待結果:
     - command は衝突を避けて `wt2` を採用する
-    - `/tmp/example/spec-dock-worktrees/spec-dock-wt2` と `main-wt2` が作成される
+    - `/tmp/worktrees/spec-dock/spec-dock-wt2` と `main-wt2` が作成される
   - 観測点:
     - CLI / runtime test
     - branch / directory / worktree record collision test
@@ -103,7 +106,7 @@ ID: "epic-00107"
     - maintainer が worktree 作成 command に label `issue-107-worktree` を指定する
   - 期待結果:
     - id は `issue-107-worktree` になる
-    - worktree path は `<repo-parent>/<repo-basename>-worktrees/<repo-basename>-issue-107-worktree` になる
+    - worktree path は `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-issue-107-worktree` になる
     - branch は `feature/base-issue-107-worktree` になる
   - 観測点:
     - naming unit test
@@ -154,14 +157,14 @@ ID: "epic-00107"
     - output assertion
 - E-AC-008:
   - 前提:
-    - command が `/tmp/example/spec-dock-worktrees/spec-dock-existing` のような既存 linked worktree から実行される
+    - command が `/tmp/worktrees/spec-dock/spec-dock-existing` のような既存 linked worktree から実行される
     - Git が認識する main worktree は `/tmp/example/spec-dock` である
     - current branch は `main-existing` である
   - 操作:
     - maintainer が label なしで worktree 作成 command を実行する
   - 期待結果:
-    - command は main worktree basename `spec-dock` を使って container `/tmp/example/spec-dock-worktrees/` を選ぶ
-    - 新しい個別 worktree は `/tmp/example/spec-dock-worktrees/spec-dock-wtN` に作成される
+    - command は main worktree basename `spec-dock` を使って namespace `/tmp/worktrees/spec-dock/` を選ぶ
+    - 新しい個別 worktree は `/tmp/worktrees/spec-dock/spec-dock-wtN` に作成される
     - initial branch は実行元 current branch を基点に `main-existing-wtN` として合成される
     - `spec-dock-existing-worktrees/` や `spec-dock-existing-wtN` のような chained path は作られない
   - 観測点:
@@ -205,7 +208,7 @@ ID: "epic-00107"
 ## スコープ
 - 必須:
   - SpecDock runtime worktree creation command
-  - repo sibling `<repo-basename>-worktrees/` container placement
+  - required `SPEC_DOCK_WORKTREE_ROOT` central root placement
   - taikyohiyou_project 由来の id / directory / branch naming
   - label validation
   - collision detection and retry
@@ -215,6 +218,7 @@ ID: "epic-00107"
   - dogfooding workspace inspection / parity confirmation
 - 禁止:
   - main checkout 内に `.worktrees/` や `worktrees/` を標準作成先として持ち込むこと
+  - missing / invalid `SPEC_DOCK_WORKTREE_ROOT` 時に legacy sibling placement へ fallback すること
   - Codex app managed worktree を移動・削除・再実装すること
   - `make init` failure を worktree 作成失敗として扱うこと
   - invalid label を shell / Git command に渡してから失敗させること
@@ -231,8 +235,8 @@ ID: "epic-00107"
 
 ## 境界
 - 常に行う:
-  - worktree 作成は repo 外 sibling container に集約する
-  - linked worktree から実行された場合も、main worktree を基準に container と repo basename を決める
+  - worktree 作成は `SPEC_DOCK_WORKTREE_ROOT` 配下の repo namespace に集約する
+  - linked worktree から実行された場合も、main worktree を基準に namespace と repo basename を決める
   - current branch を基点に initial branch 名を合成する
   - Git が管理する linked worktree として作成する
   - `make init` は project-local bootstrap interface として扱い、存在しない / 失敗する場合でも作成済み worktree を残す

--- a/spec-dock/scripts/spec_dock_runtime/application/ports.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/ports.py
@@ -169,6 +169,11 @@ class BootstrapGateway(Protocol):
         ...
 
 
+class EnvironmentGateway(Protocol):
+    def getenv(self, name: str) -> str | None:
+        ...
+
+
 class ArtifactWriter(Protocol):
     def write(self, specdock_dir: Path, bundle: ArtifactBundle) -> ArtifactWriteResult:
         ...
@@ -217,3 +222,4 @@ class Ports:
     artifact_writer: ArtifactWriter | None = None
     sync_legacy_runner: SyncLegacyRunner | None = None
     bootstrap_gateway: BootstrapGateway | None = None
+    environment_gateway: EnvironmentGateway | None = None

--- a/spec-dock/scripts/spec_dock_runtime/application/worktree.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/worktree.py
@@ -14,6 +14,8 @@ _RETRYABLE_GIT_WORKTREE_ERRORS = (
     "is already checked out",
     "a branch named",
 )
+_WORKTREE_ROOT_ENV = "SPEC_DOCK_WORKTREE_ROOT"
+_WORKTREE_ROOT_EXAMPLE = "export SPEC_DOCK_WORKTREE_ROOT=\"$HOME/workspace/worktrees\""
 
 
 def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateResult:
@@ -23,8 +25,11 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
         raise RuntimeError("worktree create requires a Git gateway")
     if ports.bootstrap_gateway is None:
         raise RuntimeError("worktree create requires a bootstrap gateway")
+    if ports.environment_gateway is None:
+        raise RuntimeError("worktree create requires an environment gateway")
 
     label = _normalize_label(req.label)
+    central_root = _resolve_worktree_root(ports)
     repo_root = ports.repo_root
     branch_prefix = ports.git_gateway.current_branch_or_none(repo_root)
     if branch_prefix is None:
@@ -35,7 +40,7 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
         raise RuntimeError("git worktree list returned no worktrees")
     main_worktree = records[0].path
     repo_basename = main_worktree.name
-    container = main_worktree.parent / f"{repo_basename}-worktrees"
+    container = central_root / repo_basename
     known_paths = {_canonical_path(record.path) for record in records}
     last_attempt_id = ""
     last_reason = "no candidates attempted"
@@ -68,7 +73,11 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
                 ports=ports,
                 refresh_records=False,
             )
-            raise RuntimeError(f"failed to create worktree container: {container} {state}\n{exc}") from exc
+            raise RuntimeError(
+                "failed to create worktree container from "
+                f"{_WORKTREE_ROOT_ENV}: root={central_root} container={container} "
+                f"{state}\n{exc}\nSet an absolute path, for example: {_WORKTREE_ROOT_EXAMPLE}"
+            ) from exc
 
         try:
             ports.git_gateway.add_worktree_with_new_branch(repo_root, path=worktree_path, branch=branch_name)
@@ -128,6 +137,39 @@ def _candidate_id(label: str | None, index: int) -> str:
     if index == 1:
         return label
     return f"{label}{index}"
+
+
+def _resolve_worktree_root(ports: Ports) -> Path:
+    assert ports.environment_gateway is not None
+    raw_value = ports.environment_gateway.getenv(_WORKTREE_ROOT_ENV)
+    if raw_value is None or not raw_value.strip():
+        raise RuntimeError(
+            f"{_WORKTREE_ROOT_ENV} is required for worktree create. "
+            "Set it to an absolute directory for spec-dock managed worktrees, "
+            f"for example: {_WORKTREE_ROOT_EXAMPLE}"
+        )
+    return _validate_worktree_root(raw_value)
+
+
+def _validate_worktree_root(raw_value: str) -> Path:
+    expanded = Path(raw_value).expanduser()
+    resolved = expanded.resolve(strict=False)
+    if not expanded.is_absolute():
+        raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is relative"))
+    if expanded.exists():
+        if not expanded.is_dir():
+            raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is not a directory"))
+        return expanded
+    if expanded.is_symlink():
+        raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is a broken symlink"))
+    return expanded
+
+
+def _invalid_worktree_root_message(raw_value: str, resolved: Path, cause: str) -> str:
+    return (
+        f"invalid {_WORKTREE_ROOT_ENV}: raw={raw_value!r} resolved={resolved} cause={cause}. "
+        f"Set an absolute directory, for example: {_WORKTREE_ROOT_EXAMPLE}"
+    )
 
 
 def _preflight_collision(

--- a/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -203,6 +204,12 @@ class _BootstrapGateway:
 
 
 @dataclass(frozen=True)
+class _EnvironmentGateway:
+    def getenv(self, name: str) -> str | None:
+        return os.environ.get(name)
+
+
+@dataclass(frozen=True)
 class _JsonStore:
     def load_json(self, path: Path):
         return infra_json_store.load_json(path)
@@ -239,6 +246,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
         bootstrap_gateway=_BootstrapGateway(),
+        environment_gateway=_EnvironmentGateway(),
         json_store=_JsonStore(),
         clock=_Clock(),
         artifact_writer=_ArtifactWriter(),

--- a/spec-dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/parser.py
@@ -82,7 +82,7 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     p_worktree = sub.add_parser("worktree", help="Manage long-lived Git worktrees")
     worktree_sub = p_worktree.add_subparsers(dest="worktree_cmd", required=True)
     _bind_leaf(
-        worktree_sub.add_parser("create", help="Create a sibling Git worktree and optional make init bootstrap"),
+        worktree_sub.add_parser("create", help="Create a central-root Git worktree and optional make init bootstrap"),
         registry,
         "worktree_create",
     )

--- a/src/spec_dock/assets/spec_dock/docs/reference_worktree.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_worktree.md
@@ -14,19 +14,38 @@ underscore、dot、space、slash、uppercase、shell metacharacters は拒否さ
 
 ## ディレクトリ構成（directory layout）
 
-main checkout と同じ親ディレクトリに `<repo-basename>-worktrees/` を作り、その中に worktree を作ります。
-main checkout の中に nested `.worktrees/` は作りません。
+`worktree create` は `SPEC_DOCK_WORKTREE_ROOT` で指定した central root 配下に、repo basename の namespace directory を作り、その中に worktree を作ります。
+`SPEC_DOCK_WORKTREE_ROOT` は必須です。未設定、空文字、空白のみの場合は fatal error になり、Git branch、worktree directory、bootstrap side effect は作られません。
+
+設定例:
+
+```bash
+export SPEC_DOCK_WORKTREE_ROOT="$HOME/workspace/worktrees"
+```
+
+layout:
 
 ```text
-~/workspace/tools/
+~/workspace/worktrees/
   spec-dock/
-  spec-dock-worktrees/
     spec-dock-wt1/
     spec-dock-feature/
 ```
 
-linked worktree から実行した場合も、Git が認識する main worktree を基準に container path と repo basename を決めます。
+worktree path は `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>` です。
+central root directory と namespace directory は、必要に応じて command が作成します。
+main checkout の中に nested `.worktrees/` は作りません。
+
+`SPEC_DOCK_WORKTREE_ROOT` は `~` 展開後に absolute path である必要があります。
+通常 directory と directory を指す symlink は許可されます。
+relative path、file、壊れた symlink、directory として使えない path は fatal error です。
+
+linked worktree から実行した場合も、Git が認識する main worktree を基準に namespace と repo basename を決めます。
 branch name は実行元 checkout の current branch を基準にします。
+
+過去バージョンで作られた sibling `<repo-basename>-worktrees/` は legacy placement です。
+この command は既存 sibling worktree を移動・削除・migration しません。
+future `worktree create` は central root を使い、missing env var 時に sibling placement へ fallback しません。
 
 ## 命名（naming）
 
@@ -34,7 +53,7 @@ LABEL なし:
 
 ```text
 id: wt1, wt2, wt3, ...
-path: <repo-basename>-worktrees/<repo-basename>-<id>
+path: $SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>
 branch: <current-branch>-<id>
 ```
 
@@ -42,7 +61,7 @@ LABEL あり:
 
 ```text
 id: <label>, <label>2, <label>3, ...
-path: <repo-basename>-worktrees/<repo-basename>-<id>
+path: $SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>
 branch: <current-branch>-<id>
 ```
 
@@ -66,7 +85,7 @@ bootstrap の detection / execution failure は worktree 作成成功を取り�
 bootstrap warning は既存 CLI warning path に流れます。
 
 ```text
-spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/spec-dock-worktrees/spec-dock-wt1
+spec-dock: ok (worktree create) id=wt1 branch=main-wt1 path=/abs/path/worktrees/spec-dock/spec-dock-wt1
 spec-dock: worktree bootstrap status=skipped command=-
 ```
 
@@ -77,7 +96,9 @@ spec-dock: worktree bootstrap status=skipped command=-
 - Git repo 外での実行。
 - detached HEAD での実行。
 - invalid label。
-- container path の作成失敗。
+- missing / blank `SPEC_DOCK_WORKTREE_ROOT`。
+- invalid `SPEC_DOCK_WORKTREE_ROOT`。
+- central root / namespace directory の作成失敗。
 - non-retryable `git worktree add` failure。
 - candidate retry ceiling exhaustion。
 

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
@@ -169,6 +169,11 @@ class BootstrapGateway(Protocol):
         ...
 
 
+class EnvironmentGateway(Protocol):
+    def getenv(self, name: str) -> str | None:
+        ...
+
+
 class ArtifactWriter(Protocol):
     def write(self, specdock_dir: Path, bundle: ArtifactBundle) -> ArtifactWriteResult:
         ...
@@ -217,3 +222,4 @@ class Ports:
     artifact_writer: ArtifactWriter | None = None
     sync_legacy_runner: SyncLegacyRunner | None = None
     bootstrap_gateway: BootstrapGateway | None = None
+    environment_gateway: EnvironmentGateway | None = None

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/worktree.py
@@ -14,6 +14,8 @@ _RETRYABLE_GIT_WORKTREE_ERRORS = (
     "is already checked out",
     "a branch named",
 )
+_WORKTREE_ROOT_ENV = "SPEC_DOCK_WORKTREE_ROOT"
+_WORKTREE_ROOT_EXAMPLE = "export SPEC_DOCK_WORKTREE_ROOT=\"$HOME/workspace/worktrees\""
 
 
 def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateResult:
@@ -23,8 +25,11 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
         raise RuntimeError("worktree create requires a Git gateway")
     if ports.bootstrap_gateway is None:
         raise RuntimeError("worktree create requires a bootstrap gateway")
+    if ports.environment_gateway is None:
+        raise RuntimeError("worktree create requires an environment gateway")
 
     label = _normalize_label(req.label)
+    central_root = _resolve_worktree_root(ports)
     repo_root = ports.repo_root
     branch_prefix = ports.git_gateway.current_branch_or_none(repo_root)
     if branch_prefix is None:
@@ -35,7 +40,7 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
         raise RuntimeError("git worktree list returned no worktrees")
     main_worktree = records[0].path
     repo_basename = main_worktree.name
-    container = main_worktree.parent / f"{repo_basename}-worktrees"
+    container = central_root / repo_basename
     known_paths = {_canonical_path(record.path) for record in records}
     last_attempt_id = ""
     last_reason = "no candidates attempted"
@@ -68,7 +73,11 @@ def worktree_create(req: WorktreeCreateRequest, ports: Ports) -> WorktreeCreateR
                 ports=ports,
                 refresh_records=False,
             )
-            raise RuntimeError(f"failed to create worktree container: {container} {state}\n{exc}") from exc
+            raise RuntimeError(
+                "failed to create worktree container from "
+                f"{_WORKTREE_ROOT_ENV}: root={central_root} container={container} "
+                f"{state}\n{exc}\nSet an absolute path, for example: {_WORKTREE_ROOT_EXAMPLE}"
+            ) from exc
 
         try:
             ports.git_gateway.add_worktree_with_new_branch(repo_root, path=worktree_path, branch=branch_name)
@@ -128,6 +137,39 @@ def _candidate_id(label: str | None, index: int) -> str:
     if index == 1:
         return label
     return f"{label}{index}"
+
+
+def _resolve_worktree_root(ports: Ports) -> Path:
+    assert ports.environment_gateway is not None
+    raw_value = ports.environment_gateway.getenv(_WORKTREE_ROOT_ENV)
+    if raw_value is None or not raw_value.strip():
+        raise RuntimeError(
+            f"{_WORKTREE_ROOT_ENV} is required for worktree create. "
+            "Set it to an absolute directory for spec-dock managed worktrees, "
+            f"for example: {_WORKTREE_ROOT_EXAMPLE}"
+        )
+    return _validate_worktree_root(raw_value)
+
+
+def _validate_worktree_root(raw_value: str) -> Path:
+    expanded = Path(raw_value).expanduser()
+    resolved = expanded.resolve(strict=False)
+    if not expanded.is_absolute():
+        raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is relative"))
+    if expanded.exists():
+        if not expanded.is_dir():
+            raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is not a directory"))
+        return expanded
+    if expanded.is_symlink():
+        raise RuntimeError(_invalid_worktree_root_message(raw_value, resolved, "path is a broken symlink"))
+    return expanded
+
+
+def _invalid_worktree_root_message(raw_value: str, resolved: Path, cause: str) -> str:
+    return (
+        f"invalid {_WORKTREE_ROOT_ENV}: raw={raw_value!r} resolved={resolved} cause={cause}. "
+        f"Set an absolute directory, for example: {_WORKTREE_ROOT_EXAMPLE}"
+    )
 
 
 def _preflight_collision(

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -203,6 +204,12 @@ class _BootstrapGateway:
 
 
 @dataclass(frozen=True)
+class _EnvironmentGateway:
+    def getenv(self, name: str) -> str | None:
+        return os.environ.get(name)
+
+
+@dataclass(frozen=True)
 class _JsonStore:
     def load_json(self, path: Path):
         return infra_json_store.load_json(path)
@@ -239,6 +246,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
         bootstrap_gateway=_BootstrapGateway(),
+        environment_gateway=_EnvironmentGateway(),
         json_store=_JsonStore(),
         clock=_Clock(),
         artifact_writer=_ArtifactWriter(),

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
@@ -82,7 +82,7 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
     p_worktree = sub.add_parser("worktree", help="Manage long-lived Git worktrees")
     worktree_sub = p_worktree.add_subparsers(dest="worktree_cmd", required=True)
     _bind_leaf(
-        worktree_sub.add_parser("create", help="Create a sibling Git worktree and optional make init bootstrap"),
+        worktree_sub.add_parser("create", help="Create a central-root Git worktree and optional make init bootstrap"),
         registry,
         "worktree_create",
     )

--- a/tests/cli_runtime/test_worktree.py
+++ b/tests/cli_runtime/test_worktree.py
@@ -9,6 +9,23 @@ from tests.cli_runtime.harness import CliRuntimeHarness, main
 
 
 class TestCliWorktree(CliRuntimeHarness):
+    def _worktree_env(self, root: Path | str) -> dict[str, str]:
+        return {"SPEC_DOCK_WORKTREE_ROOT": str(root)}
+
+    def _assert_no_sibling_container(self, target: Path) -> None:
+        self.assertFalse((target.parent / f"{target.name}-worktrees").exists())
+
+    def _run_runtime_capture_exact_env(self, target: Path, args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        script = target / "spec-dock" / "scripts" / "spec-dock"
+        self.assertTrue(script.is_file(), f"runtime script missing: {script}")
+        return subprocess.run(
+            [sys.executable, str(script), *args],
+            cwd=str(target),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
     def _prepare_git_repo(self, target: Path) -> None:
         if shutil.which("git") is None:
             self.skipTest("git not available")
@@ -20,33 +37,66 @@ class TestCliWorktree(CliRuntimeHarness):
             ["-c", "user.email=test@example.com", "-c", "user.name=test", "commit", "-m", "init"],
         )
 
-    def test_worktree_create_uses_sibling_container_auto_id_and_branch(self) -> None:
+    def test_worktree_create_requires_env_without_side_effects(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
             target.mkdir()
             self._prepare_git_repo(target)
 
-            p = self._run_runtime_capture(target, ["worktree", "create"])
+            env = os.environ.copy()
+            env.pop("SPEC_DOCK_WORKTREE_ROOT", None)
+            p = self._run_runtime_capture_exact_env(target, ["worktree", "create"], env=env)
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("SPEC_DOCK_WORKTREE_ROOT is required", p.stderr)
+            self.assertIn("export SPEC_DOCK_WORKTREE_ROOT", p.stderr)
+            self._assert_no_sibling_container(target)
+            self.assertFalse((Path(tmp) / "worktrees").exists())
+            self.assertNotIn("-wt1", self._run_git(target, ["branch", "--list"]).stdout)
+
+    def test_worktree_create_rejects_blank_env_without_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env("   "))
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("SPEC_DOCK_WORKTREE_ROOT is required", p.stderr)
+            self._assert_no_sibling_container(target)
+            self.assertNotIn("-wt1", self._run_git(target, ["branch", "--list"]).stdout)
+
+    def test_worktree_create_uses_central_root_auto_id_and_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
 
             self.assertEqual(p.returncode, 0, p.stderr)
             current_branch = self._run_git(target, ["branch", "--show-current"]).stdout.strip()
-            expected_path = (target.parent / "sample-repo-worktrees" / "sample-repo-wt1").resolve()
+            expected_path = central_root / "sample-repo" / "sample-repo-wt1"
             self.assertIn(f"id=wt1", p.stdout)
             self.assertIn(f"path={expected_path}", p.stdout)
             self.assertIn("bootstrap status=skipped", p.stdout)
             self.assertTrue(expected_path.is_dir())
             self.assertTrue((expected_path / "spec-dock" / "scripts" / "spec-dock").is_file())
+            self._assert_no_sibling_container(target)
             worktree_list = self._run_git(target, ["worktree", "list", "--porcelain"]).stdout
-            self.assertIn(str(expected_path), worktree_list)
+            self.assertIn(str(expected_path.resolve()), worktree_list)
             self.assertIn(f"branch refs/heads/{current_branch}-wt1", worktree_list)
 
     def test_worktree_create_retries_collisions_and_accepts_label(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
-            first = self._run_runtime_capture(target, ["worktree", "create", "feature"])
-            second = self._run_runtime_capture(target, ["worktree", "create", "feature"])
+            first = self._run_runtime_capture(target, ["worktree", "create", "feature"], env=self._worktree_env(central_root))
+            second = self._run_runtime_capture(target, ["worktree", "create", "feature"], env=self._worktree_env(central_root))
 
             self.assertEqual(first.returncode, 0, first.stderr)
             self.assertEqual(second.returncode, 0, second.stderr)
@@ -57,10 +107,11 @@ class TestCliWorktree(CliRuntimeHarness):
     def test_worktree_create_retries_auto_id_collisions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
-            first = self._run_runtime_capture(target, ["worktree", "create"])
-            second = self._run_runtime_capture(target, ["worktree", "create"])
+            first = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
+            second = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
 
             self.assertEqual(first.returncode, 0, first.stderr)
             self.assertEqual(second.returncode, 0, second.stderr)
@@ -68,9 +119,95 @@ class TestCliWorktree(CliRuntimeHarness):
             self.assertIn(f"id=wt1 branch={current_branch}-wt1", first.stdout)
             self.assertIn(f"id=wt2 branch={current_branch}-wt2", second.stdout)
 
+    def test_worktree_create_rejects_relative_root_without_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env("relative/worktrees"))
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("invalid SPEC_DOCK_WORKTREE_ROOT", p.stderr)
+            self.assertIn("raw='relative/worktrees'", p.stderr)
+            self.assertIn("cause=path is relative", p.stderr)
+            self.assertIn("export SPEC_DOCK_WORKTREE_ROOT", p.stderr)
+            self._assert_no_sibling_container(target)
+
+    def test_worktree_create_rejects_file_root_without_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            root_file = Path(tmp) / "root-file"
+            root_file.write_text("not a directory\n", encoding="utf-8")
+            target.mkdir()
+            self._prepare_git_repo(target)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(root_file))
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("invalid SPEC_DOCK_WORKTREE_ROOT", p.stderr)
+            self.assertIn("cause=path is not a directory", p.stderr)
+            self.assertIn(str(root_file), p.stderr)
+            self.assertFalse((Path(tmp) / "root-file" / "sample-repo").exists())
+
+    def test_worktree_create_rejects_broken_symlink_root_without_side_effects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            target.mkdir()
+            self._prepare_git_repo(target)
+            if not self._can_create_symlink(Path(tmp)):
+                self.skipTest("symlink not available")
+            broken = Path(tmp) / "broken-root"
+            os.symlink(Path(tmp) / "missing-root", broken)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(broken))
+
+            self.assertNotEqual(p.returncode, 0)
+            self.assertIn("invalid SPEC_DOCK_WORKTREE_ROOT", p.stderr)
+            self.assertIn("cause=path is a broken symlink", p.stderr)
+            self.assertFalse((Path(tmp) / "missing-root").exists())
+
+    def test_worktree_create_accepts_directory_symlink_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            real_root = Path(tmp) / "real-worktrees"
+            symlink_root = Path(tmp) / "linked-worktrees"
+            target.mkdir()
+            real_root.mkdir()
+            self._prepare_git_repo(target)
+            if not self._can_create_symlink(Path(tmp)):
+                self.skipTest("symlink not available")
+            os.symlink(real_root, symlink_root)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(symlink_root))
+
+            expected_path = symlink_root / "sample-repo" / "sample-repo-wt1"
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn(f"path={expected_path}", p.stdout)
+            self.assertTrue(expected_path.is_dir())
+
+    def test_worktree_create_expands_tilde_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "sample-repo"
+            fake_home = Path(tmp) / "home"
+            root = fake_home / "workspace" / "worktrees"
+            target.mkdir()
+            fake_home.mkdir()
+            self._prepare_git_repo(target)
+            env = self._worktree_env("~/workspace/worktrees")
+            env["HOME"] = str(fake_home)
+
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=env)
+
+            expected_path = root / "sample-repo" / "sample-repo-wt1"
+            self.assertEqual(p.returncode, 0, p.stderr)
+            self.assertIn(f"path={expected_path}", p.stdout)
+            self.assertTrue(expected_path.is_dir())
+
     def test_worktree_create_rejects_invalid_labels_without_creating_worktree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
 
@@ -87,11 +224,18 @@ class TestCliWorktree(CliRuntimeHarness):
                 "bad&label",
             ):
                 with self.subTest(label=label):
-                    p = self._run_runtime_capture(target, ["worktree", "create", label])
+                    p = self._run_runtime_capture(
+                        target,
+                        ["worktree", "create", label],
+                        env=self._worktree_env(central_root),
+                    )
 
                     self.assertNotEqual(p.returncode, 0)
                     self.assertIn("invalid worktree label", p.stderr)
-            self.assertFalse((target.parent / "sample-repo-worktrees").exists())
+                    self.assertFalse((central_root / "sample-repo").exists())
+                    self.assertFalse((target / ".init-ran").exists())
+            self._assert_no_sibling_container(target)
+            self.assertNotIn("-bad", self._run_git(target, ["branch", "--list"]).stdout)
 
     def test_worktree_create_help_exposes_optional_label(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -108,11 +252,12 @@ class TestCliWorktree(CliRuntimeHarness):
     def test_worktree_create_uses_current_branch_with_slash_for_branch_prefix(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
             self._run_git(target, ["checkout", "-b", "feature/base"])
 
-            p = self._run_runtime_capture(target, ["worktree", "create", "slice"])
+            p = self._run_runtime_capture(target, ["worktree", "create", "slice"], env=self._worktree_env(central_root))
 
             self.assertEqual(p.returncode, 0, p.stderr)
             self.assertIn("id=slice branch=feature/base-slice", p.stdout)
@@ -122,13 +267,14 @@ class TestCliWorktree(CliRuntimeHarness):
             self.skipTest("make not available")
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             (target / "Makefile").write_text("init:\n\t@echo initialized > .init-ran\n", encoding="utf-8")
             self._prepare_git_repo(target)
 
-            p = self._run_runtime_capture(target, ["worktree", "create", "setup"])
+            p = self._run_runtime_capture(target, ["worktree", "create", "setup"], env=self._worktree_env(central_root))
 
-            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-setup"
+            worktree_path = central_root / "sample-repo" / "sample-repo-setup"
             self.assertEqual(p.returncode, 0, p.stderr)
             self.assertIn("bootstrap status=succeeded", p.stdout)
             self.assertEqual((worktree_path / ".init-ran").read_text(encoding="utf-8").strip(), "initialized")
@@ -138,13 +284,14 @@ class TestCliWorktree(CliRuntimeHarness):
             self.skipTest("make not available")
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             (target / "Makefile").write_text("init:\n\t@exit 7\n", encoding="utf-8")
             self._prepare_git_repo(target)
 
-            p = self._run_runtime_capture(target, ["worktree", "create", "setup"])
+            p = self._run_runtime_capture(target, ["worktree", "create", "setup"], env=self._worktree_env(central_root))
 
-            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-setup"
+            worktree_path = central_root / "sample-repo" / "sample-repo-setup"
             self.assertEqual(p.returncode, 0, p.stderr)
             self.assertIn("bootstrap status=failed", p.stdout)
             self.assertIn("spec-dock: (warn) make init failed:", p.stderr)
@@ -160,13 +307,14 @@ class TestCliWorktree(CliRuntimeHarness):
             self.skipTest("make not available")
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             (target / "Makefile").write_text("include missing.mk\ninit:\n\t@true\n", encoding="utf-8")
             self._prepare_git_repo(target)
 
-            p = self._run_runtime_capture(target, ["worktree", "create", "detect"])
+            p = self._run_runtime_capture(target, ["worktree", "create", "detect"], env=self._worktree_env(central_root))
 
-            worktree_path = target.parent / "sample-repo-worktrees" / "sample-repo-detect"
+            worktree_path = central_root / "sample-repo" / "sample-repo-detect"
             self.assertEqual(p.returncode, 0, p.stderr)
             self.assertIn("bootstrap status=detection_failed", p.stdout)
             self.assertIn("spec-dock: (warn) make init detection failed:", p.stderr)
@@ -175,12 +323,13 @@ class TestCliWorktree(CliRuntimeHarness):
     def test_worktree_create_fails_from_detached_head(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
             head = self._run_git(target, ["rev-parse", "HEAD"]).stdout.strip()
             self._run_git(target, ["checkout", "--detach", head])
 
-            p = self._run_runtime_capture(target, ["worktree", "create"])
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
 
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("detached HEAD is not supported", p.stderr)
@@ -189,27 +338,31 @@ class TestCliWorktree(CliRuntimeHarness):
     def test_worktree_create_fails_outside_git_repo(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "plain-dir"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self.assertEqual(main(["init", str(target)]), 0)
 
-            p = self._run_runtime_capture(target, ["worktree", "create"])
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
 
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("git failed: git rev-parse --abbrev-ref HEAD", p.stderr)
 
-    def test_worktree_create_fails_when_container_path_is_file(self) -> None:
+    def test_worktree_create_fails_when_namespace_path_is_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
+            central_root.mkdir()
             self._prepare_git_repo(target)
-            (target.parent / "sample-repo-worktrees").write_text("not a directory\n", encoding="utf-8")
+            (central_root / "sample-repo").write_text("not a directory\n", encoding="utf-8")
 
-            p = self._run_runtime_capture(target, ["worktree", "create"])
+            p = self._run_runtime_capture(target, ["worktree", "create"], env=self._worktree_env(central_root))
 
             self.assertNotEqual(p.returncode, 0)
             self.assertIn("failed to create worktree container", p.stderr)
+            self.assertIn("SPEC_DOCK_WORKTREE_ROOT", p.stderr)
             self.assertIn("artifact_state=path_exists:False,branch_exists:False,record_exists:False", p.stderr)
-            self.assertFalse((target.parent / "sample-repo-worktrees" / "sample-repo-wt1").exists())
+            self.assertFalse((central_root / "sample-repo" / "sample-repo-wt1").exists())
 
     def test_worktree_create_treats_non_collision_git_add_failure_as_fatal(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -241,7 +394,7 @@ class TestCliWorktree(CliRuntimeHarness):
                     return [
                         app_contracts.GitWorktreeRecord(path=Path(tmp) / "repo", head="abc", branch="main"),
                         app_contracts.GitWorktreeRecord(
-                            path=Path(tmp) / "repo-worktrees" / "repo-wt1",
+                            path=Path(tmp) / "central-worktrees" / "repo" / "repo-wt1",
                             head="abc",
                             branch="main-wt1",
                         ),
@@ -260,11 +413,16 @@ class TestCliWorktree(CliRuntimeHarness):
                 def run_make_init_if_available(self, worktree_path):
                     raise AssertionError("bootstrap must not run after git add failure")
 
+            class FakeEnvironmentGateway:
+                def getenv(self, name):
+                    return str(Path(tmp) / "central-worktrees")
+
             ports = app_ports.Ports(
                 node_reader=object(),
                 repo_root=Path(tmp) / "repo",
                 git_gateway=FakeGitGateway(),
                 bootstrap_gateway=FakeBootstrapGateway(),
+                environment_gateway=FakeEnvironmentGateway(),
             )
 
             with self.assertRaises(RuntimeError) as raised:
@@ -322,37 +480,52 @@ class TestCliWorktree(CliRuntimeHarness):
                         warnings=[],
                     )
 
+            class FakeEnvironmentGateway:
+                def getenv(self, name):
+                    return str(Path(tmp) / "central-worktrees")
+
             git_gateway = FakeGitGateway()
             ports = app_ports.Ports(
                 node_reader=object(),
                 repo_root=Path(tmp) / "repo",
                 git_gateway=git_gateway,
                 bootstrap_gateway=FakeBootstrapGateway(),
+                environment_gateway=FakeEnvironmentGateway(),
             )
 
             result = app_worktree.worktree_create(app_contracts.WorktreeCreateRequest(), ports)
 
             self.assertEqual(result.id, "wt2")
             self.assertEqual([branch for _, branch in git_gateway.add_calls], ["main-wt1", "main-wt2"])
+            self.assertEqual(
+                [path for path, _ in git_gateway.add_calls],
+                [
+                    Path(tmp) / "central-worktrees" / "repo" / "repo-wt1",
+                    Path(tmp) / "central-worktrees" / "repo" / "repo-wt2",
+                ],
+            )
 
     def test_worktree_create_normalizes_container_from_linked_worktree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp) / "sample-repo"
+            central_root = Path(tmp) / "central-worktrees"
             target.mkdir()
             self._prepare_git_repo(target)
-            first = self._run_runtime_capture(target, ["worktree", "create", "outer"])
+            first = self._run_runtime_capture(target, ["worktree", "create", "outer"], env=self._worktree_env(central_root))
             self.assertEqual(first.returncode, 0, first.stderr)
-            linked = target.parent / "sample-repo-worktrees" / "sample-repo-outer"
+            linked = central_root / "sample-repo" / "sample-repo-outer"
+            env = os.environ.copy()
+            env["SPEC_DOCK_WORKTREE_ROOT"] = str(central_root)
 
             p = subprocess.run(
                 [str(linked / "spec-dock" / "scripts" / "spec-dock"), "worktree", "create", "inner"],
                 cwd=str(linked),
-                env=os.environ.copy(),
+                env=env,
                 capture_output=True,
                 text=True,
             )
 
-            expected = (target.parent / "sample-repo-worktrees" / "sample-repo-inner").resolve()
+            expected = central_root / "sample-repo" / "sample-repo-inner"
             self.assertEqual(p.returncode, 0, p.stderr)
             self.assertIn(f"path={expected}", p.stdout)
             current_branch = self._run_git(linked, ["branch", "--show-current"]).stdout.strip()


### PR DESCRIPTION
## 概要

- `worktree create` の配置先を、repo sibling container から `SPEC_DOCK_WORKTREE_ROOT` 配下の central root namespace へ変更した。
- `SPEC_DOCK_WORKTREE_ROOT` を必須化し、未設定・空文字・不正な path では Git / directory / bootstrap の副作用前に失敗するようにした。
- provider 側 runtime / docs と dogfooding mirror、親 Epic / issue 仕様、回帰テストを central-root contract に揃えた。

## 背景・目的

- 既存の sibling `<repo-basename>-worktrees/` 配置は、Codex sandbox の writable root 外になりやすく、worktree 作成のたびに追加許可が必要になる。
- 明示的な central root を使うことで、長期利用する spec-dock managed worktree の置き場を安定させ、Codex app managed `$CODEX_HOME/worktrees` とは分離する。

## 変更内容

- Runtime: `EnvironmentGateway` port を追加し、CLI bootstrap から `os.environ.get` を注入する形で `SPEC_DOCK_WORKTREE_ROOT` を参照するようにした。
- Runtime: root の `~` 展開、absolute path validation、file / broken symlink rejection、directory symlink acceptance、namespace 作成を追加した。
- Runtime: worktree path を `$SPEC_DOCK_WORKTREE_ROOT/<repo-basename>/<repo-basename>-<id>` に変更し、label / id / branch / collision retry / bootstrap 挙動は維持した。
- Tests: missing / blank env、invalid root、central placement、invalid label side effect、linked worktree normalization、bootstrap preservation を `tests/cli_runtime/test_worktree.py` で検証した。
- Docs/spec: reference docs、dogfooding mirror、親 Epic docs、issue requirement/design/plan/report/discussions を central-root contract に更新した。
- Report: PR #133 の S100 delivery / merge-preparation evidence と fresh spec-review pass を実装報告書に記録した。

## 影響範囲

- `spec-dock worktree create` の CLI 実行契約に影響する。
- `SPEC_DOCK_WORKTREE_ROOT` が未設定の環境では、新規 worktree 作成は失敗する。
- 既存の sibling worktree は移動・削除・migration しない。
- DB、GitHub issue import、deps/sync/validate の契約には影響しない。

## 検証

- [x] `uv run python -m unittest tests.cli_runtime.test_worktree -v` が成功（22 tests）
- [x] `python -m unittest discover -v` が成功（959 tests, 498.210s）
- [x] `./spec-dock/scripts/spec-dock validate` が成功（nodes=67）
- [x] `./spec-dock/scripts/spec-dock sync` が成功
- [x] `git diff --check` が成功
- [x] `uv run python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets -v` が成功
- [x] PR #133 latest head `53d983b9d9197235f9f57ed677abb129271adb79` で GitHub Actions `validate` x2 と `provider-tests` x2 が成功
- [x] PR #133 は `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, reviewThreads `totalCount=0`

## リスク・注意点

- `worktree create` は breaking change として `SPEC_DOCK_WORKTREE_ROOT` を必須にする。
- `uv run python -m unittest discover -v` は local `.venv` に pip がないため失敗したが、system Python で同一 unittest discovery は成功している。
- report evidence commit により PR head が変わるため、latest-head の PR monitor evidence は実装報告書ではなくこの PR 状態と最終作業報告で確認する。

## 確認観点

- `SPEC_DOCK_WORKTREE_ROOT` の missing / invalid error が user-facing に十分な復旧情報を含むか。
- provider runtime/docs と dogfooding mirror の差分が意図どおり一致しているか。
- 既存 sibling worktree を migration しない境界が docs と runtime でぶれていないか。

## フォローアップ

- なし

Closes #130
