### PR TITLE
feat: spec-dock uninstall コマンドを追加

### DIFF
--- a/spec-dock/docs/reference_github.md
+++ b/spec-dock/docs/reference_github.md
@@ -18,6 +18,8 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - `./spec-dock/scripts/spec-dock update [path]` は GitHub を更新しない repo-local self-update path です。target 省略時は current directory を更新し、明示 path を渡すとその managed repo を更新します
 - runtime update は installer update の wrapper で、固定 upstream `git+https://github.com/chemitaro/spec-dock` を `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock update <target>` として実行します。arbitrary package source / cache option / `--force` は公開しません
 - update は managed files/docs/templates/scripts/skills を refresh しますが、`init --force` ではなく、old workspace の in-place migration も保証しません
+- `spec-dock uninstall [path]` / `./spec-dock/scripts/spec-dock uninstall [path]` は repo-local managed artifacts の removal です。GitHub Issue / remote state は変更せず、Python package / global CLI / environment / `uvx` cache の uninstall も行いません
+- runtime uninstall は installer uninstall の wrapper で、固定 upstream `git+https://github.com/chemitaro/spec-dock` を `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <target>` として実行します。repo-local runtime が削除済みの場合の retry / reinstall / refresh は installer CLI の `spec-dock uninstall <target>` / `spec-dock init <target>` / `spec-dock update <target>` を使います
 - dependency metadata の canonical storage は `.meta.json` top-level `depends_on` であり、追加/削除/確認は `./spec-dock/scripts/spec-dock deps add/remove/check` の command-first mutation を使います（詳細: `reference_deps.md`）
 - legacy `meta.json`（旧名）、partial linkage、current-repo mismatch などの old contract 不整合は、`update` で吸収されず current create / import / validate / sync が reject / fail-fast しうる
 - その場合は auto-migrate を期待せず、手動で normalize するか workspace を rebuild してください
@@ -71,6 +73,7 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 
 - `new {initiative,epic,issue} --github-issue <n>` は「既存番号へリンク」するだけで、GitHub Issue は作りません（`gh` を呼びません）
 - `./spec-dock/scripts/spec-dock update [path]` は `gh` を呼びません。固定 upstream の installer update を `uvx --no-cache` で呼び出し、managed files/docs/templates/scripts/skills を更新します
+- `spec-dock uninstall [path]` / `./spec-dock/scripts/spec-dock uninstall [path]` は `gh` を呼びません。target repo 内の SpecDock-managed artifacts を dry-run / explicit apply で取り外すだけで、GitHub Issue close/delete、package/environment uninstall、`uvx` cache cleanup は行いません
 - 生成される `epics/rules.md` / `issues/rules.md` / `discussions/rules.md` は `spec-dock/docs/rules/**` への symlink です。`rules.md` は入口/ナビゲーション用で、ルールの正本は `spec-dock/docs/rules/**` にあります。runtime command はサポートされた実行経路です
 
 ## 3. `import` の URL 入力に関する注意（事故防止）

--- a/spec-dock/docs/reference_sync.md
+++ b/spec-dock/docs/reference_sync.md
@@ -44,6 +44,10 @@ legacy v1 生成物（廃止）:
 
 上記3つは `sync` 実行時に常に削除されます（stale防止）。
 
+uninstall との関係:
+- `spec-dock/active/**` と `spec-dock/.agent/**` は `sync` / active 更新で再生成される状態であり、repo-local uninstall では generated state として cleanup 対象になります
+- uninstall は GitHub state や package/environment/`uvx` cache を変更しません。repo-local runtime が削除済みの場合の再実行や復旧は installer CLI の `spec-dock uninstall <target>` / `spec-dock init <target>` / `spec-dock update <target>` を使います
+
 ## 2. 全体 / TODO 投影（all / todo projection）
 
 `*-all.json` は全件を保持します。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/design.md
@@ -17,6 +17,7 @@ ID: "epic-00054"
   - command-side GitHub close
   - local spec node delete
   - repo-local self-update command
+  - repo-local uninstall command
   - destructive guardrail and docs parity
 - impacted area:
   - runtime command surface
@@ -28,7 +29,8 @@ ID: "epic-00054"
   - 現状の create flow は command 側で完結するが、close は GitHub Web UI へ戻っている。
   - local node cleanup も command contract を持たず、directory 削除が手作業運用になっている。
   - managed assets update は installer CLI 側に存在するが、repo-local runtime command から呼び出す導線がない。
-  - 本 epic はこの lifecycle gap を埋めるが、remote delete は事故リスクから除外する。
+  - managed repo から SpecDock の開発用 agent / skill / tooling を取り外す導線もなく、開発完了後の product repo で agent / skill noise が残る。
+  - 本 epic はこの lifecycle gap を埋めるが、remote delete と package/environment uninstall は事故リスクと scope 拡大から除外する。
   - review-only issue は不自然なため採らず、各 implementation issue に review / success verification を埋め込む。
 
 ### UML（推奨: module / context）
@@ -40,15 +42,19 @@ left to right direction
 rectangle "close command" as close
 rectangle "local delete command" as delete
 rectangle "self-update command" as update
+rectangle "uninstall command" as uninstall
 rectangle "local spec tree" as tree
 rectangle "GitHub issues" as gh
 rectangle "upstream package" as pkg
+rectangle "managed repo assets" as assets
 
 close --> gh
 delete --> tree
 delete --> gh : close-only
 update --> pkg : uvx --no-cache
 pkg --> tree : installer update
+uninstall --> assets : remove SpecDock-managed tooling
+uninstall --> tree : keep/remove specs by explicit mode
 @enduml
 ```
 
@@ -85,7 +91,7 @@ pkg --> tree : installer update
   - delete command は local tree を削除するが、remote side は delete せず close-only とする
   - local delete と remote close を同一 success path に置く場合でも、destructive な主操作は local tree delete、remote は lifecycle close として意味を分離する
   - self-update command は installer update の wrapper として扱い、managed assets 更新 semantics 自体は installer 側に委ねる
-  - issue 分割は close command、local delete command、self-update command の capability scope ごとに扱う。epic final close-out evidence は固定の issue number に結びつけず、最後に完了する issue が保持する。
+  - issue 分割は close command、local delete command、self-update command、uninstall command の capability scope ごとに扱う。epic final close-out evidence は固定の issue number に結びつけず、最後に完了する issue が保持する。
 
 ## データモデル
 - model / table changes:
@@ -133,6 +139,12 @@ Node --> "0..*" Node : child
   2. upstream source と no-cache uvx invocation を固定する
   3. installer `spec-dock update <target>` を subprocess として実行する
   4. stdout / stderr / exit code を operator が追える形で返す
+- Flow-E: repo-local uninstall command
+  1. repo-local runtime command は installer CLI の uninstall implementation を subprocess として呼び出す
+  2. installer CLI は target repo の SpecDock-managed assets を inventory 化する
+  3. dry-run / explicit specs mode / category-based removal guardrail に基づいて removal plan を確定する
+  4. agent / skill assets、repo-local runtime / scaffold、repo-root shortcut、仕様履歴の keep/remove mode、product-reusable assets の content mismatch preserve を実行・報告する
+  5. repo-local runtime が削除対象になった後の再実行 / 復旧は installer CLI から行えるようにする
 
 ### UML（任意: sequence / flow）
 ```plantuml
@@ -164,6 +176,9 @@ CLI -> GH: close linked issue(s)
   - `uvx` executable missing
   - upstream package fetch failure
   - installer update failure
+  - uninstall inventory classification failure
+  - content comparison failure
+  - partial uninstall failure
 - retry:
   - close は remote retry 可能
   - delete は destructive なので、実行前 validation と confirmation で partial failure を避ける
@@ -172,9 +187,11 @@ CLI -> GH: close linked issue(s)
   - close は closed issue に対して再実行可能であることが望ましい
   - delete は既に存在しない local path に対して安全に失敗または no-op とできることが望ましい
   - self-update は installer update の idempotency に従う
+  - uninstall は既に削除済みの managed artifact を no-op / already removed として report できることが望ましい
 - partial failure:
   - local delete と remote close を同一 command で扱う場合、順序と rollback guidance を明記する必要がある
   - remote close failure 時に local delete を継続するか止めるかは local delete issue で検証対象とする
+  - uninstall partial failure 時は削除済み、未削除、preserved、failed を分けて report し、installer CLI から再実行できる必要がある
 
 ## 移行戦略
 - migration strategy:
@@ -187,6 +204,7 @@ CLI -> GH: close linked issue(s)
 - observability:
   - close / delete command の CLI evidence
   - self-update subprocess args / stdout / stderr / exit code
+  - uninstall dry-run / execution summary / preserved manual review list / failed list
   - filesystem assertion
   - sync / validate 後の state evidence
 - role / auth:
@@ -205,6 +223,7 @@ CLI -> GH: close linked issue(s)
   - close command end-to-end
   - local delete command end-to-end
   - self-update command help / default target / explicit target / failure propagation
+  - uninstall command help / dry-run / explicit specs mode / category-based removal / idempotency / partial failure summary
   - subtree delete guardrail
 - E2E:
   - docs parity
@@ -215,6 +234,7 @@ CLI -> GH: close linked issue(s)
   - E-AC-003 -> local delete issue: parent scope subtree delete guardrail + integration evidence
   - E-AC-004 -> final close-out owner issue: docs parity + dogfooding validation + final review
   - E-AC-005 -> self-update issue: runtime update command + uvx no-cache subprocess contract + docs/tests/review/success verification
+  - E-AC-006 -> uninstall issue: repo-local wrapper + installer uninstall implementation + managed asset removal guardrails + docs/tests/review/success verification
 
 ## 関連 ADR
 - なし:

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/design.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/design.md
@@ -3,7 +3,7 @@
 ID: "iss-00147"
 タイトル: "SpecDock uninstall command"
 関連GitHub: ["#147"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-31"
 依存: ["requirement.md"]
@@ -12,177 +12,358 @@ ID: "iss-00147"
 
 # iss-00147 SpecDock uninstall command — 設計（どう実現するか）
 
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
 ## 親図（Diagram）参照
 - Epic 図:
-  - ...
-- Initiative 図:
-  - ...
+  - `spec-dock/active/epic/design.md` の lifecycle command context。`uninstall command -> managed repo assets` と `uninstall command -> local spec tree` の境界を本 issue で具体化する。
 - 再利用する決定:
-  - ...
+  - self-update と同じく、repo-local runtime command は installer CLI implementation を呼び出す thin wrapper とする。
+  - uninstall は remote GitHub state や package/environment uninstall を扱わない。
+  - uninstall は project-wide garbage collection ではなく、SpecDock-managed development tooling removal と explicit specs mode に限定する。
 
 ## 目的・制約
 - 目的:
-  - ...
+  - target repo から SpecDock の開発用 agent / skill / tooling を安全に取り外す。
+  - runtime wrapper が削除対象になっても、installer CLI から再実行 / 復旧できる構造にする。
+  - operator が dry-run / result summary で削除・保持・失敗理由を追えるようにする。
 - 必須 / 禁止:
-  - ...
+  - `requirement.md` の削除対象分類を設計の正本入力とする。
+  - agent / skill core removal と user-owned / product-reusable preservation のルールを path category と content policy に分ける。
+  - repo root、`.git`、target parent、unknown unmanaged paths は削除しない。
 - 非交渉制約:
-  - ...
-- 前提:
-  - ...
+  - destructive apply は explicit `--apply` と exactly one specs mode を要求する。
+  - dry-run は filesystem mutation しない。
+  - content comparison が判定不能な場合、agent / skill core removal target を除き preserve + manual review に倒す。
 
 ## 既存実装 / 規約の理解
 - 参照した実装 / docs:
-  - ...
+  - `src/spec_dock/cli.py`
+  - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`
+  - `src/spec_dock/assets/install_root/`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `tests/test_init_update.py`
+  - `tests/cli_runtime/test_update.py`
+  - `discussions/20260531t141121z-research-uninstall-repo-analysis-evidence.md`
+  - `discussions/20260531t141123z-disc-uninstall-requirement-risk-synthesis.md`
+  - `discussions/20260531t141545z-disc-uninstall-design-draft.md`
 - 現状理解:
-  - ...
+  - installer CLI は `init` / `update` と target path validation、scaffold sync、install_root asset sync を所有する。
+  - repo-local runtime `update` は installer update を `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock update <target>` で呼び出す。
+  - `install_root` inventory と manifest から current managed files、bootstrap-only exact paths、obsolete exact paths を構築する既存 helper がある。
+  - `spec-dock/initiatives/**` は仕様履歴であり、update の managed overwrite 対象ではない。
 - 採用するパターン:
-  - ...
+  - installer CLI に uninstall implementation を置く。
+  - repo-local runtime command は update と同型の thin wrapper として installer uninstall を呼ぶ。
+  - removal は inventory -> plan/result model -> render/apply の順に扱う。
 - 採用しないもの:
-  - ...
-- 影響範囲:
-  - ...
+  - runtime process 内で repo-local scaffold を直接削除する self-removal implementation。
+  - existing `delete` command の再利用。`delete` は spec node lifecycle であり、uninstall は repo-local managed tooling removal。
+  - unknown files を convenience で削除する broad cleanup。
 
 ## 採用方針 / トレードオフ
 - 論点:
-  - ...
-- 選択肢:
-  - ...
+  - uninstall の実処理を installer CLI と runtime command のどちらへ置くか。
 - 決定:
-  - ...
+  - installer CLI に `spec-dock uninstall [path]` を追加し、実処理を所有させる。
+  - repo-local runtime に `./spec-dock/scripts/spec-dock uninstall` を追加し、installer CLI を `uvx --no-cache` で呼ぶ。
+- 理由:
+  - repo-local runtime files は uninstall の削除対象になり得るため、外側の installer CLI が recovery point になる。
+  - 既存 `update` と同じ wrapper pattern にそろえ、runtime 側で installer logic を再実装しない。
+- Flag contract:
+  - `spec-dock uninstall [path]`: dry-run plan を表示し、filesystem mutation しない。
+  - `spec-dock uninstall [path] --apply --keep-specs`: specs を保持して実削除する。
+  - `spec-dock uninstall [path] --apply --remove-specs`: specs を含めて実削除する。
+  - `spec-dock uninstall [path] --json`: dry-run plan を JSON object として stdout に出す。
+  - `spec-dock uninstall [path] --apply --keep-specs --json` / `--apply --remove-specs --json`: apply result を JSON object として stdout に出す。
+  - `--keep-specs` と `--remove-specs` は mutually exclusive。
+  - `--apply` なしの specs mode は plan の表示 mode として許容するが mutation はしない。
+  - `--apply` ありで specs mode がない場合は usage error として mutation 前に fail-fast する。
+  - `--json` は installer CLI と repo-local runtime wrapper の両方で受け付け、runtime wrapper は installer CLI へ forwarding する。
 
 ## 依存関係分析
 - module 依存:
-  - ...
-- class 依存（必要時）:
-  - ...
-- function 依存（必要時）:
-  - ...
+  - `src/spec_dock/cli.py`:
+    - installer-side parser、inventory builder、content comparison、plan/result model、apply/render helper を追加する。
+    - 初期実装は既存 installer architecture に合わせて `cli.py` 内の focused helpers とする。肥大化が顕著になった場合だけ follow-up で internal module 分割を検討する。
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`:
+    - runtime thin wrapper を追加する。
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py` / `parser.py`:
+    - runtime command registration / parser binding を追加する。
 - file 依存:
-  - ...
-- 上流 / 前提:
-  - ...
-- 下流 / 依存先:
-  - ...
+  - `src/spec_dock/assets/install_root/`:
+    - repo root managed agent/tooling inventory の SoR。
+  - `src/spec_dock/assets/spec_dock/`:
+    - scaffold managed files の SoR。
+  - target repo `spec-dock/initiatives/**`:
+    - specs mode の対象。
+  - target repo `spec-dock/.agent/**` / `spec-dock/active/**`:
+    - generated state cleanup の対象。
 - 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
-- 順序への影響:
-  - plan では upstream / prerequisite から順に step を組む
+  - installer CLI の inventory/result model と tests を先に固定する。
+  - runtime wrapper は installer command contract が固定されてから追加する。
 
 ## モジュール依存図（Module Dependency Diagram）
 - タイトル:
-  - ...
+  - Uninstall command dependency direction
 - 答える問い:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
+  - installer implementation、runtime wrapper、asset inventory、tests の依存方向を固定する。
 - 範囲:
-  - ...
+  - installer CLI と shipped runtime command の issue-local 変更。
 - 含めない詳細:
-  - 網羅的な call graph / 全 method / 全 import は描かない
+  - individual file unlink loop、全 test case、全 asset path。
 - 更新条件:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- 図:
-  - 下の `plantuml` block を更新する
+  - installer/runtime ownership、inventory SoR、runtime invocation が変わるとき。
 
-### 図表（UML / 原則: モジュール依存 / パッケージ依存差分）
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
+skinparam monochrome true
 
-rectangle "対象module-a" as A
-rectangle "対象module-b" as B
-A --> B : depends_on
+rectangle "runtime command\ncommands/uninstall.py" as Runtime
+rectangle "installer CLI\nsrc/spec_dock/cli.py" as Installer
+rectangle "install_root assets\nsrc/spec_dock/assets/install_root" as InstallRoot
+rectangle "scaffold assets\nsrc/spec_dock/assets/spec_dock" as Scaffold
+rectangle "target repo\nmanaged files" as Target
+rectangle "installer tests\ntests/test_init_update.py" as InstallerTests
+rectangle "runtime tests\ntests/cli_runtime/test_uninstall.py" as RuntimeTests
+
+Runtime --> Installer : uvx --no-cache spec-dock uninstall TARGET
+Installer --> InstallRoot : reads managed asset inventory
+Installer --> Scaffold : reads managed scaffold inventory
+Installer --> Target : dry-run / remove / preserve
+InstallerTests --> Installer : validates plan/apply behavior
+RuntimeTests --> Runtime : validates wrapper invocation
 @enduml
 ```
 
-## ローカル図の差分（Local Diagram Delta / 必要時）
-- 変更する境界 / 責務 / 相互作用:
-  - N/A: 理由
-
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
+- Installer CLI:
+  - Command:
+    - `spec-dock uninstall [path] [--apply] [--keep-specs | --remove-specs] [--json]`
+  - Exit codes:
+    - `0`: dry-run completed, or apply completed without failed removals.
+    - `1`: apply encountered one or more failed removals or unrecoverable inventory/comparison error.
+    - `2`: CLI usage error, invalid target, missing specs mode for apply, or mutually exclusive specs flags.
+  - Output:
+    - stdout: plan/result summary and grouped path details.
+    - stderr: usage/inventory/apply errors.
+    - with `--json`: stdout is exactly one JSON object for plan/result/error payloads after argument parsing; human-readable guidance must not be mixed into JSON stdout.
+- Runtime command:
+  - Command:
+    - `./spec-dock/scripts/spec-dock uninstall [path] [--apply] [--keep-specs | --remove-specs] [--json]`
+  - Invocation:
+    - `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <resolved-target> <flags>`
+  - Missing `uvx`:
+    - exit `127` with actionable PATH/install guidance, matching update wrapper style.
+  - Output:
+    - propagate installer stdout/stderr/exit code.
 
-## シーケンス差分（Sequence Delta / 必要時）
+## Uninstall Model
+- `UninstallOptions`:
+  - `target_root: Path`
+  - `apply: bool`
+  - `specs_mode: "keep" | "remove" | None`
+  - `json: bool`
+- `UninstallCategory`:
+  - `agent_skill`
+  - `native_agent`
+  - `bootstrap_only`
+  - `product_reusable`
+  - `scaffold_managed`
+  - `generated_state`
+  - `spec_history`
+  - `shortcut`
+  - `obsolete_managed`
+  - `unmanaged`
+- `ContentPolicy`:
+  - `delete_even_if_mismatch`
+  - `delete_if_exact_match`
+  - `delete_by_specs_mode`
+  - `delete_if_shortcut_target_matches`
+  - `preserve`
+- `UninstallAction`:
+  - `rel_path`
+  - `category`
+  - `policy`
+  - `planned_operation`
+  - `reason`
+  - `source_asset_rel`
+- `UninstallActionResult`:
+  - `rel_path`
+  - `category`
+  - `status`
+  - `reason`
+  - `error`
+- Status buckets:
+  - `would_remove`
+  - `removed`
+  - `already_removed`
+  - `preserved`
+  - `failed`
+  - `empty_dir_removed`
+- JSON payload:
+  - top-level fields:
+    - `schema_version`
+    - `target`
+    - `mode`
+    - `apply`
+    - `specs_mode`
+    - `status`
+    - `summary`
+    - `actions`
+    - `guidance`
+    - `errors`
+  - `actions[]` fields:
+    - `path`
+    - `category`
+    - `status`
+    - `reason`
+    - `error`
+  - `status` values:
+    - `planned`
+    - `completed`
+    - `partial_failure`
+    - `error`
+
+## シーケンス差分（Sequence Delta）
 - 変更する相互作用:
-  - N/A: 理由
+  - runtime command が installer CLI を呼ぶ。
+  - installer CLI が target repo を inventory 化し、dry-run/apply の結果を返す。
 - retry / transaction / external API / queue:
-  - ...
-- UML:
-  - N/A: 理由
+  - external API は使わない。
+  - rollback は行わず、dry-run default と idempotent re-run で safety を確保する。
+  - partial failure は summary と non-zero exit で report し、installer CLI から再実行する。
 
-## ドメインモデル差分（Domain Model Delta / 必要時）
-- 親 model 参照:
-  - ...
-- aggregate / entity / value object 変更:
-  - N/A: 理由
-- domain event / policy / specification 変更:
-  - ...
-- 不変条件の変更:
-  - ...
-- UML:
-  - N/A: 理由
+```plantuml
+@startuml
+skinparam monochrome true
+hide footbox
 
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- 責務:
-  - ...
-- 連携:
-  - ...
-- UML:
-  - N/A: 理由
+actor Maintainer
+participant "repo-local runtime\n./spec-dock/scripts/spec-dock" as Runtime
+participant "installer CLI\nspec-dock uninstall" as Installer
+participant "target repo FS" as FS
 
-## ディレクトリ / ファイル変更計画
+Maintainer -> Runtime: uninstall --apply --keep-specs
+Runtime -> Installer: uvx --no-cache ... spec-dock uninstall TARGET --apply --keep-specs
+Installer -> FS: inventory managed candidates
+Installer -> FS: compare shipped assets where required
+Installer -> FS: remove / preserve / cleanup empty dirs
+Installer --> Runtime: stdout/stderr/exit code
+Runtime --> Maintainer: propagated result
+@enduml
+```
+
+## Directory / File 変更計画
 ```text
-.
-|-- src/
-|   |-- package/
-|   |   |-- new_module.py        # 追加: 目的; 依存: ...
-|   |   |-- existing_module.py   # 変更: 目的; 依存: ...
-|   |   `-- renamed_module.py    # 移動/rename 元: src/package/old_module.py; 目的
-|   `-- tests/
-|       `-- test_new_module.py   # 追加/変更: 目的; 依存: src/package/new_module.py
-|-- docs/
-|   `-- reference.md             # 読取のみ: 目的
-`-- legacy/
-    `-- obsolete_file.py         # 削除: 目的; 依存: 代替準備完了
+src/spec_dock/
+|-- cli.py
+|   `-- 変更: installer uninstall parser, inventory/action/result helpers, content comparison, apply, rendering
+|-- assets/
+|   |-- install_root/
+|   |   `-- 読取: managed agent/tooling inventory and manifest contracts
+|   `-- spec_dock/
+|       |-- docs/
+|       |   |-- reference_github.md
+|       |   |   `-- 変更: repo-local uninstall と installer CLI uninstall の GitHub 非変更 / package 非削除 contract を追記
+|       |   `-- reference_sync.md
+|       |       `-- 点検: uninstall 後に削除 / preserve する generated state の説明が必要か確認し、不要なら S90 no-op 根拠を report に記録
+|       |-- scripts/spec_dock_runtime/
+|       |   |-- commands/uninstall.py
+|       |   |   `-- 追加: thin uvx wrapper for installer uninstall
+|       |   |-- commands/update.py
+|       |   |   `-- 読取: wrapper precedent
+|       |   |-- cli/registry.py
+|       |   |   `-- 変更: register uninstall command
+|       |   `-- cli/parser.py
+|       |       `-- 変更: bind uninstall parser
+tests/
+|-- test_init_update.py
+|   `-- 変更/追加: installer uninstall behavior tests
+`-- cli_runtime/
+    `-- test_uninstall.py
+        `-- 追加: runtime uninstall wrapper tests
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001 -> installer dry-run plan/result model and renderer.
+- AC-002 -> installer parser/apply preflight requiring exactly one specs mode when `--apply`.
+- AC-003 -> `--keep-specs` action planning, agent/skill removal, specs preservation, bounded cleanup.
+- AC-004 -> `--remove-specs` action planning and explicit spec-history deletion summary.
+- AC-005 -> bootstrap-only content comparison exact-match removal.
+- AC-006 -> bootstrap-only/product-reusable mismatch preservation and manual review result.
+- AC-007 -> known managed agent/skill category removal even on mismatch; unmanaged preserve.
+- AC-008 -> runtime wrapper invoking installer CLI and propagating output/exit code.
+- AC-009 -> idempotent inventory/apply behavior with `already_removed` statuses.
+- AC-010 -> installer/runtime `--json` output contract, JSON renderer, and runtime flag forwarding.
+- EC-001 -> `_require_specdock` / target validation style fail-fast.
+- EC-002 -> dry-run does not call unlink/rmtree cleanup.
+- EC-003 -> cleanup stops when directory contains preserved file.
+- EC-004 -> cleanup traversal stops at boundary roots and never touches repo root / `.git` / parent.
+- EC-005 -> installer CLI direct retry path and runtime wrapper recovery guidance.
+- EC-006 -> comparison error preserve policy except known core agent/skill paths.
+- EC-007 -> repo-root `spec` symlink target verification.
+- EC-008 -> JSON stdout separation and parseable error/result payloads.
 
 ## テスト戦略
-- 単体:
-  - ...
-- 統合:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
+- Installer integration:
+  - dry-run has no filesystem mutation and prints removal/preserve/cleanup plan.
+  - `--apply` without specs mode fails before mutation.
+  - `--apply --keep-specs` removes known agent / skill assets and preserves `spec-dock/initiatives/**`.
+  - `--apply --remove-specs` removes spec history and reports it explicitly.
+  - bootstrap-only `.codex/config.toml` exact match is removed; mismatch is preserved.
+  - product-reusable `.github/workflows/**`, `.codex/prompts/**`, `.codex/rules/**`, `.codex/AGENTS.md` exact match is removed; mismatch is preserved.
+  - scaffold-managed `spec-dock/docs/**`, `spec-dock/templates/**`, `spec-dock/system/**`, `spec-dock/scripts/**`, `spec-dock/spec-dock.version` exact match is removed; mismatch is preserved with manual-review reason.
+  - known managed agent / skill mismatch is removed.
+  - unknown files under managed boundary roots are preserved.
+  - repo-root `spec` matching symlink is removed; nonmatching symlink / regular file / directory is preserved.
+  - empty directory cleanup stays within boundary roots and does not delete directories containing preserved files.
+  - rerun after prior removal reports already removed and exits successfully when no failed removals remain.
+  - injected unlink / permission failure returns non-zero and reports failed separately from preserved.
+  - `--json` dry-run returns parseable JSON with summary/actions/guidance and no human-readable text mixed into stdout.
+  - `--json` apply returns parseable JSON for completed and partial-failure results.
+- Runtime wrapper:
+  - default target resolves current working directory and calls `uvx --no-cache`.
+  - explicit target is resolved and passed through.
+  - supported flags are forwarded.
+  - `--json` is forwarded and JSON stdout from installer is propagated unchanged.
+  - subprocess stdout/stderr/exit code are propagated.
+  - missing `uvx` exits `127` with actionable guidance.
+- Docs impact:
+  - `reference_github.md` に uninstall が GitHub issue / remote state を変更しないこと、package/environment uninstall ではないこと、repo-local managed artifact removal であることを反映する。
+  - `reference_sync.md` は generated state (`spec-dock/.agent/**`, `spec-dock/active/**`) の説明と uninstall cleanup の関係を点検する。既存説明で足りる場合は S90 docs impact resolution で no-op 判定を記録する。
+  - runtime help / installer help は tests で command contract と一致させる。
+- Manual / dogfooding:
+  - implementation phase should inspect whether local dogfooding workspace needs `sync --no-github` or only `validate`.
 
-## 要件 / 例外 -> 検証マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
-
-## リスク / 移行 / ロールバック（必要時）
-- ...
+## リスク / 移行 / ロールバック
+- Version drift:
+  - Current package assets may differ from older installed files, preserving more files as mismatch.
+  - Mitigation: agent / skill core paths are path-owned; other mismatch files are surfaced for manual review.
+- Over-delete:
+  - Path classification bugs can remove user files.
+  - Mitigation: candidates must come from shipped inventory, manifest obsolete exact paths, explicit generated-state roots, specs mode, or exact shortcut checks.
+- Under-delete:
+  - Conservative preservation may leave product-reused prompts/configs behind.
+  - Mitigation: summary lists preserved manual-review items.
+- Self-removal:
+  - Runtime script may be removed during uninstall.
+  - Mitigation: runtime wrapper delegates to external installer process; installer CLI direct retry is documented in output.
+- Rollback:
+  - No automatic rollback after deletion.
+  - Safety relies on dry-run default, explicit apply/specs mode, exact-match preservation, result summary, and idempotent rerun.
 
 ## 未確定事項
+- none.
+
+## 解決済み質問
 - Q-001:
   - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+    - `--json` output を初回実装に含めるか。
+  - 回答:
+    - 含める。
+  - 根拠:
+    - `spec-dock uninstall` は agent が実行する可能性があるため、machine-readable output が必要。
+  - 証跡:
+    - `discussions/20260531t144040z-interview-uninstall-json-output.md`

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t133315z-interview-uninstall-command-scope.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t133315z-interview-uninstall-command-scope.md
@@ -1,0 +1,161 @@
+---
+種別: interview
+ID: "20260531t133315z-interview"
+タイトル: "Uninstall command scope"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t133315z-interview Uninstall command scope
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - `uninstall` の対象、必須スコープ、禁止スコープ、受け入れ条件が変わる。
+  - `design.md`:
+    - installer CLI 側に置くか、repo-local runtime command 側に置くか、削除対象と guardrail が変わる。
+  - `plan.md`:
+    - 実装 step、test obligation、manual verification、destructive operation の確認手順が変わる。
+  - `ADR`:
+    - 現時点では不要。長期的な install/uninstall ownership を再定義する場合のみ候補にする。
+- chat 上の軽微な一問では足りない理由:
+  - `uninstall` が削除する対象を誤ると、repo-local docs / agent tooling / Python package / user-authored files のどれを消すかが変わり、破壊的操作の安全境界に直結するため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - `spec-dock uninstall` の primary goal が、導入済み repo から spec-dock 管理物を外すことなのか、実行環境から spec-dock package / CLI 自体を外すことなのかを確定する。
+- 回答が後続判断へ与える影響:
+  - command placement、削除対象、confirmation UX、tests、docs、rollback guidance の前提になる。
+
+## 質問 (必須)
+- 質問:
+  - `uninstall` コマンドの主目的は、どちらですか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があればその削除対象と残す対象を明示してください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `spec-dock/active/issue/requirement.md`: 現 issue は template scaffold で、scope / acceptance criteria は未固定。
+  - `spec-dock/active/epic/requirement.md`: `epic-00054` は close / local delete / repo-local self-update を lifecycle command expansion として扱い、destructive guardrail と docs/tests 整備を要求している。
+  - `spec-dock/active/epic/design.md`: existing relation として installer `update` はあるが repo-local runtime command の導線が gap とされ、delete は local tree destructive operation、self-update は installer wrapper として分離されている。
+  - `src/spec_dock/cli.py`: package entrypoint 側に `init` / `update` があり、managed scaffold と install_root assets を target repo へ同期する。
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`: repo-local runtime command から installer update を呼び出す command surface がある。
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/delete.py` and `application/delete_node.py`: local spec node delete は既存 capability として存在する。
+  - `tests/test_init_update.py`, `tests/cli_runtime/test_update.py`, `tests/cli_runtime/test_delete.py`: installer update、runtime update、delete の regression surface が分かれている。
+- local context で解決できたこと:
+  - 既存の lifecycle epic は repo-local command と installer command の両方を扱っているが、`uninstall` という語が指す対象はまだ canonical docs で定義されていない。
+  - 既存の `delete` は spec node 削除であり、spec-dock workspace / installed agent assets / root shortcut / package installation の removal とは別概念。
+- まだ人間判断が必要な理由:
+  - 「spec-dock 自体を自分自身をアンインストールする」という表現は、repo 内の導入物の削除とも、実行中の package / CLI の削除とも読める。どちらを product goal にするかは実装調査だけでは決められない。
+
+## 回答案 (必須)
+- Option A:
+  - repo-local uninstall: 対象 repo から `spec-dock/` workspace、repo-root shortcut、installer-managed agent/tooling assets を安全に取り外す。Python package / uvx cache / global executable は削除しない。
+- Option B:
+  - package/environment uninstall: 現在の実行環境から `spec-dock` package / executable / cache を削除することを主目的にする。target repo の `spec-dock/` workspace 削除は別機能にする。
+- Option C:
+  - two-layer uninstall: `spec-dock uninstall` は repo-local removal を標準にし、別 flag または別導線で package/environment removal guidance を扱う。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - 誤削除リスク、ユーザーが期待する「自分自身」の意味、既存 `init` / `update` / `delete` との責務境界、テスト可能性、rollback guidance。
+- tradeoff:
+  - repo-local removal は既存 installer-managed asset model と整合しやすく、hermetic tests も書きやすい。一方で package 自体は残るため「CLI を環境から消す」期待には応えない。
+  - package/environment removal は「自己アンインストール」に近いが、install method が uvx / pip / editable install / system package などで変わり、実行中 process が自分の配布元を削除する境界が不安定になりやすい。
+  - two-layer uninstall は期待を広く拾えるが、初回 issue としては scope が広がり、destructive guardrail と docs が重くなる。
+- リスク:
+  - managed/unmanaged 境界が未定義のまま repo-local removal を実装すると、user-authored docs や agent files を削除する危険がある。
+  - package/environment removal を自動化すると、インストール方法ごとの差異、権限、cache、shell path の副作用を扱う必要がある。
+- 具体シナリオ / edge case:
+  - 既存 repo で `spec-dock/initiatives/**` に長期的な仕様履歴がある場合、標準 uninstall がそれを削除してよいか、archive / dry-run / confirmation を要求するか。
+  - `.agents/skills/` や `.codex/config.toml` に user edit がある場合、installer-managed と bootstrap/user-owned の境界をどう扱うか。
+  - `uvx --from git+... spec-dock uninstall .` のような one-shot 実行では package は元々永続 install されていないため、environment uninstall の意味が薄い。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option A を第一候補にする。必要なら docs で「package / environment uninstall は自動削除せず、install method 別の案内に留める」と明記する。
+- 理由:
+  - `init` / `update` が target repo に scaffold / managed assets を入れる機能なので、その反対操作として repo-local uninstall を定義すると責務が自然で、既存 epic の lifecycle command expansion とも整合する。
+  - package/environment removal は install method 依存が強く、初回実装で自動化すると安全境界が大きくなる。
+- 未回答時の影響:
+  - requirement の scope / non-scope と acceptance criteria を固定できず、design / plan に進めない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option A を採用する。
+  - 主目的は、対象 repo から `spec-dock/` workspace や managed agent/tooling assets を安全に取り外すことである。
+  - Python package / global CLI / uvx cache など実行環境側の `spec-dock` 削除は主目的にしない。
+  - 背景意図:
+    - SpecDock はプロダクト開発のための機能群を提供する。
+    - ある程度開発が完了した後は、開発用の sub-agent 設定や agent skill が不要になる。
+    - sub-agent 稼働がプロダクト本体になる second brain / LLM wiki のような repo では、SpecDock の sub-agent や skill がノイズになる。
+    - そのような repo では、開発用 sub-agent 設定や開発用 skill を取り除ける必要がある。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - repo-local uninstall で、`spec-dock/initiatives/**` に蓄積された仕様履歴も削除対象に含めるか、開発用 agent/tooling だけを削除して仕様履歴は残すか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、`uninstall` の primary goal は repo-local removal と確定した。
+  - 実行環境の package / executable / cache 削除は install method 依存が強く、今回の主目的から外す。
+  - 開発完了後の product repo から、開発用 sub-agent / skill / tooling noise を取り除くことを中心の outcome とする。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - `uninstall` の目的を「対象 repo から SpecDock-managed development tooling / agent assets を安全に取り除く」として固定する。
+  - package/environment uninstall は対象外または docs guidance に限定する。
+  - 利用シナリオに、開発完了後の product repo と、sub-agent/skill が product noise になる second brain / LLM wiki 型 repo を含める。
+- `design.md`:
+  - installer-managed asset model、bootstrap-only / user-owned boundary、repo-local destructive guardrail を中心に設計する。
+  - runtime command と installer command のどちらに置くかは、repo-local target removal と managed asset inventory を踏まえて設計で固定する。
+- `plan.md`:
+  - managed agent/tooling asset removal、dry-run / confirmation、user-authored file preservation、docs/tests parity を implementation step 候補にする。
+- `ADR`:
+  - 現時点では不要。install/uninstall ownership を長期 contract として再定義する必要が出た場合のみ ADR を検討する。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t133616z-interview-uninstall-removal-boundary.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t133616z-interview-uninstall-removal-boundary.md
@@ -1,0 +1,157 @@
+---
+種別: interview
+ID: "20260531t133616z-interview"
+タイトル: "Uninstall removal boundary"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t133616z-interview Uninstall removal boundary
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - 削除対象、残す対象、受け入れ条件、禁止事項が変わる。
+  - `design.md`:
+    - managed asset inventory に基づく削除範囲、confirmation、dry-run、archive / preserve 方針が変わる。
+  - `plan.md`:
+    - tests、manual verification、rollback guidance、step 分割が変わる。
+  - `ADR`:
+    - 現時点では不要。仕様履歴を保存する長期ポリシーを別 product contract にする場合のみ候補にする。
+- chat 上の軽微な一問では足りない理由:
+  - `spec-dock/initiatives/**` は開発中の仕様履歴そのものであり、削除するか残すかは irreversible data loss と product handoff の両方に関わるため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - repo-local uninstall の削除対象に、SpecDock の仕様履歴 workspace (`spec-dock/initiatives/**`) を含めるかどうかを確定する。
+- 回答が後続判断へ与える影響:
+  - command のデフォルト挙動、`--include-specs` / `--keep-specs` のような option 要否、confirmation wording、tests、docs warning が変わる。
+
+## 質問 (必須)
+- 質問:
+  - repo-local uninstall は、`spec-dock/initiatives/**` にある仕様履歴も削除対象に含めますか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があれば「標準で消すもの」「明示 flag でだけ消すもの」「常に残すもの」を教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `20260531t133315z-interview-uninstall-command-scope.md`: primary goal は Option A の repo-local uninstall として user-approved。
+  - `src/spec_dock/cli.py`: `init` / `update` は managed scaffold と install_root assets を target repo に同期し、`spec-dock/initiatives/**` は persistent user/product data として扱うコメントがある。
+  - `spec-dock/active/epic/requirement.md`: delete 操作は destructive guardrail を持ち、silent / implicit に実行しないことを要求している。
+  - `spec-dock/active/epic/design.md`: local delete は local directory removal を伴う destructive operation として扱う。
+- local context で解決できたこと:
+  - 開発用 agent/tooling noise を消す目的は確定した。
+  - ただし `spec-dock/` 配下には agent/tooling だけでなく、仕様履歴、active/generated state、docs/templates/scripts が混在している。
+- まだ人間判断が必要な理由:
+  - 開発完了後の product repo に仕様履歴を残したいか、プロダクトから完全に SpecDock の痕跡を消したいかは product policy の判断であり、コードからは決められない。
+
+## 回答案 (必須)
+- Option A:
+  - keep specs by default: uninstall は開発用 agent/tooling と runtime/scaffold を取り除くが、`spec-dock/initiatives/**` の仕様履歴は標準では残す。仕様履歴削除は別 flag / 別 command / 手動案内にする。
+- Option B:
+  - remove all by default: uninstall は `spec-dock/` workspace 全体と managed agent/tooling assets を標準で削除し、仕様履歴も含めて repo から取り除く。
+- Option C:
+  - dry-run first with explicit mode: 標準実行は dry-run / plan 表示にし、実削除時に `--keep-specs` または `--remove-specs` の明示選択を必須にする。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - data loss risk、開発完了後の product cleanliness、agent/tooling noise の除去、仕様履歴の監査価値、CLI UX の単純さ。
+- tradeoff:
+  - Option A は仕様履歴を守りやすいが、repo に `spec-dock/initiatives/**` が残るため「完全に消えた」感は弱い。
+  - Option B は product repo を最もきれいにできるが、仕様履歴の irreversible deletion になる。
+  - Option C は安全だが、初回 UX が少し重くなる。
+- リスク:
+  - Option B を default にすると、確認不足で仕様履歴を失うリスクが高い。
+  - Option A でも `spec-dock/` のうち何を残すかが曖昧だと、中途半端な broken workspace が残る可能性がある。
+- 具体シナリオ / edge case:
+  - 開発完了後も将来の仕様参照や監査のために `spec-dock/initiatives/**` を残したい repo。
+  - second brain / LLM wiki のように `.agents/`, `.codex/`, `.github/agents/`, `.agents/skills/` から開発用 agent を消したいが、spec docs は archive として残してよい repo。
+  - OSS 配布前に SpecDock の痕跡を repo から完全に消したい repo。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option C、または Option A を default にして仕様履歴削除だけは明示 flag にする。
+- 理由:
+  - ユーザー意図の中心は agent/skill noise の除去であり、仕様履歴削除までは明示されていない。
+  - `spec-dock/initiatives/**` は product development history なので、default destructive deletion は避ける方が安全。
+- 未回答時の影響:
+  - requirement の削除対象と禁止事項を固定できず、design / plan に進めない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option C を採用する。
+  - `uninstall` は標準で dry-run / plan 表示を行い、実削除時は `--keep-specs` または `--remove-specs` のように仕様履歴を残すか削除するかの明示選択を必須にする。
+  - 一度 uninstall した後でも、開発再開や機能追加のために再び install する可能性がある。その場合、これまでの仕様書群が失われていると再開が困難になる。
+  - 一方で、使い捨ての tool や今後の機能追加を想定しない repo では、仕様履歴も削除してしまった方がよい場合がある。
+  - 主目的は、agent / skill など、エージェント稼働時にノイズになる開発用 tooling を取り除くことである。
+  - そのため、仕様履歴の扱いは選択可能にし、かつ実削除時の選択を必須にする。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - repo-local uninstall で、managed agent/tooling assets のうち user edit が入りうる bootstrap-only / user-owned files をどう扱うか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、仕様履歴の扱いは command 実行時に明示選択させる方針で確定した。
+  - 開発再開可能性がある repo では specs preservation が必要であり、使い捨て repo では specs removal が有用であるため、default implicit deletion / preservation のどちらにも寄せない。
+  - uninstall の primary objective は開発用 agent/skill noise の除去であり、仕様履歴削除は選択可能な secondary destructive scope として扱う。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - uninstall は dry-run / plan 表示を標準挙動に含める。
+  - 実削除時は specs を残すか削除するかの明示 option を必須にする。
+  - `--keep-specs` 系は開発再開可能性を維持する path、`--remove-specs` 系は使い捨て repo / 完全 cleanup path として扱う。
+  - agent / skill noise removal は primary objective、spec history removal は explicit user choice として分離する。
+- `design.md`:
+  - dry-run plan、confirmation、`keep-specs` / `remove-specs` mode、削除対象 inventory、rollback / reinstall guidance を設計対象にする。
+  - specs preservation mode では broken workspace を残さないため、残す specs と取り除く runtime/tooling/scaffold の境界を明確にする。
+- `plan.md`:
+  - dry-run / explicit mode validation / keep-specs removal / remove-specs removal / reinstall-resume scenario を step と test obligation に含める。
+- `ADR`:
+  - 現時点では不要。uninstall mode が将来の product lifecycle policy へ広がる場合のみ検討する。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134004z-interview-uninstall-user-owned-asset-boundary.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134004z-interview-uninstall-user-owned-asset-boundary.md
@@ -1,0 +1,154 @@
+---
+種別: interview
+ID: "20260531t134004z-interview"
+タイトル: "Uninstall user owned asset boundary"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t134004z-interview Uninstall user owned asset boundary
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - uninstall が消す managed assets と残す user-owned / bootstrap-only files の境界が変わる。
+  - `design.md`:
+    - manifest inventory、content match / ownership 判定、dry-run 表示、manual cleanup guidance が変わる。
+  - `plan.md`:
+    - test obligation と edge case が変わる。
+  - `ADR`:
+    - 現時点では不要。user-owned config の所有権を installer 全体で再定義する場合のみ候補にする。
+- chat 上の軽微な一問では足りない理由:
+  - `.codex/config.toml` などは開発用 agent を動かす入口であり uninstall の目的に近い一方、既存 installer では bootstrap-only として user edit を尊重しているため、誤削除すると user-owned repo config を失う可能性がある。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - uninstall が bootstrap-only / user-owned になり得る files を自動削除するか、標準では残して案内に留めるかを確定する。
+- 回答が後続判断へ与える影響:
+  - managed asset removal の安全境界、dry-run plan の分類、confirmation wording、tests が変わる。
+
+## 質問 (必須)
+- 質問:
+  - uninstall は、`.codex/config.toml` のように spec-dock が初回作成するが user edit が入り得る bootstrap-only / user-owned files を、自動削除対象に含めますか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があれば「自動削除する条件」と「残して案内する条件」を教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `20260531t133315z-interview-uninstall-command-scope.md`: repo-local uninstall が user-approved。
+  - `20260531t133616z-interview-uninstall-removal-boundary.md`: specs の扱いは explicit mode selection が user-approved。
+  - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`: `managed_assets.bootstrap_only_exact_file_paths` に `.codex/config.toml` が定義されている。
+  - `src/spec_dock/cli.py`: bootstrap-only target は update 時に既存 file があると copy を skip し、user edit を上書きしない。
+  - `src/spec_dock/assets/install_root/`: `.agents/skills/**`, `.codex/agents/**`, `.github/agents/**`, `.codex/prompts/**`, `.codex/rules/**`, `.github/workflows/ci.yml` などが current install_root asset として存在する。
+- local context で解決できたこと:
+  - current managed files と bootstrap-only files は installer metadata で区別されている。
+  - uninstall の primary objective は agent / skill noise の除去だが、bootstrap-only files は user edit を含む可能性がある。
+- まだ人間判断が必要な理由:
+  - product repo から開発用 agent 起動設定を確実に取り除くことと、user-owned config を保護することの優先順位は product policy で決める必要がある。
+
+## 回答案 (必須)
+- Option A:
+  - preserve bootstrap-only by default: `.codex/config.toml` など bootstrap-only / user-owned files は自動削除しない。dry-run に「manual review / optional cleanup」として表示する。
+- Option B:
+  - remove if content matches shipped asset: bootstrap-only files でも、現在の shipped asset と content が一致する場合だけ自動削除し、差分がある場合は残す。
+- Option C:
+  - explicit flag required: bootstrap-only / user-owned files の削除は `--remove-user-owned` のような追加明示 flag がある場合だけ行い、通常 uninstall では残す。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - agent noise removal の完全性、user edit 保護、実装の判定可能性、dry-run の分かりやすさ、再install時の復元性。
+- tradeoff:
+  - Option A は user data loss を避けやすいが、`.codex/config.toml` に SpecDock orchestrator 設定が残ると noise removal が不完全になる可能性がある。
+  - Option B は content match で安全に消せる範囲を広げるが、version drift や過去 asset との比較が難しい場合がある。
+  - Option C はもっとも明示的だが、flag が増えて UX は重くなる。
+- リスク:
+  - bootstrap-only file を無条件削除すると、ユーザーが追加した project config を失う。
+  - 残しすぎると、SpecDock uninstall 後も agent 起動設定が残り、今回の目的である noise removal が達成されない。
+- 具体シナリオ / edge case:
+  - `.codex/config.toml` が install 直後のままなら削除してよい repo。
+  - `.codex/config.toml` に product 固有の Codex 設定が追記されており、SpecDock 部分だけ取り除きたい repo。
+  - `.github/workflows/ci.yml` が SpecDock 由来だが product CI として使われ始めている repo。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option B を基本にし、content mismatch は削除せず dry-run / report で manual review に回す。
+- 理由:
+  - shipped asset と完全一致する bootstrap-only file は user edit がないと判断しやすく、noise removal の目的にも合う。
+  - 差分がある file を残せば user-owned config の誤削除を避けられる。
+- 未回答時の影響:
+  - requirement の deletion boundary と edge case を固定できず、design / plan に進めない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option B を採用する。
+  - `.codex/config.toml` のような bootstrap-only / user-owned になり得る files は、shipped asset と内容が完全一致する場合だけ自動削除する。
+  - 内容に差分がある場合は user edit が入っている可能性があるため削除せず、dry-run / report で残存理由と manual review 対象として示す。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - uninstall command surface を installer CLI に置くか、repo-local runtime command に置くか、または両方に置くか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、bootstrap-only / user-owned になり得る files の削除境界は content match based removal として確定した。
+  - shipped asset と一致する file は user edit がないと判断しやすく、agent / skill noise removal の目的に合う。
+  - content mismatch file は user-owned config を含む可能性があるため、自動削除せず manual review に回す。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - bootstrap-only / user-owned になり得る files は、shipped asset と content match する場合だけ自動削除する。
+  - content mismatch の files は削除せず、dry-run / execution result に manual review 対象として表示する。
+  - agent / skill noise removal と user edit protection の両立を非交渉制約に含める。
+- `design.md`:
+  - uninstall inventory は current managed file、obsolete managed file、bootstrap-only file を分類し、bootstrap-only file は content comparison で削除可否を判定する。
+  - content mismatch は preserve + report にする。
+- `plan.md`:
+  - shipped asset match の bootstrap-only file removal、content mismatch preservation、dry-run reporting を test obligation に含める。
+- `ADR`:
+  - 現時点では不要。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134206z-interview-uninstall-command-surface.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134206z-interview-uninstall-command-surface.md
@@ -1,0 +1,155 @@
+---
+種別: interview
+ID: "20260531t134206z-interview"
+タイトル: "Uninstall command surface"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t134206z-interview Uninstall command surface
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - ユーザーが実行する command surface と受け入れ条件が変わる。
+  - `design.md`:
+    - installer CLI / repo-local runtime wrapper / self-deleting command の責務境界が変わる。
+  - `plan.md`:
+    - 実装対象ファイル、tests、manual verification が変わる。
+  - `ADR`:
+    - 現時点では不要。installer/runtime command ownership を広く再定義する場合のみ候補にする。
+- chat 上の軽微な一問では足りない理由:
+  - uninstall は repo-local runtime 自体を削除し得るため、どの executable から実行するかが安全性と再実行性に直結する。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - `uninstall` を installer CLI、repo-local runtime command、または両方に提供するかを確定する。
+- 回答が後続判断へ与える影響:
+  - command UX、self-delete の扱い、target path の default、tests、docs guidance が変わる。
+
+## 質問 (必須)
+- 質問:
+  - `uninstall` コマンドの入口はどれにしたいですか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があれば主導線と補助導線を教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `src/spec_dock/cli.py`: installer entrypoint は `spec-dock init` / `spec-dock update [path]` を持つ。
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`: repo-local runtime command は installer update を wrapper として呼び出す導線を持つ。
+  - `spec-dock/active/epic/requirement.md`: repo-local runtime self-update command は long-form `uvx` invocation への依存を減らす operator value として定義されている。
+  - `spec-dock/active/epic/design.md`: self-update は installer update の wrapper として扱う。
+  - `20260531t133315z-interview-uninstall-command-scope.md`: uninstall の primary goal は repo-local removal。
+  - `20260531t133616z-interview-uninstall-removal-boundary.md`: specs handling は explicit mode selection。
+  - `20260531t134004z-interview-uninstall-user-owned-asset-boundary.md`: bootstrap-only / user-owned files は content match based removal。
+- local context で解決できたこと:
+  - installer CLI は target repo を外から操作できるため、自分が削除される repo-local runtime に依存しない。
+  - repo-local runtime command は operator にとって discoverable だが、実行中に `spec-dock/scripts/spec-dock` を削除し得る self-removal path になる。
+- まだ人間判断が必要な理由:
+  - product UX と安全性のどちらを主導線にするかは仕様判断であり、既存コードだけでは決められない。
+
+## 回答案 (必須)
+- Option A:
+  - installer CLI only: `spec-dock uninstall [path]` を package entrypoint に追加し、repo-local runtime command は追加しない。
+- Option B:
+  - runtime wrapper + installer implementation: `./spec-dock/scripts/spec-dock uninstall` を operator-facing 入口にし、内部で installer `spec-dock uninstall <target>` を呼ぶ。installer CLI も直接利用可能にする。
+- Option C:
+  - runtime command only: repo-local `./spec-dock/scripts/spec-dock uninstall` だけを追加し、package entrypoint には追加しない。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - discoverability、self-delete safety、再実行性、既存 `update` との一貫性、testability。
+- tradeoff:
+  - Option A は安全で実装が単純だが、repo 内から `./spec-dock/scripts/spec-dock uninstall` を見つける体験はない。
+  - Option B は `update` と同じ wrapper pattern にでき、operator-facing UX もよい。一方で、runtime wrapper が自分の file を削除する可能性を考慮した subprocess / ordering が必要になる。
+  - Option C は discoverable だが、uninstall 後に同じ command が消えるため再実行・失敗復旧の導線が弱い。
+- リスク:
+  - runtime command only にすると、途中失敗後に runtime script が消えた場合の復旧案内が難しくなる。
+  - installer only にすると、既存 self-update と command surface の一貫性が弱くなる。
+- 具体シナリオ / edge case:
+  - 開発完了時に repo 内で `./spec-dock/scripts/spec-dock uninstall --keep-specs` を実行したい。
+  - uninstall 後、再開発のために `uvx --from ... spec-dock init/update .` で再導入したい。
+  - uninstall が途中失敗した場合、package entrypoint `spec-dock uninstall .` で再試行したい。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option B。
+- 理由:
+  - repo-local command と installer command の両方を持つと、通常利用では discoverable で、失敗復旧や再実行では外側の installer CLI を使える。
+  - 既存 `update` の「repo-local wrapper が installer を呼ぶ」設計とそろう。
+- 未回答時の影響:
+  - requirement の command UX と design の責務境界を固定できず、plan に進めない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option B を採用する。
+  - `./spec-dock/scripts/spec-dock uninstall` を通常の repo-local operator-facing 入口にする。
+  - repo-local runtime command は installer `spec-dock uninstall <target>` を呼ぶ wrapper として扱う。
+  - installer CLI `spec-dock uninstall [path]` も直接利用可能にし、uninstall 途中失敗や repo-local runtime が失われた後の再実行 / 復旧導線にする。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - current managed assets も content match based removal にするか、manifest-managed であれば差分があっても削除するか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、command surface は runtime wrapper + installer implementation の二層構成で確定した。
+  - 通常利用では repo-local command として discoverable にし、失敗復旧や再実行では installer CLI から target repo を外側から操作できるようにする。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - `./spec-dock/scripts/spec-dock uninstall` を主導線、`spec-dock uninstall [path]` を直接導線 / 復旧導線として要求に含める。
+  - repo-local runtime wrapper は installer implementation を呼び出す。
+- `design.md`:
+  - installer CLI に uninstall 実処理を置き、runtime command は self-update と同様に installer wrapper として設計する。
+  - runtime script 自体が削除対象になり得るため、削除順序、subprocess invocation、失敗時の installer direct retry guidance を設計する。
+- `plan.md`:
+  - installer CLI uninstall、runtime wrapper uninstall、self-removal / failure recovery guidance の tests と manual verification を含める。
+- `ADR`:
+  - 現時点では不要。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134650z-interview-uninstall-managed-asset-mismatch.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t134650z-interview-uninstall-managed-asset-mismatch.md
@@ -1,0 +1,154 @@
+---
+種別: interview
+ID: "20260531t134650z-interview"
+タイトル: "Uninstall managed asset mismatch"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t134650z-interview Uninstall managed asset mismatch
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - uninstall が current managed files を削除する条件と manual review 条件が変わる。
+  - `design.md`:
+    - content comparison、manifest ownership、mismatch reporting、directory cleanup の設計が変わる。
+  - `plan.md`:
+    - tests / edge cases / dry-run expected output が変わる。
+  - `ADR`:
+    - 現時点では不要。
+- chat 上の軽微な一問では足りない理由:
+  - `.agents/skills/**` や `.codex/agents/**` は SpecDock 由来の開発用 noise だが、`.github/workflows/ci.yml` などは repo 側で編集・流用される可能性もあり、差分がある file を自動削除するかは data loss risk に関わるため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - install_root の current managed files について、shipped asset と内容が違う場合も uninstall で削除するか、残して manual review に回すかを確定する。
+- 回答が後続判断へ与える影響:
+  - managed asset removal の安全性、noise removal の完全性、dry-run / report の分類、tests が変わる。
+
+## 質問 (必須)
+- 質問:
+  - uninstall は、current managed asset として manifest / install_root に含まれる file でも、現在の shipped asset と内容が異なる場合は自動削除しますか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があれば「差分あり managed file」の扱いを教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `src/spec_dock/assets/install_root/`: current managed assets として `.agents/skills/**`, `.codex/agents/**`, `.github/agents/**`, `.codex/prompts/**`, `.codex/rules/**`, `.github/workflows/ci.yml` が含まれる。
+  - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`: bootstrap-only は `.codex/config.toml` のみで、obsolete exact paths も定義されている。
+  - `src/spec_dock/cli.py`: update は current managed files を source asset から copy する。bootstrap-only は既存 file がある場合 skip する。
+  - `20260531t134004z-interview-uninstall-user-owned-asset-boundary.md`: bootstrap-only / user-owned files は content match based removal として user-approved。
+- local context で解決できたこと:
+  - update semantics 上、current managed files は installer-owned として扱われる。
+  - ただし uninstall は destructive removal であり、current managed files に user edits や product reuse がある場合の扱いは別途決める必要がある。
+- まだ人間判断が必要な理由:
+  - noise removal を優先して managed file を強く消すか、user edit protection を優先して mismatch を残すかは product policy である。
+
+## 回答案 (必須)
+- Option A:
+  - manifest-owned removal: current managed file は内容差分があっても自動削除する。installer-owned なので uninstall は強く取り除く。
+- Option B:
+  - content-match removal: current managed file も shipped asset と完全一致する場合だけ削除し、差分がある場合は残して manual review に回す。
+- Option C:
+  - category-based removal: `.agents/skills/**`, `.codex/agents/**`, `.github/agents/**` のような agent/skill noise は差分があっても削除し、`.github/workflows/ci.yml` や config/rules/prompts は content mismatch の場合だけ残す。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - uninstall の目的達成度、user edit protection、implementation complexity、dry-run の説明しやすさ、再install後の復元性。
+- tradeoff:
+  - Option A は開発用 noise を最も確実に取り除くが、編集済み managed file を失う可能性がある。
+  - Option B はもっとも安全だが、編集済み agent file が残って noise removal が不完全になる可能性がある。
+  - Option C は目的に沿いやすいが、category rule が増え、将来 asset 追加時に分類が必要になる。
+- リスク:
+  - 差分あり agent file を残すと、uninstall 後も sub-agent / skill が discovery され続ける。
+  - 差分あり CI / config / prompt file を消すと、product repo の運用設定を失う。
+- 具体シナリオ / edge case:
+  - product repo が `.github/workflows/ci.yml` を SpecDock 由来から編集して流用している。
+  - `.codex/agents/spec-manager.toml` をユーザーが調整しているが、uninstall の目的上は残るとノイズになる。
+  - `.agents/skills/spec-dock-issue-planning/SKILL.md` が編集されているが、product の runtime agent には不要。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option C。
+- 理由:
+  - 今回の primary objective は agent / skill noise removal なので、agent and skill assets は強く削除する方が目的に合う。
+  - 一方で CI / config / prompt / rule のように product repo へ流用されやすいものは、content mismatch を preserve した方が安全。
+- 未回答時の影響:
+  - requirement の削除条件と design の inventory classification を固定できず、plan に進めない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option C を採用する。
+  - `.agents/skills/**`, `.codex/agents/**`, `.github/agents/**` のような agent / skill assets は、現在の shipped asset と内容が異なる場合でも uninstall で削除する。
+  - CI / config / prompt / rule のように product repo へ流用されやすい files は、現在の shipped asset と内容が異なる場合は自動削除せず、manual review 対象として残す。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - uninstall 実行後、削除された agent / skill / runtime files に由来する空 directory を自動削除するか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、current managed asset mismatch の扱いは category-based removal として確定した。
+  - primary objective である agent / skill noise removal を優先し、agent / skill assets は content mismatch があっても削除する。
+  - product repo へ流用されやすい CI / config / prompt / rule などは content mismatch 時に preserve し、user edit や product-specific adaptation の誤削除を避ける。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - agent / skill assets は uninstall の core removal target とし、content mismatch があっても削除対象にする。
+  - CI / config / prompt / rule など product reuse 可能な assets は、content match する場合だけ自動削除し、mismatch は preserve + manual review にする。
+  - dry-run / execution result は removed / preserved-manual-review / skipped を分類して表示する。
+- `design.md`:
+  - uninstall inventory は category-based に分類し、agent / skill paths と product-reusable paths を分ける。
+  - content comparison は product-reusable paths と bootstrap-only paths の自動削除判定に使う。
+  - mismatch preservation と manual review reporting を設計対象にする。
+- `plan.md`:
+  - content mismatch agent / skill removal、content mismatch CI/config/prompt/rule preservation、dry-run reporting を test obligation に含める。
+- `ADR`:
+  - 現時点では不要。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t135206z-interview-uninstall-empty-directory-cleanup.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t135206z-interview-uninstall-empty-directory-cleanup.md
@@ -1,0 +1,153 @@
+---
+種別: interview
+ID: "20260531t135206z-interview"
+タイトル: "Uninstall empty directory cleanup"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00147"
+created_at: "2026-05-31THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t135206z-interview Uninstall empty directory cleanup
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - uninstall 後に repo に残る empty directory の扱いと受け入れ条件が変わる。
+  - `design.md`:
+    - cleanup traversal、scope boundary、preserved file を含む directory の扱いが変わる。
+  - `plan.md`:
+    - filesystem tests と manual verification が変わる。
+  - `ADR`:
+    - 不要。
+- chat 上の軽微な一問では足りない理由:
+  - uninstall の目的は agent / skill noise removal だが、空の `.agents/skills`, `.codex/agents`, `.github/agents` などが残ると、実行結果が中途半端に見える。一方で親 directory を強く消しすぎると unrelated user files を巻き込む可能性があるため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - spec-dock maintainer / product owner
+- 何を明確にする質問か:
+  - uninstall が削除対象 files の親 directory をどこまで自動 cleanup するかを確定する。
+- 回答が後続判断へ与える影響:
+  - filesystem mutation boundary、tests、dry-run output、risk wording が変わる。
+
+## 質問 (必須)
+- 質問:
+  - uninstall 後、削除対象 file に由来する空 directory は自動削除しますか？
+- 回答してほしいこと:
+  - Option A / B / C から選ぶか、別案があれば cleanup の上限 directory を教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - `20260531t133315z-interview-uninstall-command-scope.md`: repo-local uninstall が user-approved。
+  - `20260531t133616z-interview-uninstall-removal-boundary.md`: specs handling は explicit mode selection が user-approved。
+  - `20260531t134650z-interview-uninstall-managed-asset-mismatch.md`: agent / skill assets は content mismatch でも削除する方針が user-approved。
+  - `src/spec_dock/assets/install_root/`: managed assets は `.agents/skills/**`, `.codex/agents/**`, `.github/agents/**`, `.codex/prompts/**`, `.codex/rules/**`, `.github/workflows/ci.yml` など複数 directory に配置される。
+- local context で解決できたこと:
+  - file 削除だけでは empty directory が残り得る。
+  - preserved mismatch files や user-authored files が残る directory は削除してはいけない。
+- まだ人間判断が必要な理由:
+  - きれいな uninstall 結果を優先するか、directory cleanup の副作用最小化を優先するかは product policy で決める必要がある。
+
+## 回答案 (必須)
+- Option A:
+  - file-only: files だけ削除し、空 directory cleanup はしない。
+- Option B:
+  - bounded empty-dir cleanup: 削除対象 file の親から上に向かって、空になった directory だけ削除する。ただし `.agents`, `.codex`, `.github`, `spec-dock` など既定の上限 root を越えない。
+- Option C:
+  - remove known empty roots: `.agents/skills`, `.codex/agents`, `.github/agents` など既知の managed directory が空なら root ごと削除するが、それ以外は残す。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - cleanup の見た目、副作用の小ささ、実装単純性、user-authored file 保護、dry-run の説明しやすさ。
+- tradeoff:
+  - Option A は最も安全だが、empty directory が残りやすい。
+  - Option B はきれいに片付くが、上限 root と traversal 条件を正しく設計する必要がある。
+  - Option C は分かりやすいが、新しい managed directory が増えたとき追従が必要になる。
+- リスク:
+  - cleanup traversal が強すぎると unrelated empty directory を消す。
+  - cleanup しないと uninstall 後に agent / skill directory が残り、ノイズ除去の完了感が弱い。
+- 具体シナリオ / edge case:
+  - `.github/agents/` が空になったが `.github/workflows/ci.yml` は残る。
+  - `.codex/agents/` は空になったが `.codex/config.toml` は content mismatch で残る。
+  - `.agents/skills/` は空になったが `.agents/host-adapters/meta.json` が残る / 消える。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option B。
+- 理由:
+  - preserved files がある directory は残しつつ、uninstall で空になった managed directory だけを片付けられる。
+  - dry-run で removed-directories として表示すれば副作用も追いやすい。
+- 未回答時の影響:
+  - requirement の filesystem cleanup acceptance と design の cleanup traversal を固定できない。
+
+## ユーザー回答 (回答後に必須)
+- 回答:
+  - Option B を採用する。
+  - 削除対象 file の親 directory から上に向かって、空になった directory だけを自動削除する。
+  - ただし `.agents`, `.codex`, `.github`, `spec-dock` など既定の上限 root を越えて cleanup しない。
+  - preserved file、user-authored file、content mismatch で残した file がある directory は削除しない。
+- 回答日時:
+  - 2026-05-31
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - no
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - none
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- 採用 / 棄却 / deferred の理由:
+  - ユーザー回答により、uninstall 後の empty directory cleanup は bounded cleanup として確定した。
+  - uninstall で空になった managed directory を片付け、agent / skill noise removal の完了感を高める。
+  - 上限 root を設けることで、unrelated directory cleanup や user-authored file の巻き込みを避ける。
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - uninstall は削除対象 files の removal 後、既定上限 root 内で空になった directory を自動 cleanup する。
+  - preserved files がある directory は削除しない。
+- `design.md`:
+  - cleanup traversal は削除対象 file の親から開始し、configured boundary root を越えない。
+  - removed directories を dry-run / execution result に表示する。
+- `plan.md`:
+  - empty directory cleanup、boundary root preservation、preserved file がある directory の非削除を test obligation に含める。
+- `ADR`:
+  - 不要。
+- reflected_to 更新方針:
+  - requirement authoring 時に `requirement.md` と `report.md` の Evidence Adoption Ledger / Spec Authoring Gate へ反映する。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141121z-research-uninstall-repo-analysis-evidence.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141121z-research-uninstall-repo-analysis-evidence.md
@@ -1,0 +1,105 @@
+---
+種別: research
+ID: "20260531t141121z-research"
+タイトル: "Uninstall repo analysis evidence"
+状態: "completed"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+authority: "synthesized"
+derived_from:
+  - repo-analyst notification 019e7e57-f09b-7130-8a31-83b851a68d71
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t141121z-research Uninstall repo analysis evidence
+
+## 調査目的
+- `spec-dock uninstall` の要件定義に必要な、既存 installer / runtime / managed asset inventory / test surface / self-removal risk を source-grounded に整理する。
+- repo-analyst sub-agent の read-only findings を、phase promotion で参照できる durable discussion evidence として固定する。
+
+## sources / 調査方法
+- 参照先:
+  - `src/spec_dock/cli.py`
+  - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`
+  - `src/spec_dock/assets/install_root/`
+  - `src/spec_dock/assets/spec_dock/scripts/spec-dock`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `tests/test_init_update.py`
+  - `tests/cli_runtime/test_update.py`
+  - `tests/cli_runtime/test_runtime_shell_s11.py`
+- 検証手順:
+  - repo-analyst が read-only で source paths と implementation/test surface を確認。
+  - orchestrator が requirement へ採用する事実だけをこの research に再記述。
+- 実験条件:
+  - code edit / command mutation は行っていない。
+
+## facts / 観測できた事実
+- installer CLI の正本は `src/spec_dock/cli.py` であり、現行 package entrypoint は `init` / `update` を持つ。
+- installer は `spec-dock/` 内の managed scaffold directory と、repo root 側の `install_root` assets を target repo に同期する。
+- `spec-dock/initiatives/**` は product/spec history として persistent data に近い扱いで、通常 update の managed overwrite 対象ではない。
+- repo root 側の managed assets は `src/spec_dock/assets/install_root/` の recursive file inventory が正本である。
+- `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json` は `.codex/config.toml` を `bootstrap_only_exact_file_paths` として定義している。
+- repo-local runtime `update` は repo 内で直接 installer logic を再実装せず、`uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock update <target>` を呼ぶ thin wrapper pattern を採る。
+- runtime command 追加の接点は `commands/<name>.py` の `command_specs()`、`cli/registry.py`、`cli/parser.py` である。
+- repo-root `spec` shortcut は installer が作る SpecDock runtime shortcut であり、uninstall で扱うなら symlink target 確認が必要である。
+- runtime entrypoint は `spec-dock/scripts/spec-dock` から runtime module を import して動くため、同一 process で runtime scaffold を削除する self-removal は platform / filesystem semantics により不安定化し得る。
+
+## inference / 推測
+- 事実から推測したこと:
+  - uninstall の実処理は installer CLI 側へ置き、repo-local runtime command は update と同様に外部 installer invocation へ委譲する方が安全である。
+  - uninstall inventory は installer の existing install_root plan builder と scaffold sync knowledge を再利用する設計が自然である。
+  - tests は installer CLI integration と runtime wrapper tests に分ける必要がある。
+- 推測の根拠:
+  - 既存 `update` が runtime wrapper + installer implementation split を採用しているため。
+  - repo-local runtime 自身が削除対象になり得るため。
+
+## unverified / 未検証事項
+- まだ確認していないこと:
+  - 具体 implementation で既存 install plan helper をどこまで reuse できるか。
+  - Windows filesystem semantics で runtime wrapper self-removal をどう扱うか。
+- 確認できない理由:
+  - requirement phase では HOW / platform-specific implementation を固定しないため。
+
+## terminology conflicts / 用語衝突
+- 衝突している用語:
+  - `delete` と `uninstall`
+- 既存 docs / code / tests / discussions での使われ方:
+  - `delete` は local spec node / subtree deletion。
+  - `uninstall` は target repo から SpecDock-managed development tooling / scaffold を取り外す repo-local operation。
+- 判断が必要な理由:
+  - `delete` の spec node cleanup と uninstall の repo-local tooling removal を混同すると、仕様履歴や repo root assets の削除境界が崩れる。
+
+## edge cases / 具体シナリオ
+- edge case:
+  - repo-local runtime command が uninstall 実行中に削除される。
+  - repo-root `spec` が user-created file または別 target の symlink である。
+  - `.github/workflows/ci.yml` が SpecDock 由来から product CI として編集・流用されている。
+- その edge case が requirement / design / plan に与える影響:
+  - installer CLI direct retry path、shortcut target verification、product-reusable asset mismatch preservation を requirement に含める必要がある。
+
+## implications / 判断への含意
+- `requirement.md`:
+  - repo-local wrapper + installer implementation を requirement として固定する。
+  - repo-root `spec` shortcut は target match した場合だけ削除対象にする。
+  - product-reusable managed assets は mismatch preserve にする。
+- `design.md`:
+  - installer CLI uninstall implementation と runtime wrapper subprocess invocation を分けて設計する。
+  - removal inventory は managed scaffold / install_root / specs / generated state / shortcut を分類する。
+- `plan.md`:
+  - installer CLI tests、runtime wrapper tests、self-removal retry guidance、shortcut preservation tests を含める。
+
+## リスク/制約
+- self-removal を runtime process 内で完結させると partial failure recovery が弱くなる。
+- current package asset と古い installed assets の comparison は version drift により mismatch が多くなり得る。
+- unknown user-created paths は preserve を基本にしないと誤削除リスクが高い。
+
+## 反映先
+- reflected_to:
+  - `spec-dock/active/issue/requirement.md`
+  - `spec-dock/active/issue/report.md`

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141123z-disc-uninstall-requirement-risk-synthesis.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141123z-disc-uninstall-requirement-risk-synthesis.md
@@ -1,0 +1,126 @@
+---
+種別: disc
+ID: "20260531t141123z-disc"
+タイトル: "Uninstall requirement risk synthesis"
+状態: "proposed"
+作成者: "iwasawayuuta"
+最終更新: "2026-05-31"
+親: ["iss-00147"]
+関連: []
+authority: "proposed"
+derived_from:
+  - consultant notification 019e7e57-fd68-7602-ad68-0e99d06f2c42
+  - spec-dock/active/issue/discussions/20260531t133315z-interview-uninstall-command-scope.md
+  - spec-dock/active/issue/discussions/20260531t133616z-interview-uninstall-removal-boundary.md
+  - spec-dock/active/issue/discussions/20260531t134004z-interview-uninstall-user-owned-asset-boundary.md
+  - spec-dock/active/issue/discussions/20260531t134206z-interview-uninstall-command-surface.md
+  - spec-dock/active/issue/discussions/20260531t134650z-interview-uninstall-managed-asset-mismatch.md
+  - spec-dock/active/issue/discussions/20260531t135206z-interview-uninstall-empty-directory-cleanup.md
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/report.md
+---
+
+# 20260531t141123z-disc Uninstall requirement risk synthesis
+
+## 対象論点
+- 今回整理する論点:
+  - repo-local uninstall requirement で、削除対象分類、content comparison、mismatch handling、partial failure、idempotency を requirement-level safety criteria として明文化する必要があるか。
+- この synthesis が必要な理由:
+  - uninstall は destructive operation であり、実装判断に任せると agent / skill noise removal と user file protection の境界が崩れやすい。
+
+## derived question sheets / research
+- `interview`:
+  - `20260531t133315z-interview-uninstall-command-scope.md`
+  - `20260531t133616z-interview-uninstall-removal-boundary.md`
+  - `20260531t134004z-interview-uninstall-user-owned-asset-boundary.md`
+  - `20260531t134206z-interview-uninstall-command-surface.md`
+  - `20260531t134650z-interview-uninstall-managed-asset-mismatch.md`
+  - `20260531t135206z-interview-uninstall-empty-directory-cleanup.md`
+- `research`:
+  - `20260531t141121z-research-uninstall-repo-analysis-evidence.md`
+- その他の根拠:
+  - consultant read-only notification 019e7e57-fd68-7602-ad68-0e99d06f2c42
+
+## synthesis
+- 合意済みのこと:
+  - uninstall は repo-local removal であり、package/environment uninstall は対象外。
+  - specs は実削除時に keep/remove の explicit mode selection を必須にする。
+  - bootstrap-only / user-owned 候補は content match の場合だけ自動削除し、mismatch は preserve + manual review。
+  - command surface は repo-local wrapper + installer implementation。
+  - agent / skill assets は known SpecDock-managed paths に限り content mismatch でも削除する。
+  - CI / config / prompt / rule など product-reusable assets は content mismatch 時に preserve + manual review。
+  - empty directory cleanup は boundary root 内の bounded cleanup。
+- 未合意 / 未確定のこと:
+  - exact flag names and final output wording は design phase で既存 CLI style に合わせる。
+- source-grounded に解決できたこと:
+  - repo-root shortcut、runtime wrapper self-removal risk、install_root inventory は repo analysis で requirement grounding に採用した。
+
+## 選択肢 / tradeoff
+- Strong removal:
+  - Pros:
+    - agent / skill noise removal が確実。
+  - Cons:
+    - user edit や product-reused settings の誤削除リスクがある。
+- Conservative preservation:
+  - Pros:
+    - data loss risk が低い。
+  - Cons:
+    - uninstall 後も agent / skill noise が残る可能性がある。
+- Category-based removal:
+  - Pros:
+    - primary objective の agent / skill noise removal と user-owned / product-reused file protection を両立しやすい。
+  - Cons:
+    - path classification と report behavior を tests で固定する必要がある。
+
+## reflection proposal
+- canonical docs / workflow / template / skill guidance へ反映すべき候補:
+  - Issue requirement に削除対象分類表を置く。
+  - partial failure / idempotency / comparison failure を AC / EC として固定する。
+- まだ proposal に留める理由:
+  - exact implementation structure と CLI flag names は design phase で扱うため。
+
+## ADR candidate triage
+- ADR candidate か:
+  - no
+- hard to reverse:
+  - no
+- surprising without context:
+  - no
+- real tradeoff:
+  - yes
+- ADR 化しない場合の反映先:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md`
+
+## 推奨案
+- category-based removal を requirement に固定する。
+- 削除対象分類表は `path/category`, ownership boundary, match requirement, mismatch behavior, specs mode dependency, report behavior を持つ。
+- comparison が判定不能な場合は、agent / skill core removal target を除いて preserve + manual review に倒す。
+- partial failure summary と idempotent re-run を acceptance criteria に含める。
+
+## 推奨反映先
+- `requirement.md`:
+  - 削除対象分類表、partial failure / idempotency AC、comparison failure EC。
+- `design.md`:
+  - inventory classifier、content comparison policy、result model、cleanup traversal。
+- `plan.md`:
+  - keep/remove specs、match/mismatch、forced agent removal、product-reusable preserve、empty-dir cleanup、idempotency tests。
+- `ADR`:
+  - 不要。
+- `report.md` Evidence Adoption Ledger:
+  - consultant findings をこの discussion 経由で採用したことを記録する。
+
+## 未採用 / deferred 理由
+- 未採用:
+  - package/environment uninstall automation。repo-local uninstall の primary objective と異なり、install method 依存が大きい。
+- deferred:
+  - exact CLI flag names。design phase で既存 command style に合わせる。
+
+## 次アクション
+- `requirement.md` / `design.md` / `plan.md` / `adr` へ反映する内容:
+  - requirement は反映済み。design / plan では implementation surface と tests に分解する。
+- 追加で作る discussion docs:
+  - requirement phase では不要。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141545z-disc-uninstall-design-draft.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t141545z-disc-uninstall-design-draft.md
@@ -1,0 +1,347 @@
+---
+created_by_role: spec-dock-system-architect
+scope_id: iss-00147
+source_paths:
+  - spec-dock/active/context-pack.md
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/epic/requirement.md
+  - spec-dock/active/epic/design.md
+  - spec-dock/active/issue/discussions/20260531t141121z-research-uninstall-repo-analysis-evidence.md
+  - spec-dock/active/issue/discussions/20260531t141123z-disc-uninstall-requirement-risk-synthesis.md
+  - spec-dock/docs/workflow_spec_authoring.md
+  - spec-dock/docs/workflow_clarification.md
+  - spec-dock/docs/phase_design.md
+  - spec-dock/docs/reference_sync.md
+  - src/spec_dock/cli.py
+  - src/spec_dock/assets/install_root/.agents/host-adapters/meta.json
+  - src/spec_dock/assets/install_root/
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/delete.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+  - tests/test_init_update.py
+  - tests/cli_runtime/test_update.py
+  - tests/cli_runtime/harness.py
+intended_targets:
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/issue/report.md
+adoption_status: unreviewed
+reflected_to: []
+diff_guard_result: manual_orchestrator_check_passed_new_issue_discussion_only
+---
+
+# Uninstall Design Draft
+
+## 1. Requirement Coverage
+
+- Requirement source revision:
+  - `iss-00147` frontmatter: `状態: "approved"`, `最終更新: "2026-05-31"`.
+- Covered requirement clusters:
+  - Installer CLI: add `spec-dock uninstall [path]` without changing `init` / `update` behavior.
+  - Repo-local runtime: add `./spec-dock/scripts/spec-dock uninstall` as a thin wrapper that calls the installer CLI implementation.
+  - Removal modes: real deletion requires explicit specs handling, proposed as exactly one of `--keep-specs` or `--remove-specs`.
+  - Dry-run / plan: default invocation should produce an operator-visible plan without filesystem mutation.
+  - Inventory classification: known SpecDock agent / skill paths are core removal targets; bootstrap-only and product-reusable files require exact content match for auto-removal.
+  - Result reporting: removed, would_remove, already_removed, preserved, failed, and empty_dirs must be distinguishable.
+  - Safety: no Python package, global CLI, uvx cache, parent directory, `.git`, unknown unmanaged path, or remote GitHub state mutation.
+  - Idempotency: missing managed artifacts are no-op / already removed rather than fatal.
+
+## 2. Existing Context Findings
+
+- `src/spec_dock/cli.py` is the installer entrypoint and currently owns `init` / `update`, target path validation, scaffold sync, install-root asset sync, manifest validation, and repo-root `spec` shortcut creation.
+- `_install_spec_dock()` owns `spec-dock/{docs,templates,scripts,system}`, `spec-dock/.gitignore`, `spec-dock/active`, `spec-dock/.agent`, `spec-dock/spec-dock.version`, and the repo-root `spec` symlink creation.
+- `_build_managed_skill_install_plan()` and related helpers already produce current install-root file mappings plus `bootstrap_only_exact_file_paths` and `obsolete_exact_file_paths` from `.agents/host-adapters/meta.json`.
+- `.agents/host-adapters/meta.json` currently marks `.codex/config.toml` as bootstrap-only and defines Codex / Copilot native shim ownership.
+- `src/spec_dock/assets/install_root/` is the provider-side authority for shipped agent tooling assets, including `.agents/skills/**`, `.codex/agents/**`, `.codex/prompts/**`, `.codex/rules/**`, `.codex/AGENTS.md`, `.github/agents/**`, and `.github/workflows/ci.yml`.
+- Runtime `update` already establishes the desired wrapper pattern: it does not reimplement installer logic; it shells out to `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock update <target>` and propagates stdout, stderr, and exit code.
+- Runtime command integration requires a command module, `cli/registry.py` registration, and `cli/parser.py` parser binding.
+- Existing tests split installer behavior under `tests/test_init_update.py` and runtime wrapper behavior under `tests/cli_runtime/test_update.py`.
+- `reference_sync.md` confirms `.agent/**` and `active/**` are generated runtime state, not product specification history.
+
+## 3. Design Decisions
+
+- Put destructive uninstall implementation in installer CLI, not repo-local runtime.
+  - Reason: repo-local runtime files are themselves removal targets. A thin wrapper leaves recovery and rerun available through external `spec-dock uninstall <target>`.
+- Add `uninstall` to installer parser as an additive subcommand.
+  - Proposed shape:
+    - `spec-dock uninstall [path]` renders a dry-run plan.
+    - `spec-dock uninstall [path] --apply --keep-specs` performs removal while preserving `spec-dock/initiatives/**`.
+    - `spec-dock uninstall [path] --apply --remove-specs` performs removal including `spec-dock/initiatives/**`.
+    - `--keep-specs` and `--remove-specs` are mutually exclusive.
+    - `--apply` without exactly one specs mode fails before mutation.
+- Represent uninstall as a plan/result model before filesystem mutation.
+  - The inventory pass should classify paths and produce deterministic actions first.
+  - The apply pass should execute actions and update statuses without recomputing ownership rules mid-delete.
+- Use category-based ownership, not a single exact-match rule.
+  - Known `.agents/skills/**`, `.codex/agents/**`, and `.github/agents/**` shipped or obsolete managed agent files are deleted even on content mismatch.
+  - Bootstrap-only and product-reusable shipped files are removed only when current content equals the package asset bytes.
+  - Unknown files under managed boundary roots are preserved.
+- Compare against the currently executing installer package assets.
+  - This matches `init` / `update` package authority and avoids relying on installed repo metadata that may be stale or missing.
+- Cleanup only empty directories inside explicit boundary roots.
+  - Proposed boundary roots: `.agents`, `.codex`, `.github`, and `spec-dock`.
+  - Directory cleanup must walk upward only from removed files and stop at the boundary root, repo root, non-empty directories, or filesystem errors.
+
+## 4. Alternatives Considered
+
+- Runtime self-removal implementation:
+  - Rejected. It couples deletion to files being deleted and weakens recovery after partial failure.
+- Reuse `delete` command:
+  - Rejected. Existing `delete` is local spec node lifecycle, while uninstall is repo-local managed tooling removal.
+- Exact content match for all managed assets:
+  - Rejected. It would preserve modified agent / skill assets and fail the primary objective of removing SpecDock agent discovery noise.
+- Delete all files under `.agents`, `.codex`, `.github`, and `spec-dock`:
+  - Rejected. It would silently remove user-authored or product-reused content.
+- Make `--keep-specs` the implicit apply default:
+  - Rejected for apply mode. Requirement says real deletion must require explicit specs handling.
+
+## 5. Boundary / Contract Model
+
+- Installer command contract:
+  - Input: target repo path, dry-run/apply mode, specs mode, optional machine-readable output if main orchestrator later chooses to add `--json`.
+  - Output: human-readable plan/result with stable status buckets.
+  - Exit code:
+    - `0`: dry-run completed or apply completed without failed removals.
+    - `1`: apply had one or more failed removals or unrecoverable inventory/comparison error.
+    - `2`: CLI usage error, invalid target, missing specs mode for apply, or mutually exclusive flags.
+- Runtime command contract:
+  - Input: optional path and pass-through uninstall flags that are intentionally supported by the installer.
+  - Invocation: `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <target> ...`.
+  - Output: propagate installer stdout, stderr, and exit code.
+  - Missing `uvx`: same style as update, exit `127` with actionable PATH guidance.
+- Ownership boundary:
+  - The command owns only known SpecDock-managed paths and generated state under explicit target repo boundaries.
+  - The command never interprets product-specific meaning of unknown files.
+
+## 6. Dependency Analysis
+
+- Upstream dependencies:
+  - `src/spec_dock/assets/install_root/` file inventory.
+  - `.agents/host-adapters/meta.json` for bootstrap-only and obsolete exact file path contracts.
+  - `src/spec_dock/assets/spec_dock/` for managed scaffold docs/templates/scripts/system comparisons.
+  - Current installer CLI target path validation and `_require_specdock()` behavior.
+- Module dependencies:
+  - Installer uninstall helpers should stay in `src/spec_dock/cli.py` initially unless size forces a focused internal module. This keeps parity with existing installer architecture and avoids a broader package restructuring.
+  - Runtime uninstall should mirror `commands/update.py`; it should not depend on application use cases.
+  - Parser and registry changes depend on the new runtime command module.
+- Test dependencies:
+  - Installer tests can call `spec_dock.cli.main([...])` directly via existing harness patterns.
+  - Runtime wrapper tests can reuse the `uvx` stub pattern from `test_update.py`.
+
+## 7. Source of Record
+
+- Shipped install-root assets:
+  - `src/spec_dock/assets/install_root/`.
+- Shipped scaffold assets:
+  - `src/spec_dock/assets/spec_dock/{docs,templates,scripts,system,.gitignore}`.
+- Spec history:
+  - target repo `spec-dock/initiatives/**`.
+- Generated runtime state:
+  - target repo `spec-dock/.agent/**`, `spec-dock/active/**`, and generated diagrams/dashboard described by `reference_sync.md`.
+- Runtime wrapper precedent:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`.
+- Canonical user-facing contract after adoption:
+  - `spec-dock/active/issue/design.md`, then `plan.md`; this draft is unreviewed evidence only.
+
+## 8. Data Flow / Domain Model / Interface Contract
+
+- Proposed data objects:
+  - `UninstallMode`:
+    - fields: `apply: bool`, `specs_mode: "keep" | "remove" | None`.
+  - `UninstallCategory`:
+    - examples: `agent_skill`, `native_agent`, `bootstrap_only`, `product_reusable`, `scaffold_managed`, `generated_state`, `spec_history`, `shortcut`, `obsolete_managed`, `unmanaged`.
+  - `ContentPolicy`:
+    - values: `delete_even_if_mismatch`, `delete_if_exact_match`, `delete_by_mode`, `delete_if_shortcut_target_matches`, `preserve`.
+  - `UninstallAction`:
+    - fields: `rel_path`, `entry_kind`, `category`, `policy`, `planned_operation`, `reason`, `source_asset_rel`.
+  - `UninstallActionResult`:
+    - fields: `rel_path`, `category`, `status`, `reason`, `error`.
+  - `UninstallResult`:
+    - fields: `target_root`, `dry_run`, `specs_mode`, `actions`, `empty_dirs`, `summary`, `exit_code`.
+- Proposed flow:
+  - Resolve target root and require `spec-dock/` exists.
+  - Build current managed mappings from package assets.
+  - Build uninstall inventory:
+    - current install-root files.
+    - obsolete exact files from manifest.
+    - managed scaffold files and directories.
+    - generated state files/directories.
+    - spec history root.
+    - repo-root `spec` shortcut.
+  - Classify each candidate by category and content policy.
+  - Render dry-run if `apply` is false.
+  - If applying, execute file/symlink removals first, then bounded empty directory cleanup.
+  - Render result with removed, already_removed, preserved, failed, and empty_dirs.
+- Content comparison contract:
+  - Compare bytes for regular files.
+  - Preserve on symlink/file-type mismatch unless the category explicitly supports symlink target verification.
+  - Preserve on read/comparison error except core agent / skill removal targets where ownership is known by path.
+- Shortcut contract:
+  - Delete repo-root `spec` only if it is a symlink whose normalized target is `spec-dock/scripts/spec-dock`.
+  - Preserve regular file, directory, missing target mismatch, or unrelated symlink target.
+
+## 9. File / Module Change Plan
+
+```text
+src/spec_dock/
+|-- cli.py
+|   `-- change: add installer uninstall parser, inventory/result helpers, content comparison, apply, rendering
+|-- assets/
+|   |-- install_root/
+|   |   `-- read-only source: managed agent/tooling inventory and manifest contracts
+|   `-- spec_dock/
+|       |-- docs/templates/system/scripts
+|       |   `-- read-only source: scaffold comparison inventory
+|       `-- scripts/spec_dock_runtime/
+|           |-- commands/uninstall.py
+|           |   `-- add: thin uvx wrapper for installer uninstall
+|           |-- commands/update.py
+|           |   `-- read-only precedent
+|           |-- cli/registry.py
+|           |   `-- change: register uninstall command
+|           `-- cli/parser.py
+|               `-- change: bind uninstall parser
+tests/
+|-- test_init_update.py
+|   `-- change/add: installer uninstall tests
+`-- cli_runtime/
+    `-- test_uninstall.py
+        `-- add: runtime wrapper tests mirroring update
+```
+
+- No implementation change is made by this draft.
+- Dogfooding `spec-dock/` generated workspace may need inspection after implementation, but direct consumer-side edits are not part of this design draft.
+
+## 10. Migration / Compatibility / Rollback
+
+- Migration:
+  - Additive CLI command; existing managed repos continue to work until operator explicitly runs uninstall.
+  - Older managed repos may contain obsolete exact files listed in manifest; uninstall should report and remove known obsolete files according to category policy.
+- Compatibility:
+  - `init` / `update` behavior should remain unchanged.
+  - After `--keep-specs`, future development recovery is `spec-dock init/update <target>` from installer CLI, with preserved `spec-dock/initiatives/**`.
+  - After `--remove-specs`, recovery requires reinitializing from scratch; the result output should state that spec history was removed.
+- Rollback:
+  - There is no automatic rollback after deletion.
+  - Safety is provided by dry-run default, explicit apply mode, exact-match preservation for user-owned candidates, and idempotent rerun.
+  - If apply partially fails, rerun from installer CLI after addressing filesystem permissions or preserved conflicts.
+
+## 11. Observability
+
+- Dry-run output should include:
+  - target root.
+  - apply mode: false.
+  - specs mode: `not_selected`, `keep`, or `remove`.
+  - planned removal buckets.
+  - preserved/manual-review buckets with reasons.
+  - empty directory cleanup plan.
+- Apply output should include:
+  - removed files/symlinks.
+  - already removed candidates.
+  - preserved paths with reason.
+  - failed removals with error text.
+  - removed empty directories.
+  - final summary counts.
+- Runtime wrapper should preserve installer stdout/stderr separation and exit code.
+- If future `--json` is added, it should serialize the same result model rather than a separate data shape.
+
+## 12. Test Strategy
+
+- Installer CLI tests in `tests/test_init_update.py` or a focused new installer test module:
+  - `spec-dock uninstall <target>` dry-run has exit `0` and makes no filesystem changes.
+  - `--apply` without `--keep-specs` / `--remove-specs` fails before mutation.
+  - `--apply --keep-specs` removes known agent / skill assets and preserves `spec-dock/initiatives/**`.
+  - `--apply --remove-specs` removes spec history and reports it explicitly.
+  - bootstrap-only `.codex/config.toml` exact match is removed; mismatch is preserved with manual-review reason.
+  - product-reusable `.github/workflows/ci.yml`, `.codex/prompts/**`, `.codex/rules/**`, `.codex/AGENTS.md` exact match is removed; mismatch is preserved.
+  - known managed agent / skill mismatch is removed.
+  - unknown files under `.agents`, `.codex`, `.github`, and `spec-dock` are preserved.
+  - repo-root `spec` symlink to `spec-dock/scripts/spec-dock` is removed; nonmatching symlink or regular file is preserved.
+  - generated `spec-dock/.agent/**` and `spec-dock/active/**` are removed or skipped according to design, without deleting preserved specs.
+  - empty directory cleanup removes only empty directories inside boundary roots and does not remove repo root, `.git`, target parent, or directories containing preserved files.
+  - rerun after prior removal reports already removed / preserved and exits successfully when no failed removals remain.
+  - injected permission/unlink failure produces non-zero exit and distinguishes failed from preserved and removed.
+- Runtime wrapper tests in `tests/cli_runtime/test_uninstall.py`:
+  - help describes dry-run default, `uvx --no-cache`, upstream source, default current working directory, and explicit specs mode.
+  - default target passes resolved current working directory to installer uninstall.
+  - explicit target is resolved and passed through.
+  - supported uninstall flags are forwarded.
+  - subprocess failure stdout/stderr/exit code are propagated.
+  - missing `uvx` exits `127` with actionable error.
+  - unsupported source/cache override options are rejected without invoking `uvx`, matching update's safety style if such options are not defined.
+- Verification bundle after implementation:
+  - focused unittest targets first.
+  - `python -m unittest discover -v` if change size warrants full regression.
+  - `./spec-dock/scripts/spec-dock validate` and `./spec-dock/scripts/spec-dock sync --no-github` only if dogfooding workspace state is intentionally refreshed or inspected.
+
+## 13. ADR Candidates
+
+- No ADR is required for the initial issue design.
+- Rationale:
+  - The main decisions are local to uninstall command behavior and already anchored in issue/epic requirement.
+  - Category-based removal is important, but reversible and better captured as issue design plus tests.
+- Revisit ADR only if future work wants uninstall policy to become a cross-issue/global managed asset lifecycle rule.
+
+## 14. Risks
+
+- Version drift risk:
+  - Comparing target files to current package assets may preserve older but valid SpecDock-managed files as mismatches.
+  - Mitigation: report preserved/manual-review clearly; keep agent / skill core removal path-based.
+- Over-delete risk:
+  - Path-prefix classification can accidentally own user files if too broad.
+  - Mitigation: known managed candidates should come from shipped inventory, manifest obsolete exact paths, explicit generated-state roots, and exact boundary rules; unknown files preserve.
+- Under-delete risk:
+  - Conservative preservation may leave some product-reused SpecDock prompts/configs behind.
+  - Mitigation: result summary should make preserved manual-review items visible.
+- Self-removal risk:
+  - Runtime script may be deleted during uninstall.
+  - Mitigation: runtime command delegates to external installer process and tells operator to rerun installer CLI directly if recovery is needed.
+- Platform risk:
+  - Symlink behavior differs across OSes.
+  - Mitigation: tests should skip symlink-specific assertions where symlinks are unsupported and separately cover regular-file preservation.
+- Large output risk:
+  - Full inventory output can be noisy.
+  - Mitigation: summary first with grouped detailed paths below; keep enough detail for manual review.
+
+## 15. Requirement Clarification Requests
+
+none
+
+## 16. Integration Notes for Main Orchestrator
+
+- Recommended canonical design adoption:
+  - Adopt installer/runtime split, category-based inventory, result model, bounded cleanup, and test surface into `design.md`.
+  - Decide whether exact flag names `--apply`, `--keep-specs`, and `--remove-specs` should be canonical or adjusted to existing CLI wording before plan authoring.
+  - Reflect test obligations into `plan.md` as step-local closure cases.
+- Delegated draft evidence:
+  - role: `spec-dock-system-architect`
+  - phase: requirement/design
+  - scope: `iss-00147`
+  - source artifacts read:
+    - `spec-dock/active/issue/requirement.md`
+    - `spec-dock/active/epic/requirement.md`
+    - `spec-dock/active/epic/design.md`
+    - `src/spec_dock/cli.py`
+    - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`
+    - `tests/test_init_update.py`
+    - `tests/cli_runtime/test_update.py`
+  - draft artifact path: `spec-dock/active/issue/discussions/20260531t141545z-disc-uninstall-design-draft.md`
+  - draft status: `produced`
+  - authority: `proposed`
+  - adoption_status: `unreviewed`
+  - reflected_to: `[]`
+  - intended_targets:
+    - `spec-dock/active/issue/design.md`
+    - `spec-dock/active/issue/plan.md`
+    - `spec-dock/active/issue/report.md`
+  - diff_guard_result: `manual_orchestrator_check_passed_new_issue_discussion_only`
+  - integration notes:
+    - This draft should be adopted only by the main orchestrator through canonical `design.md` / `plan.md` / `report.md` updates and a fresh `spec-reviewer` pass.
+  - rejected portions, if any: none
+  - blockers, if any: none
+  - canonical artifacts edited: none
+  - final authority claimed: no

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t142649z-disc-uninstall-implementation-plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t142649z-disc-uninstall-implementation-plan.md
@@ -1,0 +1,425 @@
+---
+created_by_role: spec-dock-implementation-planner
+scope_id: iss-00147
+source_paths:
+  - spec-dock/active/context-pack.md
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/epic/requirement.md
+  - spec-dock/active/epic/design.md
+  - spec-dock/docs/authoring/issue-plan.md
+  - spec-dock/docs/workflow_issue.md
+  - spec-dock/docs/phase_plan.md
+  - spec-dock/docs/reference_deps.md
+  - spec-dock/docs/reference_sync.md
+  - src/spec_dock/cli.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+  - src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
+  - tests/test_init_update.py
+  - tests/cli_runtime/test_update.py
+intended_targets:
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/issue/report.md
+adoption_status: unreviewed
+reflected_to: []
+diff_guard_result: manual_orchestrator_check_passed_new_issue_discussion_only_dirty_baseline
+adoption_ledger_note: "Main orchestrator must decide adoption in canonical report.md before using this draft as plan authority."
+source_revisions:
+  requirement_hash: e755a67255fce267b0420351b17f346b7183dd76
+  design_hash: aa5c5c35f9d67ed937ff44fdc8bd432fec1a3cd1
+  epic_requirement_hash: 77c604bb4cd3e52bdabaea9e9ae684f23c300969
+  epic_design_hash: 50c17edb26e5402d47e009b2fb29b9589e8e0d8f
+  repo_head_short: fa46713a
+---
+
+# Plan Summary
+
+This is an unreviewed implementation planning draft for `iss-00147 SpecDock uninstall command`. It translates the approved requirement and design into an executable step order, closure index candidates, and test obligations. It does not edit or supersede canonical `requirement.md`, `design.md`, `plan.md`, or `report.md`.
+
+Planning assumption:
+- The approved design is authoritative for initial flag naming: `spec-dock uninstall [path] [--apply] [--keep-specs | --remove-specs]`.
+- `--json` is out of initial scope unless the main orchestrator amends the design.
+- Installer-side implementation remains in `src/spec_dock/cli.py` for this issue, matching the approved design. If the implementation becomes too large, module extraction is a follow-up design/plan amendment rather than a hidden refactor.
+
+Proposed implementation shape:
+- S01 fixes installer command surface, usage errors, dry-run default, and plan/result rendering skeleton.
+- S02 builds uninstall inventory and category/content-policy classification.
+- S03 applies removal, idempotent rerun, partial failure reporting, and bounded empty-directory cleanup.
+- S04 adds the repo-local runtime thin wrapper and parser/registry wiring.
+- S90 resolves docs impact separately.
+- S99 performs issue-wide final quality gates.
+
+# Requirement / Design Traceability
+
+Approved requirement inputs:
+- `iss-00147` requirement status is `approved`.
+- Core requirement: repo-local and installer uninstall remove SpecDock-managed development tooling while keeping package/global environment outside scope.
+- Non-negotiable constraints:
+  - destructive operation requires explicit mode and operator-visible plan.
+  - agent / skill assets are the primary removal target and are deleted even when content mismatches, but only for known SpecDock-managed paths.
+  - bootstrap-only and product-reusable assets are deleted only on exact content match.
+  - specs deletion is explicit; no implicit spec history removal.
+  - remote GitHub state is not mutated.
+
+Approved design inputs:
+- Installer CLI owns the implementation and remains the recovery path after repo-local runtime files are removed.
+- Runtime command is a thin `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall TARGET ...` wrapper.
+- Inventory flows from `install_root`, scaffold assets, generated state, spec history, obsolete exact paths, and shortcut inspection.
+- Plan/result model separates `would_remove`, `removed`, `already_removed`, `preserved`, `failed`, and `empty_dir_removed`.
+
+Epic traceability:
+- E-RQ-011 / E-RQ-012 and E-AC-006 require uninstall to be a lifecycle command, not project-wide garbage collection.
+- Epic design Flow-E requires repo-local wrapper -> installer CLI -> inventory -> dry-run / explicit specs mode / guarded removal -> recovery via installer CLI.
+
+# Milestones
+
+M1: Installer command contract and observable dry-run baseline
+- Produces a visible uninstall command with correct exit-code behavior and no filesystem mutation by default.
+- Closes the highest-risk destructive preflight boundary before any removal logic exists.
+
+M2: Inventory and classification correctness
+- Produces a deterministic uninstall plan from current shipped assets and target repo state.
+- Locks ownership boundaries before apply logic can delete files.
+
+M3: Apply, idempotency, partial failure, and cleanup
+- Converts a validated plan into actual filesystem mutation.
+- Keeps deletion bounded, retryable, and operator-readable.
+
+M4: Repo-local runtime wrapper
+- Adds the managed repo command surface after installer contract is stable.
+- Keeps wrapper behavior aligned with the existing `update` command pattern.
+
+M5: Docs impact and final gates
+- Separates docs refresh from runtime/code implementation.
+- Requires issue-wide QA, code review, spec review, validation, and delivery evidence before completion.
+
+# Dependency-Derived Execution Order
+
+1. S01 must precede all other steps because usage errors, dry-run default, and result buckets define the public contract that later classification/apply tests observe.
+2. S02 depends on S01 because inventory/classification needs a rendered plan and stable option parsing to be tested through the public installer CLI.
+3. S03 depends on S02 because apply must consume the same `UninstallAction` decisions that dry-run reports. It must not reclassify paths independently.
+4. S04 depends on S01 and should follow S03, because the repo-local wrapper should forward to a stable installer command and should not become a second implementation.
+5. S90 follows code/runtime steps because docs must reflect the final command contract and any intentionally deferred docs impact.
+6. S99 follows all implementation and docs steps and must not replace per-step review gates.
+
+Dependency notes:
+- `src/spec_dock/cli.py` already owns installer parser, `_require_specdock`, install/update asset sync, `install_root` inventory helpers, bootstrap-only manifest parsing, obsolete exact paths, and repo-root shortcut install behavior. S01-S03 should reuse this local ownership rather than introduce a separate runtime implementation.
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py` is the wrapper precedent for `uvx --no-cache`, target resolution, stdout/stderr propagation, and missing `uvx` handling. S04 should mirror this structure.
+- `parser.py` and `registry.py` are downstream of the runtime command module; they are not useful until `commands/uninstall.py` has a `command_specs()` entry.
+
+# Issue / Step Slicing
+
+## S01 - Installer uninstall command surface and dry-run contract
+
+Behavior goal:
+- `spec-dock uninstall [path]` exists, defaults to dry-run, prints a grouped plan/result skeleton, and never mutates the filesystem without `--apply`.
+
+Allowed targets:
+- `src/spec_dock/cli.py`
+- `tests/test_init_update.py`
+
+Forbidden changes:
+- no runtime wrapper files in this step.
+- no shipped docs changes.
+- no broad module extraction unless the plan is amended.
+
+Step obligations:
+- Add parser support for `uninstall`, `--apply`, `--keep-specs`, `--remove-specs`.
+- Fail with exit `2` before mutation when `--apply` is used without exactly one specs mode.
+- Reject mutually exclusive specs flags.
+- Use existing target path validation style and `_require_specdock` for managed repo validation.
+- Establish output bucket vocabulary even if S02/S03 later fills real inventory.
+
+Reviewer gate:
+- `code-reviewer` for CLI/tests/scaffold behavior.
+
+## S02 - Inventory, category classification, and content policy
+
+Behavior goal:
+- Dry-run produces correct `would_remove` / `preserved` / manual-review decisions from shipped asset inventory and target repo state.
+
+Allowed targets:
+- `src/spec_dock/cli.py`
+- `tests/test_init_update.py`
+
+Forbidden changes:
+- no file unlink/rmtree in this step except test fixture setup/teardown.
+- no runtime wrapper files.
+- no docs changes.
+
+Step obligations:
+- Build candidates from `install_root` current mappings, manifest bootstrap-only / obsolete exact paths, scaffold-managed files, generated state, spec history, repo-root `spec` shortcut, and explicit managed boundary roots.
+- Classify known `.agents/skills/**`, `.codex/agents/**`, and `.github/agents/**` managed paths as delete-even-if-mismatch.
+- Preserve unknown files under `.agents`, `.codex`, `.github`, and `spec-dock` as unmanaged.
+- Apply exact-match policy for `.agents/host-adapters/meta.json`, `.codex/config.toml`, `.codex/prompts/**`, `.codex/rules/**`, `.codex/AGENTS.md`, `.github/workflows/**`, and scaffold-managed runtime/docs/templates/system files.
+- Treat comparison error or file-type mismatch as preserve + manual review except known core agent/skill paths.
+- Detect repo-root `spec` only when it is a symlink to `spec-dock/scripts/spec-dock`.
+
+Reviewer gate:
+- `code-reviewer` for classification correctness and over-delete prevention.
+
+## S03 - Apply engine, idempotency, partial failure, and bounded cleanup
+
+Behavior goal:
+- `--apply --keep-specs` and `--apply --remove-specs` mutate only planned paths, report exact result buckets, and remain safe to rerun after partial or complete removal.
+
+Allowed targets:
+- `src/spec_dock/cli.py`
+- `tests/test_init_update.py`
+
+Forbidden changes:
+- no runtime wrapper files.
+- no docs changes.
+- no deletion outside target repo test fixtures.
+
+Step obligations:
+- Apply only `UninstallAction` entries created by S02.
+- Keep `--keep-specs` preserving `spec-dock/initiatives/**`.
+- Make `--remove-specs` include `spec-dock/initiatives/**` and explicitly report spec history removal.
+- Remove generated state (`spec-dock/.agent/**`, `spec-dock/active/**`) according to the approved design's workspace cleanup policy.
+- Remove empty directories only within bounded roots: `.agents`, `.codex`, `.github`, `spec-dock`.
+- Stop cleanup when a directory contains preserved or unmanaged files.
+- Return non-zero for failed removals and distinguish deleted, not deleted, preserved, failed, and already removed.
+- Support rerun after prior removal without destructive errors.
+
+Reviewer gate:
+- `code-reviewer` for filesystem safety, failure modes, and idempotency.
+
+## S04 - Repo-local runtime uninstall wrapper
+
+Behavior goal:
+- `./spec-dock/scripts/spec-dock uninstall [path] [--apply] [--keep-specs | --remove-specs]` delegates to the installer CLI via `uvx --no-cache` and propagates stdout/stderr/exit code.
+
+Allowed targets:
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+- `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+- `tests/cli_runtime/test_uninstall.py`
+- if needed for import wiring only: `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/__init__.py`
+
+Forbidden changes:
+- no installer removal logic in runtime command.
+- no arbitrary `--from` / cache override option.
+- no docs changes.
+
+Step obligations:
+- Mirror `update.py` structure and `UPSTREAM_SOURCE`.
+- Default target resolves to current working directory.
+- Explicit target is resolved and passed through.
+- Forward `--apply`, `--keep-specs`, and `--remove-specs`.
+- Propagate subprocess stdout/stderr/exit code.
+- Return `127` with actionable guidance when `uvx` is missing.
+- Reject unsupported flags through argparse without invoking `uvx`.
+
+Reviewer gate:
+- `code-reviewer` for wrapper parity and command registration.
+
+## S90 - Docs impact resolution / docs refresh
+
+Behavior goal:
+- Documentation and help text describe uninstall boundaries without turning this issue into package/environment uninstall or GitHub mutation work.
+
+Allowed targets:
+- `src/spec_dock/assets/spec_dock/docs/reference_github.md`
+- `src/spec_dock/assets/spec_dock/docs/reference_sync.md`
+- possibly tests that assert docs/help fragments if existing test structure requires it.
+
+Forbidden changes:
+- no runtime/code behavior changes.
+- no canonical issue docs unless main orchestrator separately edits them.
+- no generated dogfooding refresh unless the orchestrator chooses to sync/update the local consumer workspace.
+
+Step obligations:
+- Update `reference_github.md` to state uninstall does not close/delete GitHub issues, mutate remote state, or uninstall Python packages/global CLI/uvx cache.
+- Inspect `reference_sync.md` for generated state (`spec-dock/.agent/**`, `spec-dock/active/**`) wording. If current wording is sufficient, record no-op rationale in `report.md`; if not, update provider-side docs.
+- Ensure installer/runtime help output remains contract-aligned through tests.
+
+Reviewer gate:
+- `spec-reviewer` docs/spec alignment. If tests are changed only to assert docs/help text, `code-reviewer` may also be required by workflow mapping.
+
+## S99 - Final quality gate
+
+Behavior goal:
+- Confirm the integrated issue satisfies requirement/design/plan, has adequate test coverage, and is ready for PR delivery and merge-preparation judgment.
+
+Required checks:
+- focused installer tests, for example `python -m unittest tests.test_init_update -v`.
+- focused runtime tests, for example `python -m unittest tests.cli_runtime.test_uninstall -v`.
+- full baseline `python -m unittest discover -v`.
+- `./spec-dock/scripts/spec-dock validate`.
+- `./spec-dock/scripts/spec-dock sync` unless GitHub/network state is intentionally unavailable; if unavailable, use `./spec-dock/scripts/spec-dock sync --no-github` and record the opt-out reason.
+- `git diff --check`.
+
+Required reviewers:
+- `qa-reviewer`: issue-wide test adequacy and integration-test need.
+- issue-wide `code-reviewer`: integrated diff, structure, responsibility boundaries, regression risk, maintainability.
+- final `spec-reviewer`: requirement / design / plan / report / docs / implementation / tests consistency.
+
+# Test Strategy Mapping
+
+Closure index candidates:
+
+| ID | Step | Slice | Spec link | Locked expectation | Evidence level | Required |
+|---|---|---|---|---|---|---|
+| tc-001 | S01 | installer dry-run surface | AC-001, EC-002 | `spec-dock uninstall <target>` reports plan and mutates no files | red-required | yes |
+| tc-002 | S01 | apply preflight | AC-002 | `--apply` without specs mode exits `2` before any deletion | red-required | yes |
+| tc-003 | S01 | flag exclusivity | design Flag contract | `--keep-specs` and `--remove-specs` cannot both be accepted for apply | red-required | yes |
+| tc-004 | S02 | agent/skill classification | AC-003, AC-007 | known managed agent/skill paths are planned for removal even on mismatch | red-required | yes |
+| tc-005 | S02 | unmanaged preservation | AC-007 | unknown user-created files under managed-looking roots are preserved and reported | red-required | yes |
+| tc-006 | S02 | bootstrap/product-reusable exact match | AC-005 | exact-match bootstrap/product-reusable assets are planned for removal | red-required | yes |
+| tc-007 | S02 | bootstrap/product-reusable mismatch | AC-006, EC-006 | mismatch or comparison-error assets are preserved for manual review | red-required | yes |
+| tc-008 | S02 | scaffold-managed policy | design mapping | scaffold-managed files are exact-match delete, mismatch preserve | red-required | yes |
+| tc-009 | S02 | repo-root shortcut | EC-007 | `spec` symlink to runtime is removable; nonmatching symlink/file/directory is preserved | red-required | yes |
+| tc-010 | S03 | keep-specs apply | AC-003 | apply removes tooling but preserves `spec-dock/initiatives/**` | red-required | yes |
+| tc-011 | S03 | remove-specs apply | AC-004 | apply includes spec history and reports that destructive choice explicitly | red-required | yes |
+| tc-012 | S03 | bounded cleanup | EC-003, EC-004 | empty dirs are removed only inside boundary roots and never through preserved content | red-required | yes |
+| tc-013 | S03 | idempotent rerun | AC-009 | prior removals report `already_removed` / no-op without destructive failure | red-required | yes |
+| tc-014 | S03 | partial failure | requirement failure behavior | unlink/rmtree failure returns non-zero and reports `failed` separately | red-required | yes |
+| tc-015 | S04 | runtime wrapper invocation | AC-008 | wrapper calls `uvx --no-cache --from ... spec-dock uninstall TARGET` | red-required | yes |
+| tc-016 | S04 | runtime flag/output propagation | AC-008 | wrapper forwards supported flags and propagates stdout/stderr/exit code | red-required | yes |
+| tc-017 | S04 | missing uvx | design Runtime command | missing `uvx` exits `127` with PATH/install guidance | red-required | yes |
+| tc-018 | S90 | docs boundary | Docs impact | docs state no GitHub mutation and no package/environment uninstall | inspect-only | yes |
+| tc-019 | S99 | integrated issue adequacy | workflow_issue.md | full tests, validate/sync, final QA/code/spec gates pass or record blocker | manual-required | yes |
+
+Concrete test obligation notes:
+- Installer tests should prefer temp directories and direct `main([...])` calls, consistent with `tests/test_init_update.py`.
+- Runtime tests should mirror `tests/cli_runtime/test_update.py` and use an `uvx` stub to capture args rather than network access.
+- For destructive apply behavior, fixture assertions must verify both presence and absence after execution, not only CLI text.
+- For dry-run behavior, capture a pre/post filesystem snapshot for representative files and directories.
+- For content policy, at least one exact-match and one mismatch fixture is required for each high-risk category: bootstrap-only, product-reusable, scaffold-managed, agent/skill, unknown unmanaged.
+- For cleanup, include a preserved file inside a boundary root to prove parent directory is not removed.
+- For partial failure, use a controlled failing unlink/rmtree path or permission/mock strategy that is hermetic and does not require platform-specific global state.
+
+# Review Gates
+
+Per-step gates:
+- S01, S02, S03, S04 require `code-reviewer` pass because they touch installer/runtime behavior and tests.
+- S90 requires `spec-reviewer` docs/spec alignment; if S90 changes tests or help assertions, also require `code-reviewer`.
+- S99 requires independent final `qa-reviewer`, issue-wide `code-reviewer`, and final `spec-reviewer` passes.
+
+Report evidence required before each step closes:
+- `Implementation Delegation Gate`: delegated role, allowed paths, forbidden changes, required verification, stop conditions, output required.
+- `Step Contract Closure`: step, closure ids, close condition, evidence, result.
+- `Test Contract Closure`: required closure ids, pre-implementation evidence, verification command, result.
+- `Closure Coverage`: mapping from every required closure id to evidence.
+- `Reviewer Gate Status`: reviewer role, freshness, state, re-review evidence if needed.
+- `Step Commit Gate`: review scope, closure state, commit/no-op evidence, post-commit clean check.
+
+Amendment triggers:
+- Any deletion candidate source outside shipped inventory, explicit generated-state roots, spec-history mode, obsolete exact paths, or verified shortcut target.
+- Need to delete mismatch content for non-agent/product-reusable assets.
+- Need to add machine-readable `--json`.
+- Need to mutate GitHub state or uninstall package/global environment.
+- Need to split `src/spec_dock/cli.py` into new modules due to size or maintainability.
+- Any required closure row deletion, locked expectation change, required flag change, or spec link meaning change.
+
+# Rollback / Compatibility
+
+Implementation compatibility:
+- The change should be additive to installer and runtime command surfaces.
+- Existing `init`, `update`, `delete`, `sync`, and `validate` behavior must remain unchanged.
+- Runtime wrapper must not accept arbitrary package source/cache options, matching self-update safety precedent.
+- No GitHub remote state, package manager environment, global CLI, pip/uvx cache, or target repo parent directory is touched.
+
+Operational rollback:
+- Code rollback is normal git revert of the issue commits.
+- Uninstall apply itself has no automatic rollback after deletion. Safety is provided by dry-run default, explicit `--apply` plus specs mode, exact-match preservation, bounded cleanup, result summary, and idempotent rerun.
+- Partial failure recovery path is rerun via installer CLI `spec-dock uninstall <target> ...`; repo-local runtime may already have been deleted.
+
+# Docs Impact
+
+S90 is required, not optional.
+
+Required docs actions:
+- `src/spec_dock/assets/spec_dock/docs/reference_github.md`:
+  - add or adjust wording that uninstall does not close/delete GitHub issues and does not mutate remote GitHub state.
+  - state that uninstall is repo-local managed artifact removal, not Python package / global CLI / uvx cache cleanup.
+- `src/spec_dock/assets/spec_dock/docs/reference_sync.md`:
+  - inspect whether generated state (`spec-dock/.agent/**`, `spec-dock/active/**`) and uninstall cleanup interaction need explanation.
+  - if no update is needed, record the no-op rationale in `report.md` and include spec-reviewer alignment evidence.
+- CLI help:
+  - installer help and runtime help must match the final flag contract and be covered by tests.
+
+Dogfooding impact:
+- If shipped docs or runtime scaffold assets are changed, the orchestrator should decide whether to refresh the local `spec-dock/` dogfooding workspace. This draft does not request or perform that refresh.
+
+# Final Quality Gate
+
+S99 must remain an independent step after S90.
+
+Required S99 inputs:
+- all implementation steps closed as committed or valid approved-no-op.
+- all required closure ids covered in `report.md`.
+- S90 docs impact resolved.
+- no open plan blockers or unadopted material decisions that are needed for implementation authority.
+
+Required S99 commands/evidence:
+- focused installer test command and result.
+- focused runtime uninstall test command and result.
+- full `python -m unittest discover -v` result.
+- `./spec-dock/scripts/spec-dock validate` result.
+- `./spec-dock/scripts/spec-dock sync` result, or explicit `--no-github` opt-out evidence and reason.
+- `git diff --check` result.
+- final diff summary and changed-file scope.
+
+Required S99 reviewers:
+- `qa-reviewer` pass for test sufficiency and integration-test need.
+- issue-wide `code-reviewer` pass for integrated implementation quality.
+- final `spec-reviewer` pass for requirement/design/plan/report/docs/implementation/test consistency.
+
+Completion guard:
+- S99 pass is not `issue finish`, PR delivery, merge readiness, or lifecycle completion by itself. The main orchestrator must still record final report ledger, final commit scope, PR delivery gate, merge preparation gate, and lifecycle closure evidence according to `workflow_issue.md`.
+
+# Plan Blockers
+
+none
+
+Non-blocking notes:
+- Existing working tree status showed pre-existing modified canonical docs and untracked discussion drafts before this draft was created. The main orchestrator should run the delegated-authoring diff guard from its baseline and decide adoption eligibility.
+- Design Q-001 recommends no `--json` in initial implementation. This draft follows that recommendation and does not treat JSON output as a blocker.
+
+# Integration Notes for Main Orchestrator
+
+Delegated Draft Evidence:
+- role: `spec-dock-implementation-planner`
+- phase: plan
+- scope: `iss-00147`
+- source artifacts read:
+  - `spec-dock/active/context-pack.md`
+  - `spec-dock/active/issue/requirement.md`
+  - `spec-dock/active/issue/design.md`
+  - `spec-dock/active/issue/plan.md`
+  - `spec-dock/active/epic/requirement.md`
+  - `spec-dock/active/epic/design.md`
+  - `spec-dock/docs/authoring/issue-plan.md`
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/phase_plan.md`
+  - `spec-dock/docs/reference_deps.md`
+  - `spec-dock/docs/reference_sync.md`
+  - `src/spec_dock/cli.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `tests/test_init_update.py`
+  - `tests/cli_runtime/test_update.py`
+- draft artifact path: `spec-dock/active/issue/discussions/20260531t142649z-disc-uninstall-implementation-plan.md`
+- draft status: `produced`
+- authority: `proposed`
+- adoption_status: `unreviewed`
+- reflected_to: `[]`
+- intended_targets:
+  - `spec-dock/active/issue/plan.md`
+  - `spec-dock/active/issue/report.md`
+- diff_guard_result: `manual_orchestrator_check_passed_new_issue_discussion_only_dirty_baseline`
+- integration notes:
+  - Use this draft as candidate material for canonical `plan.md` only after main-orchestrator adoption and fresh `spec-reviewer` review.
+  - Keep S01-S04, S90, and S99 as separate review scopes unless the orchestrator amends the plan with explicit rationale.
+  - Preserve the design's no-`--json` initial scope unless a plan amendment is approved.
+- rejected portions: none
+- blockers: none
+- canonical artifacts edited: none
+- final authority claimed: no
+
+No canonical edit, final authority, promotion, reviewer-pass, implementation-readiness, or user-dialogue ownership is claimed.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t144040z-interview-uninstall-json-output.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/discussions/20260531t144040z-interview-uninstall-json-output.md
@@ -1,0 +1,49 @@
+---
+kind: interview
+scope: issue
+scope_id: iss-00147
+title: "Uninstall command JSON output scope"
+status: answered
+created_at: "2026-05-31T14:40:40Z"
+question_id: "Q-001"
+source_paths:
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/plan.md
+intended_targets:
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/issue/report.md
+reflected_to:
+  - spec-dock/active/issue/requirement.md
+  - spec-dock/active/issue/design.md
+  - spec-dock/active/issue/plan.md
+  - spec-dock/active/issue/report.md
+---
+
+# Interview: uninstall command JSON output scope
+
+## 背景
+- `design.md` の未確定事項 `Q-001` は、`spec-dock uninstall` の初回実装で machine-readable `--json` output を含めるかどうか。
+- 現在の requirement は operator-visible な dry-run plan / result summary を要求しているが、machine-readable output は明示要求していない。
+- 回答前の plan は `--json` を scope 外 / follow-up 候補として扱っていた。
+
+## 質問
+`spec-dock uninstall` の初回実装に `--json` output を含めますか。
+
+## 選択肢
+- A:
+  - 初回実装では human-readable output のみとし、`--json` は follow-up 候補にする。
+- B:
+  - 初回実装から `--json` output を追加し、plan/result の machine-readable contract と tests も今回 scope に含める。
+
+## 推奨
+- A。
+- 理由:
+  - 今回の primary objective は agent / skill noise removal と安全な repo-local uninstall であり、machine-readable output は必須受け入れ条件ではない。
+  - `--json` を今回含めると、result schema、互換性、help/docs、tests の契約が増える。
+
+## 回答
+- B。
+- `spec-dock uninstall` は agent が実行する可能性があるため、初回実装から JSON output を必ず実装する。
+- `--json` は dry-run plan と apply result の両方で machine-readable output を返し、runtime wrapper からも forwarding する。

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/plan.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/plan.md
@@ -3,7 +3,7 @@
 ID: "iss-00147"
 タイトル: "SpecDock uninstall command"
 関連GitHub: ["#147"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-31"
 依存: ["requirement.md", "design.md"]
@@ -12,258 +12,708 @@ ID: "iss-00147"
 
 # iss-00147 SpecDock uninstall command — 実装計画（実行契約 / Execution Contract）
 
-> このテンプレートは最小 scaffold です。`plan.md` は計画済み契約（planned contract）を所有し、実装者が step を上から順に実行できる command queue として書く。実行結果、逸脱、発見された tests、reviewer verdict、commit/no-op evidence は `report.md` の観測証跡台帳（observed evidence ledger）に記録する。実行 policy は `workflow_issue.md`、Issue 計画の書き方は `phase_plan_issue.md` と `docs/authoring/issue-plan.md` を正本にする。
-
 ## この計画で満たす要件ID
 - AC:
-  - ...
+  - AC-001, AC-002, AC-003, AC-004, AC-005, AC-006, AC-007, AC-008, AC-009, AC-010
 - EC:
-  - ...
+  - EC-001, EC-002, EC-003, EC-004, EC-005, EC-006, EC-007, EC-008
 - 制約:
-  - ...
+  - destructive operation は explicit `--apply` と specs mode を要求する
+  - package/environment uninstall と GitHub remote mutation は対象外
+  - unknown unmanaged paths / repo root / `.git` / target parent は削除しない
+  - agent / skill noise removal を primary objective としつつ、product-reused/user-owned mismatch は preserve する
 
 ## 依存関係から導く実装順序
 - 依存関係の正本:
-  - `design.md` の依存関係、図、ファイル変更計画
+  - `design.md` の `依存関係分析`、`Module Dependency Diagram`、`Directory / File 変更計画`
 - 順序ルール:
-  - prerequisite / lower-dependency slice から先に閉じる
-  - downstream slice は前提が固定されてから置く
+  - Installer CLI public contract を先に固定し、inventory classification、apply、runtime wrapper、docs impact、final gate の順に進む。
+  - runtime wrapper は installer command が stable になってから追加し、runtime 側に uninstall logic を重複実装しない。
 - step 依存サマリー:
   - S01:
-    - 依存:
-    - unblock:
-    - 対象ファイル:
+    - 依存: approved requirement/design
+    - unblock: S02/S03/S04
+    - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - S02:
+    - 依存: S01 command surface
+    - unblock: S03 apply engine
+    - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - S03:
+    - 依存: S02 inventory/action plan
+    - unblock: S04 runtime wrapper, S90 docs
+    - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - S04:
+    - 依存: S01 command contract, S03 installer behavior
+    - unblock: S90/S99
+    - 対象ファイル: `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`, `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`, `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`, `tests/cli_runtime/test_uninstall.py`
+  - S90:
+    - 依存: S01-S04 final command contract
+    - unblock: S99
+    - 対象ファイル: `src/spec_dock/assets/spec_dock/docs/reference_github.md`, `src/spec_dock/assets/spec_dock/docs/reference_sync.md` if needed
+  - S99:
+    - 依存: S01-S04 and S90 closed
+    - unblock: PR delivery / issue readiness
+    - 対象ファイル: `report.md` evidence only unless blockers require fixes
 
 ## ステップ一覧
 - S01:
-  - 観測可能な振る舞い:
-  - 依存:
-  - unblock:
-  - 対象ファイル:
-  - 閉じる要件:
-  - レビューゲート:
+  - 観測可能な振る舞い: installer CLI `spec-dock uninstall` が dry-run default、usage guardrail、JSON output contract を持つ
+  - 依存: approved requirement/design
+  - unblock: S02, S03, S04
+  - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - 閉じる要件: AC-001, AC-002, AC-010, EC-001, EC-002, EC-008
+  - レビューゲート: code-reviewer
 - S02:
-  - ...
+  - 観測可能な振る舞い: dry-run が inventory/category/content-policy に基づく plan を表示する
+  - 依存: S01
+  - unblock: S03
+  - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - 閉じる要件: AC-005, AC-006, AC-007, EC-006, EC-007
+  - レビューゲート: code-reviewer
+- S03:
+  - 観測可能な振る舞い: `--apply --keep-specs` / `--apply --remove-specs` が plan に従って削除・保持・失敗報告・bounded cleanup を行う
+  - 依存: S02
+  - unblock: S04, S90
+  - 対象ファイル: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+  - 閉じる要件: AC-003, AC-004, AC-009, AC-010, EC-003, EC-004, EC-005, EC-008
+  - レビューゲート: code-reviewer
+- S04:
+  - 観測可能な振る舞い: repo-local runtime uninstall wrapper が installer CLI を `uvx --no-cache` で呼ぶ
+  - 依存: S01, S03
+  - unblock: S90, S99
+  - 対象ファイル: `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`, `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`, `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`, `tests/cli_runtime/test_uninstall.py`
+  - 閉じる要件: AC-008, AC-010
+  - レビューゲート: code-reviewer
+- S90:
+  - 観測可能な振る舞い: docs/help が uninstall の non-GitHub / non-package uninstall boundary と generated state cleanup を説明または no-op 判定する
+  - 依存: S01-S04
+  - unblock: S99
+  - 対象ファイル: `src/spec_dock/assets/spec_dock/docs/reference_github.md`, `src/spec_dock/assets/spec_dock/docs/reference_sync.md`
+  - 閉じる要件: docs contract, E-AC-006
+  - レビューゲート: spec-reviewer docs/spec alignment
+- S99:
+  - 観測可能な振る舞い: issue-wide verification and final QA/code/spec gates pass
+  - 依存: all previous steps
+  - unblock: PR delivery / issue ready
+  - 対象ファイル: `report.md` evidence
+  - 閉じる要件: whole issue
+  - レビューゲート: qa-reviewer, issue-wide code-reviewer, final spec-reviewer
 
 ## 要件 ↔ ステップ対応
 - AC-001 -> S01
-- EC-001 -> S02
+- AC-002 -> S01
+- AC-003 -> S03
+- AC-004 -> S03
+- AC-005 -> S02
+- AC-006 -> S02
+- AC-007 -> S02
+- AC-008 -> S04
+- AC-009 -> S03
+- AC-010 -> S01 / S03 / S04
+- EC-001 -> S01
+- EC-002 -> S01
+- EC-003 -> S03
+- EC-004 -> S03
+- EC-005 -> S03 / S04
+- EC-006 -> S02
+- EC-007 -> S02
+- EC-008 -> S01 / S03
+- docs contract -> S90
+- final workflow gates -> S99
 
 ## 仕様固定クロージャ索引（Spec-Locked Closure Index）
 
-> これは Issue 全体のテスト一覧ではなく、仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の step-local obligation と concrete seeds は各 implementation step の `具体テストケース一覧` に置く。
-
 | 識別子（ID） | ステップ（step） | スライス（slice） | 種別（type） | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル（evidence level） | クロージャ証跡（closure evidence） |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | 受け入れ（acceptance） | AC-001 | ... | ... | 仕様 drift（spec drift） | yes | red-required | ステップ完了証跡（report step closure） |
-| tc-002 | S01 | <behavior> | 否定系（negative） | EC-001 | ... | ... | 沈黙失敗（silent failure） | yes | inspect-only | ステップ完了証跡（report step closure） |
-
-- 証跡レベル（evidence level）:
-  - red-required: 実装前に失敗する新規 test / characterization を固定する。
-  - covered-existing: 既存 test が対象 behavior を検出できる根拠を固定する。
-  - inspect-only: docs / template / config などを inspection、structural assertion、review evidence で閉じる。
-  - manual-required: 自動化できない確認手順、期待結果、記録先を固定する。
-- 詳細化方針:
-  - 件数ではなく、AC、changed contract、failure mode、regression risk、invariant、manual / integration risk から必要な obligation を決める。
-  - private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+| tc-001 | S01 | installer dry-run surface | acceptance | AC-001, EC-002 | `spec-dock uninstall <target>` は plan を表示し filesystem を変更しない | initialized temp repo, uninstall dry-run | accidental destructive default | yes | red-required | tests + report closure |
+| tc-002 | S01 | apply preflight | negative | AC-002 | `--apply` without specs mode exits before mutation | initialized temp repo, apply without mode | implicit specs deletion | yes | red-required | tests + report closure |
+| tc-003 | S01 | flag exclusivity | negative | design flag contract | `--keep-specs` and `--remove-specs` are mutually exclusive | CLI args with both flags | ambiguous destructive mode | yes | red-required | tests + report closure |
+| tc-020 | S01 | target validation | negative | EC-001 | target without managed `spec-dock/` state fails before mutation with guidance | temp dir or repo lacking managed SpecDock state | running destructive workflow against unmanaged target | yes | red-required | tests + report closure |
+| tc-023 | S01 | JSON dry-run output | acceptance | AC-010, EC-008 | `--json` dry-run emits one parseable JSON object with summary/actions/guidance and action-level status/category/reason for planned removal and preservation | initialized temp repo, uninstall dry-run with `--json` | agent cannot parse uninstall plan semantics | yes | red-required | tests + report closure |
+| tc-004 | S02 | agent/skill classification | acceptance | AC-003, AC-007 | known managed agent/skill mismatch is planned for removal | modified known agent/skill file | leaving product-noise assets | yes | red-required | tests + report closure |
+| tc-005 | S02 | unmanaged preservation | negative | AC-007 | unknown user-created files under managed-looking roots are preserved | unknown `.agents` / `.codex` / `.github` file | deleting user-created assets | yes | red-required | tests + report closure |
+| tc-006 | S02 | bootstrap/product-reusable exact match | acceptance | AC-005 | exact-match bootstrap/product-reusable assets are planned for removal | matching `.codex/config.toml` / docs-managed file | stale managed residue | yes | red-required | tests + report closure |
+| tc-007 | S02 | bootstrap/product-reusable mismatch | negative | AC-006, EC-006 | mismatch assets are preserved for manual review | edited product-reusable file | user edit loss | yes | red-required | tests + report closure |
+| tc-021 | S02 | comparison-error preservation | negative | EC-006 | non-core comparison errors preserve with manual-review reason | symlink/type mismatch or read failure in product-reusable asset | deleting user-owned content when ownership cannot be proven | yes | red-required | tests + report closure |
+| tc-008 | S02 | scaffold-managed policy | acceptance/negative | design mapping | scaffold-managed exact match removes; mismatch preserves | `spec-dock/docs/**` or scripts fixture | broken scaffold cleanup contract | yes | red-required | tests + report closure |
+| tc-009 | S02 | repo-root shortcut | negative | EC-007 | matching `spec` symlink removes; nonmatching file/symlink preserves | repo-root `spec` variants | deleting unrelated shortcut | yes | red-required | tests + report closure |
+| tc-010 | S03 | keep-specs apply | acceptance | AC-003 | apply removes tooling but preserves `spec-dock/initiatives/**` | apply with `--keep-specs` | losing restartable specs | yes | red-required | tests + report closure |
+| tc-011 | S03 | remove-specs apply | acceptance | AC-004 | apply includes spec history and reports destructive choice | apply with `--remove-specs` | hidden specs deletion | yes | red-required | tests + report closure |
+| tc-012 | S03 | bounded cleanup | negative | EC-003, EC-004 | empty dirs removed only inside boundary roots and not through preserved content | preserved file inside boundary root | over-broad directory deletion | yes | red-required | tests + report closure |
+| tc-013 | S03 | idempotent rerun | acceptance | AC-009 | prior removals report already_removed/no-op without destructive failure | run uninstall twice | non-idempotent cleanup | yes | red-required | tests + report closure |
+| tc-014 | S03 | partial failure | negative | requirement failure behavior | unlink/rmtree failure returns non-zero and reports failed separately | injected unlink failure | silent partial deletion | yes | red-required | tests + report closure |
+| tc-022 | S03 | installer direct recovery guidance | acceptance | AC-008, EC-005 | apply output gives installer-direct retry/reinstall guidance after repo-local runtime removal | apply removes repo-local runtime wrapper | operator cannot recover after self-removal | yes | red-required | tests + report closure |
+| tc-024 | S03 | JSON apply result | acceptance/negative | AC-010, EC-008 | `--json` apply emits parseable completed/partial_failure payload with action-level removed/already_removed/preserved/failed/empty_dir_removed statuses and no human-readable stdout mixing | apply success, rerun, preserved item, cleanup, and injected failure with `--json` | agent cannot parse destructive operation result semantics | yes | red-required | tests + report closure |
+| tc-015 | S04 | runtime wrapper invocation | acceptance | AC-008 | wrapper calls `uvx --no-cache --from ... spec-dock uninstall TARGET` | runtime command with stubbed uvx | duplicated runtime implementation | yes | red-required | tests + report closure |
+| tc-016 | S04 | runtime flag/output propagation | acceptance | AC-008 | wrapper forwards supported flags and propagates stdout/stderr/exit code | stubbed uvx output/failure | lost installer evidence | yes | red-required | tests + report closure |
+| tc-017 | S04 | missing uvx | negative | design runtime command | missing `uvx` exits 127 with guidance | PATH without uvx | opaque tool failure | yes | red-required | tests + report closure |
+| tc-025 | S04 | runtime JSON forwarding | acceptance | AC-010 | runtime wrapper forwards `--json` and preserves installer JSON stdout | runtime command with stubbed uvx and JSON stdout | repo-local agent execution loses machine-readable output | yes | red-required | tests + report closure |
+| tc-018 | S90 | docs boundary | docs | E-AC-006 docs contract | docs/help state no GitHub mutation and no package/environment uninstall | docs diff / help output | misleading operator docs | yes | inspect-only | docs review + report closure |
+| tc-019 | S99 | final quality gate | workflow | workflow_issue.md | focused/full tests, validate/sync, final QA/code/spec gates pass or block | whole issue diff and commands | incomplete handoff | yes | manual-required | final report evidence |
 
 ## レビュー / QA ゲート方針
-- RG1 step review:
-  - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only）
-  - pass 条件: review_status: pass
-- QG1 final QA:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage、missing high-value tests、manual / integration test 要否
-- SG1 final spec review:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / docs 整合
-
-## 実行ルール（全ステップ共通）
-- 各 implementation step は原則として 1 behavior slice / 1 review scope / 1 commit boundary とする。
-- `plan.md` には planned requirements、evidence destination、closure 条件だけを書く。observed result は `report.md` に書く。
-- docs-only / inspect-only / manual-required step は code test 前提にせず、代替 evidence path と rationale を implementation 前に固定する。
-- implementation 中に新しい仕様、bug class、外部 contract risk、未計画の closure が見つかった場合は、report 記録だけで足りるか、plan amendment と re-review が必要かを判断する。
+- Per-step:
+  - S01-S04: step-local `code-reviewer` pass before step commit.
+  - S90: `spec-reviewer` docs/spec alignment; if test/help assertion code changes are included, also use `code-reviewer`.
+  - S99: final `qa-reviewer`, issue-wide `code-reviewer`, final `spec-reviewer`.
+- Gating rule:
+  - Missing, stale, fail, unavailable, denied, waived, or provisional reviewer result is not pass.
+  - Any required closure row changed or removed requires plan amendment and re-review.
 
 ## 実装ステップ
 
-### 実装ステップ S01 — <観測可能な振る舞い>
+### 実装ステップ S01 — Installer uninstall command surface and dry-run contract
 - 振る舞いの目標（behavior goal）:
-  - ...
+  - `spec-dock uninstall [path]` exists, defaults to dry-run, renders stable plan/result buckets, supports JSON plan output, and never mutates without `--apply`.
 - design 参照:
-  - ...
+  - `Interface contract`, `Uninstall Model`, `Directory / File 変更計画`
 - 依存:
-  - ...
+  - approved requirement/design
 - unblock:
-  - ...
+  - S02 inventory/classification, S03 apply, S04 wrapper
 - 対象ファイル:
-  - ...
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
 - 計画済み契約（planned contract）:
   - scope:
-    - 実装・文書化する範囲:
+    - Add installer parser for `uninstall [path] [--apply] [--keep-specs | --remove-specs] [--json]`.
+    - Add dry-run renderer with status buckets and JSON output.
+    - Add pre-mutation validation for target repo and specs mode.
   - テスト義務（test obligation）:
-    - closure id:
-      - tc-001
-    - coverage rationale:
-      - AC / changed contract / failure mode / regression risk / invariant / manual risk から必要性を書く:
+    - closure id: tc-001, tc-002, tc-003, tc-020, tc-023
+    - coverage rationale: destructive default, explicit specs mode, CLI contract, invalid target fail-fast, agent-readable plan output.
   - Red / 代替証跡の要件:
-    - red-required / covered-existing:
-      - 実装前に確認する failing test、characterization、または既存 test sensitivity:
-    - docs-only / inspect-only / manual-required:
-      - code test を置かない理由:
-      - 代替 evidence path:
-      - manual 手順と期待結果:
+    - red-required:
+      - tests in `tests/test_init_update.py` fail before implementation for dry-run no-mutation, apply missing mode, mutually exclusive flags, invalid target fail-fast, and JSON dry-run output.
   - 実装範囲（implementation scope）:
     - allowed paths:
-      - ...
+      - `src/spec_dock/cli.py`
+      - `tests/test_init_update.py`
     - forbidden changes:
-      - ...
+      - runtime wrapper, docs, broad module extraction, actual deletion logic beyond no-op skeleton.
   - Green 検証:
-    - command / inspection / manual evidence:
-      - ...
+    - `python -m unittest tests.test_init_update -v`
   - Refactor / cleanup ガードレール:
-    - 目的:
-    - 禁止する広がり:
+    - Keep helpers local and focused; no unrelated installer refactor.
   - closure 証跡要件:
-    - Step Contract Closure:
-    - Test Contract Closure:
-    - Closure Coverage:
-  - report 証跡の記録先:
-    - `report.md` の対象 section / ledger:
-  - amendment trigger（plan amendment が必要になる契機）:
-    - plan amendment と re-review が必要になる発見:
+    - Step Contract Closure, Test Contract Closure, Closure Coverage, Reviewer Gate Status, Step Commit Gate in `report.md`.
+  - amendment trigger:
+    - Need to remove `--json` or change the JSON top-level contract.
 
 #### 委任契約（delegation contract）
 - 委任ロール（delegated role）:
-  - dev-coder / doc-writer / other named worker / N/A
+  - dev-coder
 - 入力 docs:
-  - `requirement.md`
-  - `design.md`
-  - `plan.md`
-  - workflow / authoring docs:
-  - current target files:
+  - `requirement.md`, `design.md`, `plan.md`, `workflow_issue.md`, `tests/test_init_update.py`, `src/spec_dock/cli.py`
 - 許可 paths:
-  - ...
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
 - 禁止 changes:
-  - ...
+  - runtime command files, docs, package metadata, GitHub state, broad restructuring.
 - 受け入れ条件:
-  - closure id / step close condition:
+  - tc-001, tc-002, tc-003, tc-020, tc-023 close.
 - 必須 tests または docs-only verification:
-  - targeted command / inspection / docs diff / manual evidence:
+  - `python -m unittest tests.test_init_update -v`
 - reviewer focus:
-  - code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only docs/spec alignment）
+  - code-reviewer: CLI parser behavior, no-mutation default, usage exits, minimal scope.
 - 必須出力（output required）:
-  - changed files:
-  - verification result:
-  - report evidence to update:
-  - unresolved risks:
+  - changed files, test result, report ledger notes, unresolved risks.
 - 停止条件（stop conditions）:
-  - input docs conflict / path outside allowed scope / verification cannot run / acceptance cannot be met:
+  - CLI contract conflict with design, need for new module extraction, inability to assert no mutation.
 
 #### 具体テストケース一覧
-
-> この欄は full test inventory ではありません。step-local obligation と concrete red / characterization / inspect / manual seeds を、実装前に固定するための欄です。
-
-- `tc-s01-001` acceptance: <短い説明>
-  - 前提: ...
-  - 操作: ...
-  - 期待結果: ...
-  - 失敗検出: ...
-  - 検証方法: ...
+- `tc-s01-001` acceptance: dry-run prints plan and mutates no files
+  - 前提: temp repo initialized with SpecDock assets and representative files.
+  - 操作: call `main(["uninstall", target])`.
+  - 期待結果: exit `0`, output contains dry-run/plan buckets, pre/post filesystem snapshot is unchanged.
+  - 失敗検出: uninstall accidentally deletes files by default.
+  - 検証方法: `tests/test_init_update.py`.
   - 関連 closure id: tc-001
-
-- `tc-s01-002` inspect-only / manual-required: <短い説明>
-  - テスト不要理由: <自動テスト不要の理由>
-  - 代替検証方法: <確認手順>
-  - 期待結果: <期待される状態>
-  - 記録先: <証跡の保存先>
+- `tc-s01-002` negative: apply without specs mode fails before mutation
+  - 前提: temp repo initialized with specs and agent assets.
+  - 操作: call `main(["uninstall", target, "--apply"])`.
+  - 期待結果: exit `2`, error asks for `--keep-specs` or `--remove-specs`, files remain.
+  - 失敗検出: specs mode is implicit or mutation happens before validation.
+  - 検証方法: `tests/test_init_update.py`.
   - 関連 closure id: tc-002
+- `tc-s01-003` negative: keep/remove specs flags are mutually exclusive
+  - 前提: temp repo initialized.
+  - 操作: call uninstall with `--apply --keep-specs --remove-specs`.
+  - 期待結果: usage error before mutation.
+  - 失敗検出: ambiguous destructive mode is accepted.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-003
+- `tc-s01-004` negative: unmanaged target fails before mutation
+  - 前提: temp directory or Git repo lacks managed `spec-dock/` state.
+  - 操作: call `main(["uninstall", target])` and `main(["uninstall", target, "--apply", "--keep-specs"])`.
+  - 期待結果: exit `2`, output explains the target is not a managed SpecDock repo, and filesystem snapshot is unchanged.
+  - 失敗検出: invalid target proceeds to dry-run/apply or mutates non-managed repo content.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-020
+- `tc-s01-005` acceptance: dry-run json output is parseable and machine-readable
+  - 前提: temp repo initialized with representative remove/preserve candidates.
+  - 操作: call `main(["uninstall", target, "--json"])`.
+  - 期待結果: stdout is one parseable JSON object containing `schema_version`, `target`, `mode`, `apply`, `status`, `summary`, `actions`, `guidance`, and `errors`; `actions[]` entries expose `path`, `category`, `status`, and `reason` for `would_remove` and `preserved` examples; no human-readable lines are mixed into stdout.
+  - 失敗検出: agent execution cannot reliably parse dry-run plan semantics.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-023
 
 #### ステップ完了契約（step closure contract）
 - closure id:
-  - tc-001
+  - tc-001, tc-002, tc-003, tc-020, tc-023
 - close 条件:
-  - ...
+  - tests are red before implementation, green after, code-reviewer pass, report updated.
 - 検証 evidence:
-  - targeted command / inspection / manual evidence:
+  - `python -m unittest tests.test_init_update -v`
 - report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-  - Closure Delta:
+  - Step Contract Closure, Test Contract Closure, Closure Coverage, Reviewer Gate Status, Step Commit Gate.
 - 残リスク:
-  - ...
+  - inventory/apply behavior remains planned for S02/S03.
 
 #### ステップゲート（step gate）
 - step reviewer gate:
-  - reviewer:
-  - review 範囲:
+  - reviewer: code-reviewer
+  - review 範囲: installer CLI surface and tests
   - pass 条件: review_status: pass
-  - re-review rule: 指摘を修正し pass まで再実行
+  - re-review rule: fix findings and rerun fresh reviewer
 - commit / no-op gate:
-  - closure 状態: committed / approved-no-op
-  - commit 範囲:
-  - no-op の場合の確認対象、差分なし確認コマンド、read-only evidence:
+  - closure 状態: committed unless all S01 behavior already exists and is approved-no-op.
+  - commit 範囲: S01 files only
+  - no-op 条件: only allowed when tests and code-reviewer prove tc-001/tc-002/tc-003/tc-020/tc-023 already pass without source changes.
+  - report update: record Red/Green/Refactor, Step/Test Contract Closure, Reviewer Gate Status, and Step Commit Gate before commit or approved-no-op handoff.
 
-### 実装ステップ Sxx — <次に観測可能な振る舞い>
-- S01 の subsections を複製して記入する。
-- `planned contract`、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`step gate` がない implementation step は implementation-ready ではない。
+### 実装ステップ S02 — Inventory, category classification, and content policy
+- 振る舞いの目標（behavior goal）:
+  - dry-run produces correct remove/preserve/manual-review decisions from shipped assets and target repo state.
+- design 参照:
+  - `Uninstall Model`, `要件 → 設計マッピング`, `テスト戦略`
+- 依存:
+  - S01
+- unblock:
+  - S03
+- 対象ファイル:
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
+- 計画済み契約（planned contract）:
+  - scope:
+    - Build inventory from install_root current files, bootstrap-only, obsolete exact paths, scaffold-managed files, generated state, specs, repo-root shortcut, unknown boundary-root files.
+    - Apply category/content policies in dry-run only.
+  - テスト義務:
+    - closure id: tc-004, tc-005, tc-006, tc-007, tc-008, tc-009, tc-021
+    - coverage rationale: over-delete/under-delete prevention for every high-risk category.
+  - Red / 代替証跡の要件:
+    - red-required for each listed category/policy.
+  - 実装範囲:
+    - allowed paths:
+      - `src/spec_dock/cli.py`
+      - `tests/test_init_update.py`
+    - forbidden changes:
+      - actual file removal, runtime wrapper, docs.
+  - Green 検証:
+    - `python -m unittest tests.test_init_update -v`
+  - Refactor / cleanup ガードレール:
+    - Keep classification deterministic and derived from approved design categories.
+  - closure 証跡要件:
+    - report ledgers for all closure ids.
+  - amendment trigger:
+    - New deletion candidate source outside approved inventory.
 
-### ドキュメント影響の解消ステップ S90（docs impact resolution / docs refresh）
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md`, `design.md`, `plan.md`, `src/spec_dock/cli.py`, `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`
+- 許可 paths:
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
+- 禁止 changes:
+  - file deletion apply logic, runtime wrapper, docs.
+- 受け入れ条件:
+  - tc-004 through tc-009 and tc-021 close.
+- 必須 tests:
+  - `python -m unittest tests.test_init_update -v`
+- reviewer focus:
+  - code-reviewer: ownership classification, unknown-file preservation, comparison failure safety.
+- 必須出力:
+  - changed files, test result, report notes, any classification ambiguity.
+- 停止条件:
+  - Need to delete unknown files, need to alter requirement categories, comparison impossible to test hermetically.
+
+#### 具体テストケース一覧
+- `tc-s02-001` acceptance: known managed agent/skill mismatch planned for removal
+  - 前提: temp repo has edited known `.agents/skills/...` or `.codex/agents/...` file.
+  - 操作: dry-run uninstall.
+  - 期待結果: path is listed as would_remove, not preserved.
+  - 失敗検出: edited agent/skill remains as product noise.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-004
+- `tc-s02-002` negative: unknown files under managed roots are preserved
+  - 前提: temp repo has user-created `.agents/skills/custom/SKILL.md` or similar unknown file.
+  - 操作: dry-run uninstall.
+  - 期待結果: unknown file is preserved with unmanaged reason.
+  - 失敗検出: broad prefix deletion owns user files.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-005
+- `tc-s02-003` acceptance: exact-match bootstrap/product-reusable assets planned for removal
+  - 前提: `.codex/config.toml` and representative product-reusable file equal shipped asset.
+  - 操作: dry-run uninstall.
+  - 期待結果: files are would_remove.
+  - 失敗検出: shipped residue is left behind unnecessarily.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-006
+- `tc-s02-004` negative: mismatch bootstrap/product-reusable assets preserved
+  - 前提: `.codex/config.toml` or `.github/workflows/ci.yml` has user edit.
+  - 操作: dry-run uninstall.
+  - 期待結果: file is preserved with content mismatch/manual review reason.
+  - 失敗検出: user/product config is deleted.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-007
+- `tc-s02-007` negative: comparison errors preserve non-core assets
+  - 前提: representative product-reusable path is a file type mismatch, symlink mismatch, or read-failure fixture instead of a comparable regular file.
+  - 操作: dry-run uninstall.
+  - 期待結果: path is preserved/manual-review with comparison-error reason unless it belongs to the core agent/skill category.
+  - 失敗検出: comparison failure is treated as ownership proof and deletes user-owned content.
+  - 検証方法: `tests/test_init_update.py` using symlink/type fixture or hermetic read-failure monkeypatch.
+  - 関連 closure id: tc-021
+- `tc-s02-005` acceptance/negative: scaffold-managed exact match removes, mismatch preserves
+  - 前提: representative `spec-dock/docs/**` or `spec-dock/scripts/**` file has exact-match and mismatch variants.
+  - 操作: dry-run uninstall.
+  - 期待結果: exact-match is would_remove; mismatch is preserved/manual review.
+  - 失敗検出: scaffold cleanup contract is untested.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-008
+- `tc-s02-006` negative: repo-root spec shortcut target is verified
+  - 前提: repo-root `spec` is matching symlink, nonmatching symlink, regular file, or directory across fixtures.
+  - 操作: dry-run uninstall.
+  - 期待結果: only matching SpecDock shortcut is would_remove; others are preserved.
+  - 失敗検出: unrelated shortcut/file is deleted.
+  - 検証方法: `tests/test_init_update.py`, with symlink availability guard if needed.
+  - 関連 closure id: tc-009
+
+#### ステップ完了契約
+- closure id:
+  - tc-004, tc-005, tc-006, tc-007, tc-008, tc-009, tc-021
+- close 条件:
+  - all classification tests pass; code-reviewer pass; report updated.
+- 検証 evidence:
+  - `python -m unittest tests.test_init_update -v`
+- report evidence:
+  - Step/Test Contract Closure and Closure Coverage.
+- 残リスク:
+  - apply semantics deferred to S03.
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+  - review 範囲: inventory/classification/content policy
+  - pass 条件: review_status: pass
+- commit / no-op gate:
+  - closure 状態: committed unless all S02 behavior already exists and is approved-no-op.
+  - commit 範囲: S02 files only
+  - no-op 条件: only allowed when tests and code-reviewer prove all S02 closure ids already pass without source changes.
+  - report update: record Red/Green/Refactor, Step/Test Contract Closure, Reviewer Gate Status, and Step Commit Gate before commit or approved-no-op handoff.
+
+### 実装ステップ S03 — Apply engine, idempotency, partial failure, and bounded cleanup
+- 振る舞いの目標:
+  - apply executes planned actions safely, reports results, supports rerun, and cleans empty directories within boundaries.
+- design 参照:
+  - `Sequence Delta`, `リスク / 移行 / ロールバック`
+- 依存:
+  - S02
+- unblock:
+  - S04, S90
+- 対象ファイル:
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
+- 計画済み契約:
+  - scope:
+    - Apply only actions produced by S02.
+    - Implement `--keep-specs`, `--remove-specs`, generated state removal, bounded cleanup, idempotent rerun, partial failure summary, JSON apply result.
+  - テスト義務:
+    - closure id: tc-010, tc-011, tc-012, tc-013, tc-014, tc-022, tc-024
+  - Red / 代替証跡:
+    - red-required for apply modes, cleanup boundary, rerun, failure injection, JSON apply success/failure.
+  - 実装範囲:
+    - allowed paths: `src/spec_dock/cli.py`, `tests/test_init_update.py`
+    - forbidden changes: runtime wrapper, docs, deletion outside target fixture.
+  - Green 検証:
+    - `python -m unittest tests.test_init_update -v`
+  - amendment trigger:
+    - Need for automatic rollback or out-of-target deletion.
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md`, `design.md`, `plan.md`, S01/S02 implementation
+- 許可 paths:
+  - `src/spec_dock/cli.py`
+  - `tests/test_init_update.py`
+- 禁止 changes:
+  - runtime wrapper, docs, package/environment deletion, GitHub mutation.
+- 受け入れ条件:
+  - tc-010 through tc-014, tc-022, and tc-024 close.
+- 必須 tests:
+  - `python -m unittest tests.test_init_update -v`
+- reviewer focus:
+  - code-reviewer: filesystem safety, cleanup traversal, failure/idempotency.
+- 必須出力:
+  - changed files, test results, failure simulation method, report notes.
+- 停止条件:
+  - Need to touch repo root/parent, inability to simulate failure hermetically, conflict with content policy.
+
+#### 具体テストケース一覧
+- `tc-s03-001` acceptance: keep-specs preserves spec history
+  - 前提: temp repo has specs and managed tooling.
+  - 操作: apply uninstall with `--keep-specs`.
+  - 期待結果: tooling is removed; `spec-dock/initiatives/**` remains.
+  - 失敗検出: development restart history is lost.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-010
+- `tc-s03-002` acceptance: remove-specs removes spec history with explicit summary
+  - 前提: temp repo has specs and managed tooling.
+  - 操作: apply uninstall with `--remove-specs`.
+  - 期待結果: specs are removed and result explicitly reports spec history removal.
+  - 失敗検出: hidden or unreported destructive spec deletion.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-011
+- `tc-s03-003` negative: bounded cleanup respects preserved files and root boundaries
+  - 前提: boundary root contains removed files plus preserved file.
+  - 操作: apply uninstall.
+  - 期待結果: empty subdirs are removed, directories containing preserved files remain, repo root/`.git`/parent untouched.
+  - 失敗検出: over-broad directory cleanup.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-012
+- `tc-s03-004` acceptance: rerun is idempotent
+  - 前提: uninstall has already removed managed files.
+  - 操作: run same apply command again.
+  - 期待結果: command reports already_removed/no-op and exits successfully when no failures remain.
+  - 失敗検出: second run crashes or treats missing managed file as destructive error.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-013
+- `tc-s03-005` negative: partial failure reports failed separately
+  - 前提: unlink/rmtree is made to fail for a controlled target.
+  - 操作: apply uninstall.
+  - 期待結果: exit non-zero, failed path is reported separately from removed/preserved.
+  - 失敗検出: partial deletion is hidden as success.
+  - 検証方法: hermetic monkeypatch/mock in `tests/test_init_update.py`.
+  - 関連 closure id: tc-014
+- `tc-s03-006` acceptance: apply output provides installer-direct recovery guidance
+  - 前提: apply uninstall removes repo-local runtime wrapper or `spec-dock/scripts/**` from a temp repo.
+  - 操作: apply uninstall with an explicit specs mode.
+  - 期待結果: result summary includes guidance to rerun/reinstall through installer CLI, not only through the repo-local runtime command that may have been removed.
+  - 失敗検出: operator loses recovery path after self-removal.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-022
+- `tc-s03-007` acceptance/negative: apply json output covers success and partial failure
+  - 前提: temp repo has apply success fixture, preserved/manual-review item, bounded cleanup candidate, rerun fixture, and a separate injected unlink/rmtree failure fixture.
+  - 操作: apply uninstall with `--json` and an explicit specs mode; then rerun with `--json`; run failure fixture with `--json`.
+  - 期待結果: success returns JSON with `status: "completed"` and action-level `removed`, `preserved`, and `empty_dir_removed` examples; rerun returns `already_removed`; failure returns non-zero with parseable JSON containing `status: "partial_failure"`, `failed` action details, summary counts, and guidance. Each apply-side `actions[]` example includes `path`, `category`, `status`, `reason`, and `error`.
+  - 失敗検出: agent execution cannot reliably parse destructive operation result semantics or failures.
+  - 検証方法: `tests/test_init_update.py`.
+  - 関連 closure id: tc-024
+
+#### ステップ完了契約
+- closure id:
+  - tc-010, tc-011, tc-012, tc-013, tc-014, tc-022, tc-024
+- close 条件:
+  - apply behavior tests pass, code-reviewer pass, report updated.
+- 検証 evidence:
+  - `python -m unittest tests.test_init_update -v`
+- report evidence:
+  - Step/Test Contract Closure and Closure Coverage.
+- 残リスク:
+  - runtime wrapper still pending until S04.
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+  - review 範囲: apply engine, cleanup, failure/idempotency
+  - pass 条件: review_status: pass
+- commit / no-op gate:
+  - closure 状態: committed unless all S03 behavior already exists and is approved-no-op.
+  - commit 範囲: S03 files only
+  - no-op 条件: only allowed when tests and code-reviewer prove all S03 closure ids already pass without source changes.
+  - report update: record Red/Green/Refactor, Step/Test Contract Closure, Reviewer Gate Status, and Step Commit Gate before commit or approved-no-op handoff.
+
+### 実装ステップ S04 — Repo-local runtime uninstall wrapper
+- 振る舞いの目標:
+  - repo-local `uninstall` command delegates to installer CLI via `uvx --no-cache`.
+- design 参照:
+  - `Interface contract`, `Module Dependency Diagram`
+- 依存:
+  - S01, S03
+- unblock:
+  - S90, S99
+- 対象ファイル:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `tests/cli_runtime/test_uninstall.py`
+- 計画済み契約:
+  - scope:
+    - Mirror update wrapper structure.
+    - Forward target and supported flags, including `--json`.
+    - Propagate stdout/stderr/exit code and handle missing `uvx`.
+  - テスト義務:
+    - closure id: tc-015, tc-016, tc-017, tc-025
+  - Red / 代替証跡:
+    - red-required with stubbed `uvx`.
+  - 実装範囲:
+    - allowed paths listed above.
+    - forbidden changes: installer removal logic in runtime, arbitrary source/cache overrides.
+  - Green 検証:
+    - `python -m unittest tests.cli_runtime.test_uninstall -v`
+  - amendment trigger:
+    - Need to add arbitrary upstream/package source options.
+
+#### 委任契約（delegation contract）
+- 委任ロール:
+  - dev-coder
+- 入力 docs:
+  - `requirement.md`, `design.md`, `plan.md`, `commands/update.py`, runtime parser/registry files
+- 許可 paths:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py`
+  - `tests/cli_runtime/test_uninstall.py`
+- 禁止 changes:
+  - installer code, docs, package metadata, arbitrary uvx override options.
+- 受け入れ条件:
+  - tc-015, tc-016, tc-017, tc-025 close.
+- 必須 tests:
+  - `python -m unittest tests.cli_runtime.test_uninstall -v`
+- reviewer focus:
+  - code-reviewer: wrapper parity with update, argument forwarding, missing uvx handling.
+- 必須出力:
+  - changed files, test result, report notes.
+- 停止条件:
+  - Runtime needs to reimplement installer logic or accepted flags diverge from installer CLI.
+
+#### 具体テストケース一覧
+- `tc-s04-001` acceptance: wrapper invokes uvx no-cache installer uninstall
+  - 前提: runtime command test harness with stubbed `uvx`.
+  - 操作: run repo-local `uninstall` with default target.
+  - 期待結果: command args contain `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <resolved-target>`.
+  - 失敗検出: wrapper bypasses installer or omits no-cache upstream source.
+  - 検証方法: `tests/cli_runtime/test_uninstall.py`.
+  - 関連 closure id: tc-015
+- `tc-s04-002` acceptance: wrapper forwards flags and propagates output/exit code
+  - 前提: stubbed `uvx` emits stdout/stderr and exits non-zero.
+  - 操作: run `uninstall --apply --keep-specs`.
+  - 期待結果: flags are forwarded; stdout/stderr/exit code are propagated.
+  - 失敗検出: installer evidence is lost or flags are dropped.
+  - 検証方法: `tests/cli_runtime/test_uninstall.py`.
+  - 関連 closure id: tc-016
+- `tc-s04-004` acceptance: wrapper forwards json and preserves json stdout
+  - 前提: stubbed `uvx` records args and emits JSON stdout.
+  - 操作: run `uninstall --json --apply --keep-specs`.
+  - 期待結果: `--json` is forwarded to installer CLI; stdout JSON is propagated unchanged.
+  - 失敗検出: repo-local command drops machine-readable output for agent execution.
+  - 検証方法: `tests/cli_runtime/test_uninstall.py`.
+  - 関連 closure id: tc-025
+- `tc-s04-003` negative: missing uvx exits with guidance
+  - 前提: PATH lacks `uvx`.
+  - 操作: run runtime uninstall.
+  - 期待結果: exit `127` and actionable install/PATH guidance.
+  - 失敗検出: opaque FileNotFoundError or wrong exit status.
+  - 検証方法: `tests/cli_runtime/test_uninstall.py`.
+  - 関連 closure id: tc-017
+
+#### ステップ完了契約
+- closure id:
+  - tc-015, tc-016, tc-017, tc-025
+- close 条件:
+  - runtime tests pass, code-reviewer pass, report updated.
+- 検証 evidence:
+  - `python -m unittest tests.cli_runtime.test_uninstall -v`
+- report evidence:
+  - Step/Test Contract Closure and Closure Coverage.
+- 残リスク:
+  - docs impact remains for S90.
+
+#### ステップゲート
+- step reviewer gate:
+  - reviewer: code-reviewer
+  - review 範囲: runtime wrapper and tests
+  - pass 条件: review_status: pass
+- commit / no-op gate:
+  - closure 状態: committed unless all S04 behavior already exists and is approved-no-op.
+  - commit 範囲: S04 files only
+  - no-op 条件: only allowed when tests and code-reviewer prove tc-015/tc-016/tc-017/tc-025 already pass without source changes.
+  - report update: record Red/Green/Refactor, Step/Test Contract Closure, Reviewer Gate Status, and Step Commit Gate before commit or approved-no-op handoff.
+
+### ドキュメント影響の解消ステップ S90 — docs impact resolution / docs refresh
 - 対象:
-  - docs / templates / README / workflow / skill / migration notes / none
+  - `src/spec_dock/assets/spec_dock/docs/reference_github.md`
+  - `src/spec_dock/assets/spec_dock/docs/reference_sync.md`
+  - CLI help tests from S01/S04
 - 対応:
-  - ...
+  - `reference_github.md` に、uninstall が GitHub issue / remote state を変更せず、package/environment uninstall でもない repo-local managed artifact removal であることを追記する。
+  - `reference_sync.md` は generated state と uninstall cleanup の説明が必要か点検し、不要なら `report.md` に no-op rationale を記録する。
+  - installer/runtime help が final flag contract と一致することを tests で確認する。
 - doc update owner:
   - doc-writer when updates are required
 - spec/doc review:
   - reviewer: spec-reviewer
-  - pass 条件: docs が requirement / design / plan と整合し、未解決の必須 docs 影響が残っていない
+- 具体テストケース一覧:
+  - `tc-s90-001` inspect-only: docs boundary matches uninstall contract
+    - 前提: S01-S04 implementation complete.
+    - 操作: inspect provider docs and help output.
+    - 期待結果: docs/help state no GitHub mutation, no package/environment uninstall, and explain repo-local artifact removal.
+    - 失敗検出: operator docs imply GitHub/package uninstall side effects.
+    - 検証方法: docs diff inspection plus relevant unittest/help assertions.
+    - 関連 closure id: tc-018
+- step closure contract:
+  - close 条件: docs updated or no-op rationale recorded, spec-reviewer pass.
+  - report evidence: Docs Impact Resolution, Reviewer Gate Status.
+- step gate:
+  - reviewer: spec-reviewer; code-reviewer if tests/code changed.
+  - no-op 条件: allowed only when docs inspection records that existing docs/help already cover tc-018, tc-022, and `--json` agent-execution guidance without changes.
+  - report update: record Docs Impact Resolution and Reviewer Gate Status before S99.
 
-### 最終品質ゲートステップ S99（final quality gate）
-- branch diff 範囲:
-  - ...
-- 必須 validation:
-  - ...
-- final QA gate:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage と integration test 要否
-  - pass 条件: reviewer pass
-- final code review ゲート:
-  - reviewer: code-reviewer
-  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性
-  - pass 条件: review_status: pass
-- final spec review ゲート:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合
-  - pass 条件: reviewer pass
-- final commit gate:
-  - commit 範囲:
-  - final report ledger:
-  - post-commit external evidence destination:
+### 最終品質ゲート S99 — final quality gate
+- 対象:
+  - whole issue integrated diff and evidence
+- 対応:
+  - Run focused tests and full baseline, validate/sync, diff checks.
+  - Run final QA/code/spec reviewers.
+  - Ensure all closure ids are covered in `report.md`.
+- 必須コマンド / evidence:
+  - `python -m unittest tests.test_init_update -v`
+  - `python -m unittest tests.cli_runtime.test_uninstall -v`
+  - `python -m unittest discover -v`
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync` or `./spec-dock/scripts/spec-dock sync --no-github` with opt-out reason
+  - `git diff --check`
+- final reviewers:
+  - qa-reviewer: test sufficiency and integration-test need
+  - code-reviewer: issue-wide integrated diff
+  - spec-reviewer: requirement/design/plan/report/docs/implementation/test consistency
+- 具体テストケース一覧:
+  - `tc-s99-001` manual-required: final gate bundle complete
+    - 前提: S01-S04 and S90 closed.
+    - 操作: run required commands and reviewers.
+    - 期待結果: commands pass or blockers are recorded; reviewers return pass.
+    - 失敗検出: issue handed off with missing closure or stale reviewer state.
+    - 検証方法: report final quality gate evidence.
+    - 関連 closure id: tc-019
+- step closure contract:
+  - close 条件: all final gates pass and report evidence is complete.
+  - report evidence: Final Quality Gate, Closure Coverage, Reviewer Gate Status.
+- step gate:
+  - reviewer: qa-reviewer, code-reviewer, spec-reviewer
+  - no-op 条件: not applicable; S99 is evidence-only but required.
+  - report update: record Final Quality Gate, complete Closure Coverage, final Reviewer Gate Status, and any blockers before issue handoff.
 
-## 未確定事項
-- Q-001:
-  - 質問:
-  - 推奨案:
-  - 影響範囲:
-
-## 最終完了条件
-- AC/EC 達成:
-  - ...
-- docs 影響解決:
-  - ...
-- 全 implementation step 完了:
-  - committed / approved-no-op:
-- final quality gate pass:
-  - qa-reviewer:
-  - issue-wide code-reviewer:
-  - spec-reviewer:
-- final commit 完了:
-  - ...
-- 必須 closure id 完了:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-- final clean state:
-  - no unintended staged / unstaged changes:
+## Final Exit Contract
+- Implementation readiness:
+  - Plan gate must have fresh spec-reviewer pass before issue execution starts.
+  - All required closure ids are mapped to steps and have planned verification evidence.
+- Completion readiness after execution:
+  - Every implementation step is committed or approved-no-op with report evidence.
+  - S90 docs impact is resolved.
+  - S99 final QA/code/spec gates pass.
+  - `report.md` has no open decision ledger entries or unresolved blocking EAL entries.
+- Not included:
+  - This plan does not perform `issue finish`, PR creation, merge preparation, or lifecycle closure.

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -285,7 +285,7 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S01 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S01 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
+| S01 | committed | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S01 evidence | `96a1fa89280e7d2332f41b8e84991bc9d0b90d6d` | `git status --short` after commit -> clean | N/A | N/A | N/A | N/A |
 
 #### 変更したファイル
 - `src/spec_dock/cli.py` - installer uninstall S01 command surface and dry-run/JSON skeleton.
@@ -293,7 +293,8 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 - `spec-dock/active/issue/report.md` - S01 observed evidence ledger.
 
 #### コミット
-- pending S01 step commit.
+- `96a1fa89280e7d2332f41b8e84991bc9d0b90d6d`
+- message: `feat(installer): uninstall のコマンド面を追加`
 
 #### メモ
 - Worker reported: No material implementation decisions beyond the approved plan.
@@ -303,11 +304,102 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 ### セッションログ（2026-05-31 HH:MM - HH:MM）
 
 #### 対象
-- Step: ...
-- AC/EC: ...
+- Step: S02
+- AC/EC: AC-005, AC-006, AC-007, EC-006, EC-007
+- closure ids: tc-004, tc-005, tc-006, tc-007, tc-008, tc-009, tc-021
 
 #### 実施内容
-- ...
+- `uninstall` dry-run を S01 skeleton から S02 inventory / category classification / content policy 実装へ差し替えた。
+- `install_root` current assets、obsolete exact paths、scaffold assets、generated state、spec history、repo-root `spec` shortcut、unknown boundary-root files を dry-run action に分類するようにした。
+- agent / native agent は known SpecDock-managed path なら mismatch でも `would_remove`、bootstrap-only / product-reusable / scaffold-managed は exact match のみ `would_remove`、mismatch / comparison error は `preserved` とした。
+- `--apply` は S03 scope のまま deferred で、S02 では filesystem mutation を追加していない。
+
+#### 実行コマンド / 結果
+```bash
+python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall
+
+Ran 18 tests in 1.613s
+OK
+
+git diff --check -- src/spec_dock/cli.py tests/test_init_update.py
+
+pass
+
+git diff --check
+
+pass
+
+python -m unittest tests.test_init_update -v
+
+Ran 196 tests
+FAILED (failures=1)
+known unrelated observed failure: test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json
+reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
+```
+
+#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
+| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|---|
+| S02 | 赤フェーズ | red-required | tc-005, tc-006, tc-007, tc-021, tc-008, tc-009 tests failed before implementation because S01 skeleton did not emit those inventory actions | delegated dev-coder command | pass | tc-004 was covered-existing by S01 representative known skill and expanded in S02 |
+| S02 | 緑フェーズ | focused uninstall command | 18 uninstall tests passed | `python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall` | pass | S01 + S02 uninstall behavior passed |
+| S02 | リファクタリング | guardrail satisfied | dry-run inventory only; apply remains deferred | diff inspection and `git diff --check` | pass | no runtime wrapper/docs/apply changes |
+
+#### 発見されたテスト / リスク（Discovered Tests）
+| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
+|---|---|---|---|---|---|---|
+| S02 | full `tests.test_init_update` still has dogfooding `.meta.json` snapshot drift failure | verification | recorded as broad-suite blocker to resolve before final S99 | N/A | no | `test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` failure |
+
+#### ステップ契約の完了証跡（Step Contract Closure）
+| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|
+| S02 | tc-004, tc-005, tc-006, tc-007, tc-008, tc-009, tc-021 | classification tests pass, code-reviewer pass, report updated | red evidence captured by dev-coder; focused 18-test command pass; report updated; code-reviewer Darwin pass | pass | S02 ready for step commit |
+
+#### テスト契約の完了証跡（Test Contract Closure）
+| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| tc-004 | S02 | yes | red-required | covered-existing S01 representative known skill; expanded S02 inventory | focused uninstall command | pass | known managed agent/skill mismatch planned for removal |
+| tc-005 | S02 | yes | red-required | S01 skeleton did not emit unknown boundary actions | focused uninstall command | pass | unknown files under managed roots preserved |
+| tc-006 | S02 | yes | red-required | S01 skeleton did not emit bootstrap/product-reusable exact-match actions | focused uninstall command | pass | exact-match bootstrap/product-reusable assets would_remove |
+| tc-007 | S02 | yes | red-required | S01 skeleton did not emit mismatch preservation actions | focused uninstall command | pass | mismatch assets preserved with manual review reason |
+| tc-021 | S02 | yes | red-required | S01 skeleton did not emit comparison-error preservation actions | focused uninstall command | pass | symlink/type mismatch preserve |
+| tc-008 | S02 | yes | red-required | S01 skeleton did not emit scaffold-managed exact/mismatch actions | focused uninstall command | pass | scaffold exact match removes, mismatch preserves |
+| tc-009 | S02 | yes | red-required | S01 skeleton did not inspect repo-root `spec` variants | focused uninstall command | pass | only matching shortcut would_remove |
+
+#### クロージャ網羅（Closure Coverage）
+| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
+|---|---|---|---|---|
+| tc-004 | S02 | `test_uninstall_dry_run_removes_known_agent_skill_mismatch` | pass | known managed skill mismatch remains removal candidate |
+| tc-005 | S02 | `test_uninstall_dry_run_preserves_unknown_files_under_managed_roots` | pass | unknown files in `.agents`, `.codex`, `.github`, `spec-dock` preserved |
+| tc-006 | S02 | `test_uninstall_dry_run_removes_exact_match_bootstrap_and_product_reusable_assets` | pass | exact-match bootstrap/product-reusable assets would_remove |
+| tc-007 | S02 | `test_uninstall_dry_run_preserves_mismatch_bootstrap_and_product_reusable_assets` | pass | mismatch preserved/manual review |
+| tc-021 | S02 | `test_uninstall_dry_run_preserves_non_core_comparison_errors_for_manual_review` | pass | type/symlink comparison errors preserved/manual review |
+| tc-008 | S02 | `test_uninstall_dry_run_scaffold_managed_exact_match_removes_and_mismatch_preserves` | pass | scaffold exact match vs mismatch policy |
+| tc-009 | S02 | `test_uninstall_dry_run_spec_shortcut_only_removes_matching_symlink` | pass | matching symlink removed, nonmatching/file/directory preserved |
+
+#### クロージャ差分（Closure Delta）
+| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
+|---|---|---|---|---|---|---|
+| added | S02 classification tests | listed S02 uninstall dry-run tests | tc-004 through tc-009 and tc-021 | S02 inventory/category/content policy closure | no | yes |
+
+#### 実装委任ゲート（Implementation Delegation Gate）
+| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S02 | delegated | inventory/classification logic and tests change | dev-coder | dry-run inventory/category/content policy | `plan.md` S02 | `src/spec_dock/cli.py`, `tests/test_init_update.py` | actual apply deletion, runtime wrapper, docs | focused uninstall tests; `python -m unittest tests.test_init_update -v`; `git diff --check` | need to delete unknown files, category conflict, comparison impossible to test hermetically | changed files, tests, Ledger Note | pass; reviewer pending |
+
+#### 委任 worker 証跡（Delegated Worker Evidence）
+| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
+|---|---|---|---|---|---|---|---|
+| S02 | dev-coder | Replaced S01 skeleton with S02 dry-run inventory/classification for install_root assets, scaffold assets, generated state, specs, shortcut, and unknown boundary files | `src/spec_dock/cli.py`; `tests/test_init_update.py` | focused uninstall command -> pass (`Ran 18 tests`); full `tests.test_init_update` -> fail with known dogfooding `.meta.json` snapshot drift; `git diff --check` -> pass | Darwin final review passed with no findings | apply/delete engine and empty-dir cleanup remain S03; broad suite snapshot drift remains for S99 | accepted for S02 step commit |
+
+#### レビューゲート状態（Reviewer Gate Status）
+| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| S02 | step code review | code-reviewer | fresh | passed | N/A | proceed to S02 step commit | Darwin: review_status=pass; no findings |
+
+#### ステップ commit ゲート（Step Commit Gate）
+| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
+|---|---|---|---|---|---|---|---|---|
+| S02 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S02 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
 
 ---
 

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -49,7 +49,9 @@ Disposition ごとの必須証跡:
 
 | 識別子（ID） | 状態（Status） | 種別（Type） | 起票元（Raised By） | 契機 / 差分（Gap） | 検討した選択肢 | 判断 / 解釈 | 根拠（Rationale） | 処置（Disposition） | 証跡（Evidence） | フォローアップ（Follow-up） |
 |---|---|---|---|---|---|---|---|---|---|---|
-| D-001 | 未解決 / 解決済み / 置換済み（open / resolved / superseded） | 解釈 / 範囲 / 実装 / 互換性 / テスト戦略 / 運用 / 逸脱 / フォローアップ（interpretation / scope / implementation / compatibility / test-strategy / operation / deviation / follow-up） | 起票元（orchestrator / reviewer / worker source） | 計画の曖昧さ / 実装制約 / レビュー指摘 / 発見リスク（plan ambiguity / implementation constraint / reviewer finding / discovered risk） | 選択肢 A; 選択肢 B; 対応なし（option A; option B; no action） | ... | ... | 採用 / 却下 / design 昇格 / ADR 昇格 / plan 昇格 / follow-up 化 / 延期 / 対応なし / 置換済み（applied / rejected / promoted_to_design / promoted_to_adr / promoted_to_plan / converted_to_followup / deferred / no_action / superseded） | `path` / コマンド / reviewer 指摘 / discussion（path / command / reviewer finding / discussion） | 対象 artifact / issue / discussion / 置換先 entry / 理由付き対応なし（target artifact / issue / discussion / replacement entry / none with reason） |
+| D-001 | resolved | scope | spec-reviewer | parent epic scope did not originally include uninstall command | update parent epic; move issue; stop planning | parent epic requirement/design were extended to include uninstall command scope | user requested uninstall issue under lifecycle command expansion and parent epic already owned repo-local lifecycle commands | applied | parent epic `requirement.md` / `design.md`; requirement review Godel pass | none |
+| D-002 | resolved | test-strategy | spec-reviewer | design test strategy did not explicitly mention scaffold-managed removal coverage | add design coverage; defer to plan only | scaffold-managed exact-match removal and mismatch-preserve coverage added to design test strategy | scaffold-managed runtime/docs files are core repo-local uninstall targets | applied | design review Avicenna pass with P2 finding; `design.md` test strategy | plan closure mapping |
+| D-003 | resolved | scope | user | design Q-001 asked whether `--json` belongs in initial implementation | human-readable only; include `--json` now | initial implementation must include JSON output because agents may execute uninstall | agent execution requires machine-readable plan/result output, so JSON is part of the primary command contract | applied | `discussions/20260531t144040z-interview-uninstall-json-output.md`; requirement/design/plan amendment | fresh spec-reviewer re-review |
 
 ## 証跡採用台帳（Evidence Adoption Ledger / 必須）
 
@@ -63,7 +65,22 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 
 | 識別子（ID） | 採用状態（adoption_status） | 出所（source） | 対象（target） | 判断理由（rationale） | 証跡（evidence） | 次アクション（next_action） |
 |---|---|---|---|---|---|---|
-| EAL-001 | 採用（`adopted`） / 部分採用（`partially_adopted`） / 棄却（`rejected`） / 延期（`deferred`） / stale（`stale`） / blocked（`blocked`） | サブエージェント（`sub-agent`） / レビュアー（`reviewer`） / 議論（`discussion`） / コマンド（`command`） / 調査（`research`） | 成果物（`artifact`） / Issue（`issue`） / フォローアップ（`follow-up`） | ... | `path` / コマンド / レビュアー指摘 | なし / フォローアップ（`follow-up`） / 再レビュー（`re-review`） / 再訪条件（`revisit condition`） |
+| EAL-001 | adopted | discussion | `requirement.md` | repo-local uninstall を primary objective として採用し、package/environment uninstall を対象外にした | `discussions/20260531t133315z-interview-uninstall-command-scope.md` | requirement review |
+| EAL-002 | adopted | discussion | `requirement.md` | specs は開発再開可能性と使い捨て cleanup の両方があるため、実削除時の explicit mode selection として採用した | `discussions/20260531t133616z-interview-uninstall-removal-boundary.md` | requirement review |
+| EAL-003 | adopted | discussion | `requirement.md` | bootstrap-only / user-owned 候補は content match の場合だけ自動削除し、mismatch は preserve + manual review とした | `discussions/20260531t134004z-interview-uninstall-user-owned-asset-boundary.md` | requirement review |
+| EAL-004 | adopted | discussion | `requirement.md` | repo-local wrapper + installer implementation の二層 command surface を採用した | `discussions/20260531t134206z-interview-uninstall-command-surface.md` | requirement review |
+| EAL-005 | adopted | discussion | `requirement.md` | agent / skill assets は mismatch でも削除し、CI / config / prompt / rule は mismatch preserve とする category-based removal を採用した | `discussions/20260531t134650z-interview-uninstall-managed-asset-mismatch.md` | requirement review |
+| EAL-006 | adopted | discussion | `requirement.md` | uninstall 後の empty directory は boundary root 内で bounded cleanup する方針を採用した | `discussions/20260531t135206z-interview-uninstall-empty-directory-cleanup.md` | requirement review |
+| EAL-007 | adopted | discussion synthesis from consultant | `requirement.md` | 削除対象分類、comparison 判定不能時 preserve、partial failure / idempotency を requirement-level safety criteria として補強した | `discussions/20260531t141123z-disc-uninstall-requirement-risk-synthesis.md` | requirement review |
+| EAL-008 | adopted | research synthesis from repo-analyst | `requirement.md` | installer/runtime split、repo-local update wrapper pattern、install_root inventory、repo-root `spec` shortcut、self-removal recovery risk を requirement grounding に採用した | `discussions/20260531t141121z-research-uninstall-repo-analysis-evidence.md` | requirement review |
+| EAL-009 | adopted | reviewer: spec-reviewer | parent epic `requirement.md` / `design.md`, issue `requirement.md`, interview provenance | requirement reviewer fail findingsを採用し、parent epic scope bridge、AC-007 known managed path限定、interview `reflected_to` を修正した | spec-reviewer Hilbert, review_status=fail, 2026-05-31 | re-review |
+| EAL-010 | adopted | delegated draft: system-architect | `design.md` | installer/runtime split、inventory/result model、bounded cleanup、failure/idempotency、test surface を design に採用した | `discussions/20260531t141545z-disc-uninstall-design-draft.md` | design review |
+| EAL-011 | adopted | reviewer: spec-reviewer | `report.md`, `design.md`, design draft | design reviewer fail findings を採用し、delegated draft evidence の矛盾を解消し、docs impact handoff を具体化した | spec-reviewer Bacon, review_status=fail, 2026-05-31 | design re-review |
+| EAL-012 | adopted | delegated draft: implementation-planner | `plan.md` | S01-S04/S90/S99 の実行順、closure index、test obligations、docs impact、final gate を plan に採用した | `discussions/20260531t142649z-disc-uninstall-implementation-plan.md` | plan review |
+| EAL-013 | adopted | reviewer: spec-reviewer | `plan.md` | plan reviewer fail findings を採用し、invalid target closure、comparison-error preservation、runtime-removal recovery guidance、no-op/report-update gates を plan に追加した | spec-reviewer Gibbs, review_status=fail, 2026-05-31 | plan re-review |
+| EAL-014 | adopted | interview | `requirement.md`, `design.md`, `plan.md` | user answer requires JSON output in initial implementation because agents may execute uninstall | `discussions/20260531t144040z-interview-uninstall-json-output.md` | fresh spec-reviewer re-review |
+| EAL-015 | adopted | reviewer: spec-reviewer | `plan.md` | JSON amendment reviewer fail findingを採用し、agent が判別する action-level `status` / `category` / `reason` coverage を tc-023 / tc-024 に追加した | spec-reviewer Zeno, review_status=fail, 2026-05-31 | JSON amendment re-review |
+| EAL-016 | adopted | reviewer: spec-reviewer | `plan.md` | JSON amendment re-review の P2 を採用し、apply-side `actions[]` の `path` / `category` / `status` / `reason` / `error` assertion を tc-s03-007 に追加した | spec-reviewer Heisenberg, review_status=pass, 2026-05-31 | no re-review required; P2 applied |
 
 ## 目的整合台帳（Objective Alignment Ledger / 必須）
 
@@ -71,7 +88,7 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 
 | 対象 | 主要目的の証跡（primary objective evidence） | 副次要件の証跡（secondary requirement evidence） | 逆転リスク（inversion risk） | レビュアー判定（reviewer verdict） |
 |---|---|---|---|---|
-| OAL-001 | ... | ... | なし / 低 / 中 / 高（none / low / medium / high） | 合格 / 不合格 / blocked（pass / fail / blocked） |
+| OAL-001 | agent / skill noise removal を primary objective として `requirement.md` に固定 | specs preservation/removal、user edit protection、runtime recovery、bounded cleanup | medium: user edit protection が強すぎると noise removal が不完全になり、agent/skill mismatch deletion が強すぎると user edit loss risk がある | pending spec-reviewer |
 
 ## 仕様 authoring ゲート（Spec Authoring Gate / 必須）
 
@@ -79,7 +96,9 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 
 | フェーズ（phase） | 調査証跡（investigated facts） | 未確定事項 / 回答（open questions / answers） | 採用判断（adoption decision） | レビュアー判定（reviewer verdict） | ブロック有無（blocking） | 昇格 / 次アクション（promotion / next_action） |
 |---|---|---|---|---|---|---|
-| 要件 / 設計 / 計画（requirement / design / plan） | 文書 / コード / discussions / 外部証跡（docs / code / discussions / external evidence） | なし / `discussions/...`（none / `discussions/...`） | 採用 / 部分採用 / 棄却 / 延期 / なし（adopted / partially_adopted / rejected / deferred / none） | 合格 / 不合格 / 利用不可 / 拒否 / waiver / provisional（passed / failed / unavailable / denied / waived / provisional） | はい / いいえ（yes / no） | 昇格 / clarification へ戻す / 再レビュー / フォローアップ（promote / return to clarification / re-review / follow-up） |
+| requirement | active issue scaffold, parent epic requirement/design, installer CLI, install_root metadata, runtime update/delete commands, tests, six interview artifacts, consultant/repo-analyst findings | answered: uninstall scope, specs mode, bootstrap-only boundary, command surface, mismatch category, empty-dir cleanup | adopted into `requirement.md`; parent epic scope bridge added after reviewer finding | passed: spec-reviewer Godel, 2026-05-31 | no | promote to design |
+| design | approved requirement, parent epic requirement/design, repo analysis research, requirement risk synthesis, system-architect design draft, installer/runtime source files, JSON interview answer | no open requirement gaps; `--json` resolved as in scope | adopted system-architect draft into `design.md`; reviewer fixes applied for provenance and docs handoff; P2 scaffold coverage added; JSON output contract added after user answer | passed: spec-reviewer Heisenberg, 2026-05-31; prior Zeno fail fixed | no | approved after JSON amendment |
+| plan | approved requirement/design, phase_plan_issue, authoring/issue-plan, implementation-planner draft, first plan review findings, fresh plan re-review, JSON interview answer | no open design gaps; `--json` in scope | adopted S01-S04/S90/S99 plan structure into `plan.md`; added reviewer-required closure rows and gate evidence requirements; added JSON closure/test obligations | passed: spec-reviewer Heisenberg, 2026-05-31; prior Zeno fail fixed; P2 apply-side field assertion applied | no | promote to implementation readiness |
 
 ## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
 - 委任 authoring の使用:
@@ -107,7 +126,8 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 
 | ロール（created_by_role） | 範囲（scope_id） | ドラフトパス（discussion draft path） | 参照元（source_paths） | 予定反映先（intended_targets） | 採用状態（adoption_status） | 反映先（reflected_to） | 差分ガード結果（diff_guard_result） | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果（reviewer result） | 昇格判断（promotion decision） |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| 該当なし | 該当なし | 該当なし | 該当なし | 該当なし | 未使用（not used） | なし（[]） | 未実行（not_run） | 手動 authoring | 該当なし | なし（none） | 該当なし | 委任ドラフト昇格なし |
+| spec-dock-system-architect | iss-00147 | `discussions/20260531t141545z-disc-uninstall-design-draft.md` | approved requirement, parent epic docs, repo analysis, requirement synthesis, installer/runtime source, tests | `design.md`, `plan.md`, `report.md` | adopted | `design.md` | manual_orchestrator_check_passed_new_issue_discussion_only | adopted into canonical design by orchestrator | none | none | passed design spec-reviewer Avicenna | canonical design promoted to plan |
+| spec-dock-implementation-planner | iss-00147 | `discussions/20260531t142649z-disc-uninstall-implementation-plan.md` | approved requirement/design, workflow/plan docs, installer/runtime source, tests | `plan.md`, `report.md` | adopted | `plan.md` | manual_orchestrator_check_passed_new_issue_discussion_only_dirty_baseline | adopted into canonical plan by orchestrator | none | none | passed plan spec-reviewer Ptolemy after Gibbs fixes | canonical plan promoted to implementation readiness |
 
 ### 委任ドラフトの失敗モード（Delegated Draft Failure Modes）
 | 失敗モード | 期待される判定 | 許可される次アクション | レポート証跡の記録先（report evidence destination） | 昇格可否 |
@@ -186,7 +206,7 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 
 | 同意元（consent source） | リポジトリ / worktree（repo/worktree） | 対象課題（active issue） | セッション（session） | 指名ロール（named roles） | 境界（boundary） | 期限 / 無効化条件（expires / invalidation condition） | 拒否 / 利用不可理由（denied / unavailable reason） | 次アクション（next action） |
 |---|---|---|---|---|---|---|---|---|
-| user instruction / explicit approval / none | ... | iss-00147 | current session / ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | same repo, active issue, session, named role; no destructive action / publishing / credentialed access / scope expansion / write-capable delegation / private external system use | issue complete / session end / scope change / host policy conflict / user revocation | none / denied / unavailable / host conflict | proceed / ask user / block gate / record waiver request |
+| user instruction | `/Users/iwasawayuuta/.codex/worktrees/f413/spec-dock` | iss-00147 | current session | spec-reviewer, system-architect, implementation-planner, consultant, repo-analyst, researcher as needed | same repo, active issue, session, named role; canonical docs remain orchestrator-owned; no destructive action / publishing / credentialed access / scope expansion | issue planning complete / session end / scope change / user revocation | none | proceed with scoped planning and review gates |
 
 #### 実装委任ゲート（Implementation Delegation Gate）
 `workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records observed evidence only.
@@ -209,6 +229,13 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 | ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
 |---|---|---|---|---|---|---|---|
 | S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
+| requirement | requirement spec review | spec-reviewer | fresh | passed | N/A | proceed to design | Godel: no findings; parent scope and provenance blockers fixed |
+| design | design spec review | spec-reviewer | fresh | passed | N/A | proceed to plan | Avicenna: no blocking findings; P2 scaffold coverage and decision ledger cleanup applied |
+| plan | plan spec review | spec-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Gibbs: P1 closure gaps for EC-001, EC-006, AC-008/EC-005; P2 no-op/report-update gates |
+| plan | plan spec re-review | spec-reviewer | fresh | passed | N/A | proceed to implementation readiness | Ptolemy: blocking Gibbs findings resolved; P2 stale delegated design draft reviewer state fixed |
+| requirement/design/plan | JSON amendment spec re-review | spec-reviewer | pending | pending | N/A | blocked until fresh pass | `--json` moved into initial scope after user answer |
+| requirement/design/plan | JSON amendment spec review | spec-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Zeno: P1 action-level JSON state coverage gap fixed in tc-023/tc-024 |
+| requirement/design/plan | JSON amendment spec re-review | spec-reviewer | fresh | passed | N/A | proceed to implementation readiness | Heisenberg: Zeno P1 resolved; P2 apply-side category/reason assertions applied |
 
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -56,6 +56,9 @@ Disposition ごとの必須証跡:
 | D-005 | resolved | implementation | code-reviewer / dev-coder | shared target directory validation bypassed uninstall JSON for missing/file targets | leave as non-blocking P2; route uninstall target validation through uninstall preflight | route uninstall command through `_run_uninstall` before the shared init/update directory check | keeps `--json` output parseable for all uninstall preflight failures while preserving non-json stderr behavior | applied | Averroes P2 finding; `test_uninstall_json_missing_target_path_returns_json_error`; `test_uninstall_json_file_target_returns_json_error_without_mutation` | none |
 | D-006 | superseded | implementation | dev-coder / code-reviewer | keep-specs rerun after apply removes `spec-dock/spec-dock.version` but preserves `spec-dock/initiatives` | strict version preflight; relax all apply preflight; accept missing version only when initiatives remains | initiatives-only fallback is unsafe and is replaced by D-007 retry marker semantics | code-reviewer Faraday found initiatives-only fallback allows unmanaged deletion | superseded | Faraday P1; `test_uninstall_apply_rejects_unmanaged_initiatives_only_target_before_mutation` | superseded by D-007 |
 | D-007 | resolved | implementation | dev-coder / code-reviewer | remove-specs rerun needs managed retry evidence after specs and version file are removed | require re-init before rerun; keep initiatives fallback; create preserved retry marker | create and preserve exact non-symlink `spec-dock/.uninstall-retry.json` marker during apply; accept only exact marker content as retry evidence | preserves unmanaged-target rejection while satisfying AC-009 idempotent rerun for keep-specs and remove-specs; marker symlink is rejected before read/write | applied | Euclid Ledger Note; Ampere P1; Planck review_status=pass; `test_uninstall_apply_remove_specs_rerun_reports_already_removed_and_succeeds`; `test_uninstall_apply_rejects_symlinked_retry_marker_without_external_mutation` | none |
+| D-008 | resolved | implementation | dev-coder / full-suite verification | full discover can generate ignored provider-asset `__pycache__/*.pyc` before installer tests, and init/update then copied binary caches into target repos | manual cleanup only; test snapshot binary-aware; installer copy guard | ignore `__pycache__` directories and `*.pyc` files during init/update asset copy and provider asset inventory | generated Python caches are never managed SpecDock artifacts and should not ship into target repos or uninstall inventory | applied | `test_init_does_not_copy_generated_python_caches_from_provider_assets`; `test_update_does_not_copy_generated_python_caches_from_provider_assets`; full discover 1026 OK | none |
+| D-009 | resolved | implementation | code-reviewer / dev-coder | stale `spec-dock/spec-dock.version` was classified as scaffold mismatch and preserved | preserve all version mismatches; special-case version file; broaden scaffold mismatch removal | treat `spec-dock/spec-dock.version` as SpecDock managed state and remove it even when content differs from current tool version | version file is generated installer state, not product-authored content; uninstall should remove stale repo-local managed state while preserving user-edited docs/templates/config | applied | Lorentz P2; Socrates Ledger Note; `test_uninstall_dry_run_removes_stale_specdock_version` | none |
+| D-010 | resolved | test-strategy | qa-reviewer | generated-state cleanup behavior has docs/report coverage but not dedicated dry-run/apply tests for `spec-dock/active/**` and `spec-dock/.agent/**` | add tests now; convert to follow-up; accept as non-blocking | no immediate test addition; record as non-blocking QA P2 for future hardening | final QA found this as P2 only after broad uninstall, full `tests.test_init_update`, full discover, validate, sync, and diff-check passed; the primary destructive safety obligations were covered by S03/S99 tests | no_action | Linnaeus P2; final QA review_status=pass; current implementation includes generated-state inventory and docs boundary | consider future regression test when generated-state cleanup behavior changes |
 
 ## 証跡採用台帳（Evidence Adoption Ledger / 必須）
 
@@ -267,7 +270,7 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 #### 親実装例外（Parent Implementation Exception）
 | ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
 |---|---|---|---|---|---|---|---|---|
-| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
+| S01 | N/A | no parent implementation exception used | N/A | N/A | N/A | normal delegated path verified by S01 worker/reviewer evidence | code-reviewer Herschel passed | no unavailable / denied / host conflict / waiver path used |
 
 #### レビューゲート状態（Reviewer Gate Status）
 | ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
@@ -611,7 +614,7 @@ pass
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S04 | ready for commit | runtime uninstall command/parser/registry, `tests/cli_runtime/test_uninstall.py`, `report.md` S04 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
+| S04 | committed | runtime uninstall command/parser/registry, `tests/cli_runtime/test_uninstall.py`, `report.md` S04 evidence | `f2eb8a82770e41be8a3d3df7f30d89cecd4e7414` | `git status --short` after commit -> clean | N/A | N/A | N/A | N/A |
 
 ---
 
@@ -620,27 +623,170 @@ pass
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
 | 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
 |---|---|---|---|---|
-| docs / templates / README / workflow / skill / migration notes | yes / no | doc-writer / N/A | ... | pass / fail / blocked |
+| `src/spec_dock/assets/spec_dock/docs/reference_github.md` | yes | doc-writer | `uninstall` is documented as repo-local managed artifacts removal with no GitHub mutation and no package/environment/`uvx` cache uninstall; runtime wrapper delegates through fixed upstream installer via `uvx --no-cache`; retry/reinstall/refresh after self-removal uses installer CLI | pass: spec-reviewer Laplace |
+| `src/spec_dock/assets/spec_dock/docs/reference_sync.md` | yes | doc-writer | generated state cleanup relationship added for `spec-dock/active/**` and `spec-dock/.agent/**`; recovery after runtime self-removal points to installer CLI | pass: spec-reviewer Laplace |
+| templates / README / workflow / skill / migration notes | no | orchestrator inspection | S90 scope and plan only required provider reference docs for GitHub boundary and sync/generated-state cleanup; no issue-local evidence found that required broader persistent docs changes | pass: spec-reviewer Laplace |
+
+#### S90 実行コマンド / 結果
+```bash
+git diff --check -- src/spec_dock/assets/spec_dock/docs/reference_github.md src/spec_dock/assets/spec_dock/docs/reference_sync.md
+
+pass
+
+PYTHONPATH=src python -m spec_dock.cli uninstall --help
+
+pass; help shows `spec-dock uninstall [path] [--apply] [--keep-specs | --remove-specs] [--json]` and does not describe GitHub/package/environment/uvx-cache side effects
+
+PYTHONPATH=src/spec_dock/assets/spec_dock/scripts python -c 'from spec_dock_runtime.cli.parser import build_parser; from spec_dock_runtime.cli.registry import build_registry; build_parser(build_registry()).parse_args(["uninstall", "--help"])'
+
+pass; source runtime help describes `SpecDock-managed repo assets` and the fixed `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall TARGET` delegation; it does not describe GitHub/package/environment/uvx-cache cleanup
+```
+
+#### S90 クロージャ網羅（Closure Coverage）
+| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
+|---|---|---|---|---|
+| tc-018 | S90 | docs diff inspection, installer help output inspection, source runtime help output inspection, and `git diff --check` | pass | docs state no GitHub mutation, no package/environment/`uvx` cache uninstall, repo-local artifact removal, generated-state cleanup, and installer-direct recovery guidance; help output does not imply forbidden side effects |
+
+#### S90 委任 worker 証跡（Delegated Worker Evidence）
+| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
+|---|---|---|---|---|---|---|---|
+| S90 | doc-writer | Updated provider reference docs for uninstall's repo-local/GitHub/package boundary, runtime delegation, installer-direct recovery, and generated-state cleanup relationship | `src/spec_dock/assets/spec_dock/docs/reference_github.md`; `src/spec_dock/assets/spec_dock/docs/reference_sync.md` | `git diff --check -- src/spec_dock/assets/spec_dock/docs/reference_github.md src/spec_dock/assets/spec_dock/docs/reference_sync.md` -> pass | Laplace final re-review passed with no findings | dogfooding mirror parity remains for S99 | accepted for S90 step commit |
+
+#### S90 レビューゲート状態（Reviewer Gate Status）
+| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| S90 | docs/spec alignment review | spec-reviewer | fresh | failed | N/A | blocked until help-output evidence was recorded | Mendel: P1 tc-018 report evidence lacked planned help-output inspection |
+| S90 | docs/spec alignment re-review | spec-reviewer | fresh | passed | N/A | proceed to S90/S99 parity and final gates | Laplace: review_status=pass; docs diff plus installer/source-runtime help evidence resolves tc-018 |
+
+#### S99 先行ブロッカー修正（Pre-Final Verification Fixes）
+| 対象（target） | 起票元（source） | 実施した対応 | 証跡（evidence） | 残リスク（remaining risk） |
+|---|---|---|---|---|
+| checked-in dogfooding `.meta.json` snapshot drift for `iss-00147` | broad `tests.test_init_update` failure observed in S01-S03 | updated `tests/test_init_update.py` snapshot baselines for `iss-00147-spec-dock-uninstall-command/.meta.json` path and `depends_on: []` | `python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json -v` -> pass; `git diff --check -- tests/test_init_update.py` -> pass | full `tests.test_init_update` still had provider/dogfooding mirror parity failures to resolve before S99 |
+| dogfooding mirror parity for S04/S90 provider asset changes | full `tests.test_init_update` failure after snapshot fix | synced checked-in dogfooding mirrors for provider reference docs and runtime parser/registry assets | three parity tests -> pass; legacy deps snapshot test -> pass; mirror `git diff --check` -> pass | full suite still pending |
+| dogfooding runtime mirror missing `commands/uninstall.py` | `tests.test_init_update` failed broadly with `ImportError: cannot import name 'uninstall' from 'spec_dock_runtime.commands'` | added checked-in dogfooding mirror `spec-dock/scripts/spec_dock_runtime/commands/uninstall.py` from provider asset; `commands/__init__.py` unchanged because provider and mirror matched | runtime surface test -> pass; runtime mirror parity test -> pass; command file `git diff --check` -> pass | full suite cache-copy blocker discovered next |
+| generated Python cache copy into scaffold targets | `python -m unittest discover -v` failed after runtime tests generated provider-asset `__pycache__/*.pyc`, then uninstall snapshot tests read copied binary `.pyc` as UTF-8 | added generic installer guard to ignore `__pycache__` directories and `*.pyc` files for init/update copy and provider asset inventory; added init/update regression tests | focused cache regression 2 tests -> pass; uninstall 28 tests -> pass; `tests.test_init_update` 208 tests -> pass; full discover 1026 tests -> pass; focused diff check -> pass | local ignored cache files may exist but are no longer copied/inventoried |
+| final QA/code review findings | qa-reviewer Halley P1/P2 and code-reviewer Lorentz P2 | added `shutil.rmtree` failure coverage for `spec-dock/initiatives`, preserved-file content assertion for mismatched `.codex/config.toml`, and stale `spec-dock/spec-dock.version` removal policy/test | stale version focused test -> pass; rmtree failure focused test -> pass; apply JSON focused test -> pass; uninstall focused 30 tests -> pass; `tests.test_init_update` 210 tests -> pass; focused diff check -> pass | final re-review pending |
+
+#### S99 先行 mirror parity 実行コマンド / 結果
+```bash
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_mirror_docs_match_provider_assets tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets tests.test_init_update.TestInitUpdate.test_reference_sync_doc_matches_bundled_asset -v
+
+Ran 3 tests
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json -v
+
+Ran 1 test
+OK
+
+git diff --check -- spec-dock/docs/reference_github.md spec-dock/docs/reference_sync.md spec-dock/scripts/spec_dock_runtime/cli/parser.py spec-dock/scripts/spec_dock_runtime/cli/registry.py spec-dock/scripts/spec_dock_runtime/commands/uninstall.py
+
+pass
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_surface_includes_doctor_and_explicit_target_hint -v
+
+Ran 1 test
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_checked_in_dogfooding_runtime_mirror_match_provider_assets -v
+
+Ran 1 test
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_init_does_not_copy_generated_python_caches_from_provider_assets tests.test_init_update.TestInitUpdate.test_update_does_not_copy_generated_python_caches_from_provider_assets -v
+
+Ran 2 tests
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall
+
+Ran 28 tests
+OK
+
+python -m unittest tests.test_init_update -v
+
+Ran 208 tests
+OK
+
+python -m unittest discover -v
+
+Ran 1026 tests
+OK
+
+git diff --check -- src/spec_dock/cli.py tests/test_init_update.py
+
+pass
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_uninstall_dry_run_removes_stale_specdock_version -v
+
+Ran 1 test
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_uninstall_apply_partial_rmtree_failure_reports_failed_spec_history_separately -v
+
+Ran 1 test
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate.test_uninstall_apply_json_covers_success_rerun_and_partial_failure_statuses -v
+
+Ran 1 test
+OK
+
+python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall
+
+Ran 30 tests
+OK
+
+python -m unittest tests.test_init_update -v
+
+Ran 210 tests
+OK
+
+./spec-dock/scripts/spec-dock validate
+
+spec-dock: ok (validate) nodes=74
+
+./spec-dock/scripts/spec-dock sync --no-github
+
+spec-dock: sync: active unchanged (matched id in branch: iss-00147)
+spec-dock: ok (sync) wrote=spec-dock/.agent/index-all.json,spec-dock/.agent/tree-all.json,spec-dock/.agent/index.json,spec-dock/.agent/tree.json,spec-dock/tree-all.puml,spec-dock/tree.puml,spec-dock/.agent/deps-issues.json,spec-dock/deps-issues.puml,spec-dock/dashboard.md
+
+git diff --check
+
+pass
+```
+
+`sync --no-github` opt-out reason: final local artifact consistency was required for PR handoff, while live GitHub enrichment was not required for uninstall implementation correctness and would introduce network-state variability into the final gate.
+
+#### S99 先行 mirror parity クロージャ差分（Closure Delta）
+| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
+|---|---|---|---|---|---|---|
+| discovered | S99 dogfooding mirror parity | `spec-dock/scripts/spec_dock_runtime/cli/registry.py` mirror sync | tc-019 | runtime parser parity fix exposed registry parity drift for the same S04 provider asset change | no | yes, final review gates |
+| discovered | S99 dogfooding mirror parity | `spec-dock/scripts/spec_dock_runtime/commands/uninstall.py` mirror sync | tc-019 | registry mirror imports `commands.uninstall`; dogfooding mirror needed the provider command file to keep runtime subprocess tests importable | no | yes, final review gates |
+| discovered | S99 full-suite cache guard | `test_init_does_not_copy_generated_python_caches_from_provider_assets`; `test_update_does_not_copy_generated_python_caches_from_provider_assets` | tc-019 | full discover can generate ignored provider-asset caches before installer tests; init/update must not copy generated Python caches into target repos | no | yes, final review gates |
+| added | S03/S99 reviewer regression | `test_uninstall_apply_partial_rmtree_failure_reports_failed_spec_history_separately` | tc-014 | destructive directory removal failures must be reported separately, not only file unlink failures | no | yes, final review gates |
+| strengthened | S03/S99 reviewer regression | preserved `.codex/config.toml` content assertion in apply JSON test | tc-024 / AC-006 | apply result must not only report preservation but also leave product-owned mismatch content intact | no | yes, final review gates |
+| added | S02/S99 reviewer regression | `test_uninstall_dry_run_removes_stale_specdock_version` | tc-008 / managed state cleanup | stale version files are generated managed state and should not be preserved as user-edited scaffold content | no | yes, final review gates |
 
 ### 最終 QA ゲート（Final QA Gate）
 | レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | added / already sufficient / not applicable | ... | pass / fail / blocked |
+| Halley / Linnaeus | whole issue obligation coverage | added regression coverage for rmtree failure and preserved file content; generated-state cleanup behavior recorded as D-010 non-blocking no_action | initial fail: P1 rmtree failure coverage, P2 preserved content assertion; fixed by Socrates; Linnaeus re-review found only P2 generated-state cleanup coverage recommendation and review_status=pass | pass |
 
 ### 最終コードレビューゲート（Final Code Review Gate）
 | レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
 |---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | ... | 0 | pass / fail / blocked |
+| Lorentz / Huygens | issue-wide integrated diff | Lorentz P2 stale `spec-dock/spec-dock.version` preservation fixed by treating version file as managed state; Huygens re-review found no findings | 1 | pass |
 
 ### 最終 spec review ゲート（Final Spec Review Gate）
 | レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
 |---|---|---|---|---|
-| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | ... | 0 | pass / fail / blocked |
+| Raman / Nash | requirement / design / plan / report / implementation / tests / docs alignment | Raman P1 final gate/evidence placeholders fixed; Nash re-review passed with non-blocking P2/P3 report-audit recommendations; D-010 and S01 parent-exception row cleanup applied | 1 | pass |
 
 ### 最終 commit（Final Commit）
 | 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
 |---|---|---|---|
-| ... | ... | final response / PR / issue comment / other external delivery evidence | ready / blocked |
+| S99 evidence updated through final reviewer findings, local validation bundle, D-008/D-010 decisions, and final reviewer pass rows | pending final commit after this report update | PR body / final response | ready for commit |
 
 ## 遭遇した問題と解決 (任意)
 - 問題: ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -786,7 +786,7 @@ pass
 ### 最終 commit（Final Commit）
 | 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
 |---|---|---|---|
-| S99 evidence updated through final reviewer findings, local validation bundle, D-008/D-010 decisions, and final reviewer pass rows | pending final commit after this report update | PR body / final response | ready for commit |
+| S99 evidence updated through final reviewer findings, local validation bundle, D-008/D-010 decisions, final reviewer pass rows, and PR delivery verification | implementation commits through `f03e9a8118881c05d7cb66f6d523520252b1fcfe` plus report-only PR delivery evidence update | PR #148 / final response | committed and PR submitted; PR #148 is open, ready, base `main`, head `iss-00147-spec-dock-uninstall-command` |
 
 ## 遭遇した問題と解決 (任意)
 - 問題: ...

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -52,6 +52,8 @@ Disposition ごとの必須証跡:
 | D-001 | resolved | scope | spec-reviewer | parent epic scope did not originally include uninstall command | update parent epic; move issue; stop planning | parent epic requirement/design were extended to include uninstall command scope | user requested uninstall issue under lifecycle command expansion and parent epic already owned repo-local lifecycle commands | applied | parent epic `requirement.md` / `design.md`; requirement review Godel pass | none |
 | D-002 | resolved | test-strategy | spec-reviewer | design test strategy did not explicitly mention scaffold-managed removal coverage | add design coverage; defer to plan only | scaffold-managed exact-match removal and mismatch-preserve coverage added to design test strategy | scaffold-managed runtime/docs files are core repo-local uninstall targets | applied | design review Avicenna pass with P2 finding; `design.md` test strategy | plan closure mapping |
 | D-003 | resolved | scope | user | design Q-001 asked whether `--json` belongs in initial implementation | human-readable only; include `--json` now | initial implementation must include JSON output because agents may execute uninstall | agent execution requires machine-readable plan/result output, so JSON is part of the primary command contract | applied | `discussions/20260531t144040z-interview-uninstall-json-output.md`; requirement/design/plan amendment | fresh spec-reviewer re-review |
+| D-004 | resolved | implementation | code-reviewer / dev-coder | S01 JSON preflight errors needed an explicit payload shape | separate minimal error object; reuse uninstall payload schema with `status: "error"` and empty `actions` | reuse the S01 uninstall payload schema for post-parse semantic/preflight errors | keeps the agent-readable JSON surface stable and avoids a second S01 error schema | applied | Volta P2 finding; `test_uninstall_json_preflight_errors_are_parseable_objects` | none |
+| D-005 | resolved | implementation | code-reviewer / dev-coder | shared target directory validation bypassed uninstall JSON for missing/file targets | leave as non-blocking P2; route uninstall target validation through uninstall preflight | route uninstall command through `_run_uninstall` before the shared init/update directory check | keeps `--json` output parseable for all uninstall preflight failures while preserving non-json stderr behavior | applied | Averroes P2 finding; `test_uninstall_json_missing_target_path_returns_json_error`; `test_uninstall_json_file_target_returns_json_error_without_mutation` | none |
 
 ## 証跡採用台帳（Evidence Adoption Ledger / 必須）
 
@@ -81,6 +83,8 @@ Delegated draft、worker note、research、reviewer finding、discussion、comma
 | EAL-014 | adopted | interview | `requirement.md`, `design.md`, `plan.md` | user answer requires JSON output in initial implementation because agents may execute uninstall | `discussions/20260531t144040z-interview-uninstall-json-output.md` | fresh spec-reviewer re-review |
 | EAL-015 | adopted | reviewer: spec-reviewer | `plan.md` | JSON amendment reviewer fail findingを採用し、agent が判別する action-level `status` / `category` / `reason` coverage を tc-023 / tc-024 に追加した | spec-reviewer Zeno, review_status=fail, 2026-05-31 | JSON amendment re-review |
 | EAL-016 | adopted | reviewer: spec-reviewer | `plan.md` | JSON amendment re-review の P2 を採用し、apply-side `actions[]` の `path` / `category` / `status` / `reason` / `error` assertion を tc-s03-007 に追加した | spec-reviewer Heisenberg, review_status=pass, 2026-05-31 | no re-review required; P2 applied |
+| EAL-017 | adopted | reviewer: code-reviewer | S01 implementation | S01 code re-review の P2 を採用し、`--json` semantic/preflight error と scripts-missing recovery target validation を追加した | code-reviewer Volta, review_status=pass with P2, 2026-05-31; focused 9-test command pass | fresh S01 code re-review |
+| EAL-018 | adopted | reviewer: code-reviewer | S01 implementation | S01 final code re-review の P2 を採用し、missing path / file target の `--json` error を JSON payload にした | code-reviewer Averroes, review_status=pass with P2, 2026-05-31; focused 11-test command pass | fresh S01 code re-review |
 
 ## 目的整合台帳（Objective Alignment Ledger / 必須）
 
@@ -144,62 +148,100 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 | reviewer 利用不可 / 拒否 / waiver / provisional（reviewer unavailable/denied/waived/provisional） | blocked / incomplete | fresh な passed reviewer を取得する、または昇格なしの risk acceptance を記録する | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
 
 ## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+- S01 として installer CLI に `uninstall` command surface、dry-run text / JSON plan renderer、target validation、destructive apply preflight を追加した。
+- 実削除、full inventory classification、runtime wrapper は plan に従い S02-S04 へ残している。
 
 ## 実装記録（セッションログ） (必須)
 
-### セッションログ（2026-05-31 HH:MM - HH:MM）
+### セッションログ（2026-05-31 S01）
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
+- Step: S01
+- AC/EC: AC-001, AC-002, AC-010, EC-001, EC-002, EC-008
 - 計画上の出典（Planned source）:
-  - `plan.md` section:
-  - closure ids:
+  - `plan.md` section: 実装ステップ S01 — Installer uninstall command surface and dry-run contract
+  - closure ids: tc-001, tc-002, tc-003, tc-020, tc-023
 
 #### 実施内容
-- ...
+- `src/spec_dock/cli.py` に installer CLI `uninstall [path] [--apply] [--keep-specs | --remove-specs] [--json]` を追加した。
+- S01 scope として dry-run plan rendering、JSON dry-run payload、managed target validation、`--apply` specs mode preflight、mutually exclusive specs flags を実装した。
+- code-reviewer Bohr の P1 に従い、S01 時点で apply engine が未実装の `--apply --keep-specs` / `--apply --remove-specs` は success として扱わず、mutation なしで exit 2 にした。
+- code-reviewer Volta の P2 に従い、`--json` 指定時の semantic/preflight error を stdout の単一 JSON object にし、`spec-dock/scripts/` が既に削除された recovery target でも `spec-dock/spec-dock.version` があれば managed target として受け入れるようにした。
+- code-reviewer Averroes の P2 に従い、missing path / file target の `--json` preflight error も stdout の単一 JSON object にした。
+- full inventory classification、actual removal、runtime wrapper は S02-S04 のまま残した。
 
 #### 実行コマンド / 結果
 ```bash
-<command>
+python -m unittest tests.test_init_update.TestInitUpdate.test_uninstall_dry_run_prints_plan_and_mutates_no_files tests.test_init_update.TestInitUpdate.test_uninstall_apply_without_specs_mode_fails_before_mutation tests.test_init_update.TestInitUpdate.test_uninstall_apply_with_specs_mode_is_deferred_before_mutation tests.test_init_update.TestInitUpdate.test_uninstall_keep_and_remove_specs_are_mutually_exclusive tests.test_init_update.TestInitUpdate.test_uninstall_unmanaged_target_fails_before_mutation tests.test_init_update.TestInitUpdate.test_uninstall_dry_run_json_is_one_parseable_object tests.test_init_update.TestInitUpdate.test_uninstall_json_preflight_errors_are_parseable_objects tests.test_init_update.TestInitUpdate.test_uninstall_json_missing_target_path_returns_json_error tests.test_init_update.TestInitUpdate.test_uninstall_json_file_target_returns_json_error_without_mutation tests.test_init_update.TestInitUpdate.test_uninstall_accepts_recovery_target_when_scripts_are_missing tests.test_init_update.TestInitUpdate.test_uninstall_rejects_target_missing_version_file -v
 
-<result>
+Ran 11 tests in 0.548s
+OK
+
+git diff --check -- src/spec_dock/cli.py tests/test_init_update.py
+
+pass
+
+python -m unittest tests.test_init_update -v
+
+Ran 183 tests in 59.734s
+FAILED (failures=1)
+unrelated observed failure: test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json
+reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 ```
 
 #### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
 | ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
 |---|---|---|---|---|---|---|
-| S01 | 赤フェーズ / 代替証跡（Red / alternative） | red-required / covered-existing / inspect-only / manual-required | ... | `command` / 文書点検（docs inspection） / 手動記録（manual record） | pass / approved-no-op / fail / blocked | ... |
-| S01 | 緑フェーズ（Green） | ... | ... | `command` / 点検（inspection） / 手動記録（manual record） | pass / fail / blocked | ... |
-| S01 | リファクタリング（Refactor） | guardrail satisfied / no refactor needed | ... | 差分点検（diff inspection） / command | pass / approved-no-op / fail / blocked | ... |
+| S01 | 赤フェーズ | red-required | S01 5 tests failed before implementation with `invalid choice: 'uninstall' (choose from 'init', 'update')` | delegated dev-coder command | pass | command surface absence was observed |
+| S01 | 赤フェーズ | reviewer-discovered regression | added apply-deferred test failed before fix with `0 != 2` for explicit specs-mode apply | delegated dev-coder command | pass | Bohr P1 reproduced successful no-op apply bug |
+| S01 | 赤フェーズ | reviewer-discovered P2 | JSON semantic/preflight errors were stderr-only, and scripts-missing recovery target was rejected | delegated dev-coder command | pass | Volta P2 reproduced before fix |
+| S01 | 赤フェーズ | reviewer-discovered P2 | missing path / file target with `--json` returned human stderr before uninstall JSON preflight | delegated dev-coder command | pass | Averroes P2 reproduced before fix |
+| S01 | 緑フェーズ | focused S01 command | 11 focused S01 tests passed | `python -m unittest ... -v` | pass | tc-001/tc-002/tc-003/tc-020/tc-023 plus apply-deferred and P2 regression guards covered |
+| S01 | リファクタリング | guardrail satisfied | no broad refactor; S01 skeleton only | diff inspection and `git diff --check -- src/spec_dock/cli.py tests/test_init_update.py` | pass | full apply remains S03 |
 
 #### 発見されたテスト / リスク（Discovered Tests）
 | ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
 |---|---|---|---|---|---|---|
-| S01 | none / ... | implementation / review / QA / user report | recorded / added test / deferred / amended plan | tc-001 / new | yes / no | ... |
+| S01 | explicit specs-mode apply must not report completed before S03 apply engine exists | code-reviewer Bohr | added `test_uninstall_apply_with_specs_mode_is_deferred_before_mutation` and changed S01 apply path to exit 2 without mutation | S01 regression guard | no | Bohr review_status=fail; follow-up dev-coder pass |
+| S01 | JSON semantic/preflight errors must be parseable under `--json`; recovery target remains valid after `spec-dock/scripts/` removal | code-reviewer Volta | added JSON error and recovery target tests; changed error emitter and managed target validation | S01 P2 regression guards | no | Volta review_status=pass with P2; follow-up dev-coder pass |
+| S01 | missing path / file target must still return parseable JSON under `--json` | code-reviewer Averroes | added missing path and file target JSON error tests; routed uninstall before shared init/update target directory check | S01 P2 regression guards | no | Averroes review_status=pass with P2; follow-up dev-coder pass |
+| S01 | full `tests.test_init_update` has dogfooding `.meta.json` snapshot drift failure | verification | recorded as unrelated to S01 diff; still blocks broad green until resolved later | N/A | no | `test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` failure |
 
 #### ステップ契約の完了証跡（Step Contract Closure）
 | ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
 |---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved-no-op / fail / blocked | ... |
+| S01 | tc-001, tc-002, tc-003, tc-020, tc-023 | tests are red before implementation, green after, code-reviewer pass, report updated | red evidence captured by dev-coder; focused 11-test command pass; report updated with P2 adoption; code-reviewer Herschel pass | pass | S01 ready for step commit |
 
 #### テスト契約の完了証跡（Test Contract Closure）
 | クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
 |---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required / covered-existing / inspect-only / manual-required | ... | ... | pass / approved-no-op / fail / blocked | ... |
+| tc-001 | S01 | yes | red-required | uninstall parser missing before implementation | focused S01 unittest command | pass | dry-run prints plan and mutates no files |
+| tc-002 | S01 | yes | red-required | uninstall parser missing before implementation | focused S01 unittest command | pass | apply without specs mode fails before mutation |
+| tc-003 | S01 | yes | red-required | uninstall parser missing before implementation | focused S01 unittest command | pass | keep/remove specs mutually exclusive |
+| tc-020 | S01 | yes | red-required | uninstall parser missing before implementation; P2 found shared missing/file target check bypassed JSON before follow-up | focused S01 unittest command | pass | unmanaged target and non-directory target fail before mutation |
+| tc-023 | S01 | yes | red-required | uninstall parser missing before implementation; P2 found stderr-only JSON semantic and non-directory errors before follow-up | focused S01 unittest command | pass | dry-run JSON is parseable and action-level fields exist; semantic/preflight errors also return parseable JSON |
 
 - `closure id / test id` は Spec-Locked Closure Index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
 
 #### クロージャ網羅（Closure Coverage）
 | クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
 |---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved-no-op / fail / blocked | ... |
+| tc-001 | S01 | `test_uninstall_dry_run_prints_plan_and_mutates_no_files` | pass | focused command OK |
+| tc-002 | S01 | `test_uninstall_apply_without_specs_mode_fails_before_mutation` | pass | focused command OK |
+| tc-003 | S01 | `test_uninstall_keep_and_remove_specs_are_mutually_exclusive` | pass | focused command OK |
+| tc-020 | S01 | `test_uninstall_unmanaged_target_fails_before_mutation` | pass | focused command OK |
+| tc-023 | S01 | `test_uninstall_dry_run_json_is_one_parseable_object` | pass | focused command OK |
+| tc-023 | S01 | `test_uninstall_json_preflight_errors_are_parseable_objects` | pass | P2 regression guard for agent-readable errors |
+| tc-020 | S01 | `test_uninstall_accepts_recovery_target_when_scripts_are_missing`; `test_uninstall_rejects_target_missing_version_file` | pass | recovery validation accepts version-file target and rejects missing managed state |
+| tc-020, tc-023 | S01 | `test_uninstall_json_missing_target_path_returns_json_error`; `test_uninstall_json_file_target_returns_json_error_without_mutation` | pass | P2 regression guard for non-directory targets under JSON mode |
 
 #### クロージャ差分（Closure Delta）
 | 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
 |---|---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no | yes / no |
+| added | S01 regression guard | `test_uninstall_apply_with_specs_mode_is_deferred_before_mutation` | S01 step reviewer finding | S01 skeleton must not report successful apply before S03 apply engine | no | yes |
+| added | S01 P2 regression guard | `test_uninstall_json_preflight_errors_are_parseable_objects` | tc-023 | JSON command surface must stay parseable for semantic/preflight errors | no | yes |
+| added | S01 P2 recovery guard | `test_uninstall_accepts_recovery_target_when_scripts_are_missing`; `test_uninstall_rejects_target_missing_version_file` | tc-020 | direct installer recovery must work after repo-local runtime/scripts have been removed while still rejecting unmanaged targets | no | yes |
+| added | S01 P2 target guard | `test_uninstall_json_missing_target_path_returns_json_error`; `test_uninstall_json_file_target_returns_json_error_without_mutation` | tc-020, tc-023 | non-directory target preflight must remain machine-readable under `--json` | no | yes |
 
 #### ワークフロー委任同意の証跡（Workflow Delegation Consent）
 `workflow_issue.md` is the policy source for workflow-scoped delegation consent. This report records observed consent, boundary, expiry, and denied / unavailable handling only.
@@ -213,12 +255,12 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 
 | ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
+| S01 | delegated | installer CLI and tests change | dev-coder | installer uninstall command surface and S01 tests | `plan.md` S01 | `src/spec_dock/cli.py`, `tests/test_init_update.py` | runtime files, docs, package metadata, actual deletion logic beyond S01 skeleton | focused S01 unittest command; `python -m unittest tests.test_init_update -v`; `git diff --check` | CLI contract conflict, need for S02/S03 behavior, inability to assert no mutation | changed files, tests, Ledger Note | pass with reviewer follow-up applied |
 
 #### 委任 worker 証跡（Delegated Worker Evidence）
 | ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
 |---|---|---|---|---|---|---|---|
-| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
+| S01 | dev-coder | Added installer `uninstall` parser, S01 dry-run text/JSON skeleton, target validation, specs-mode preflight, explicit apply-deferred guard, JSON preflight errors, recovery target validation, and non-directory target JSON handling after reviewer findings | `src/spec_dock/cli.py`; `tests/test_init_update.py` | focused S01 command -> pass (`Ran 11 tests`); `python -m unittest tests.test_init_update -v` -> fail with unrelated dogfooding `.meta.json` snapshot drift; `git diff --check -- src/spec_dock/cli.py tests/test_init_update.py` -> pass; `./spec-dock/scripts/spec-dock validate` -> pass | Herschel final re-review passed with no findings | full file test has unrelated snapshot drift failure | accepted for S01 step commit |
 
 #### 親実装例外（Parent Implementation Exception）
 | ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
@@ -228,7 +270,10 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 #### レビューゲート状態（Reviewer Gate Status）
 | ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
 |---|---|---|---|---|---|---|---|
-| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
+| S01 | step code review | code-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Bohr: P1 apply skeleton reported completed without mutation; P1 report evidence placeholder |
+| S01 | step code re-review | code-reviewer | fresh | passed | N/A | P2 follow-up adopted before step commit | Volta: review_status=pass; P2 JSON semantic error payload and scripts-missing recovery validation applied |
+| S01 | step code final re-review | code-reviewer | fresh | passed | N/A | P2 follow-up adopted before step commit | Averroes: review_status=pass; P2 missing/file target JSON error applied |
+| S01 | step code final re-review after P2 | code-reviewer | fresh | passed | N/A | proceed to S01 step commit | Herschel: review_status=pass; no findings after all P2 follow-ups |
 | requirement | requirement spec review | spec-reviewer | fresh | passed | N/A | proceed to design | Godel: no findings; parent scope and provenance blockers fixed |
 | design | design spec review | spec-reviewer | fresh | passed | N/A | proceed to plan | Avicenna: no blocking findings; P2 scaffold coverage and decision ledger cleanup applied |
 | plan | plan spec review | spec-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Gibbs: P1 closure gaps for EC-001, EC-006, AC-008/EC-005; P2 no-op/report-update gates |
@@ -240,17 +285,18 @@ Requirement / design / plan の phase promotion ごとに、調査、未確定�
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S01 | committed / approved-no-op | ... | <hash or final ledger reference> | `git status --short` -> clean | ... | ... | ... | ... |
+| S01 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S01 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
 
 #### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
+- `src/spec_dock/cli.py` - installer uninstall S01 command surface and dry-run/JSON skeleton.
+- `tests/test_init_update.py` - S01 command surface, preflight, no-mutation, JSON, and apply-deferred tests.
+- `spec-dock/active/issue/report.md` - S01 observed evidence ledger.
 
 #### コミット
-- <hash> <message>
+- pending S01 step commit.
 
 #### メモ
-- ...
+- Worker reported: No material implementation decisions beyond the approved plan.
 
 ---
 

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -521,7 +521,97 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S03 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S03 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
+| S03 | committed | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S03 evidence | `c39c1c9b0e8b7cae663e1b6156086b79b3e0f285` | `git status --short` after commit -> clean | N/A | N/A | N/A | N/A |
+
+---
+
+### セッションログ（2026-05-31 S04）
+
+#### 対象
+- Step: S04
+- AC/EC: AC-008, AC-010
+- closure ids: tc-015, tc-016, tc-017, tc-025
+
+#### 実施内容
+- repo-local runtime command `uninstall` を追加した。
+- runtime 側に uninstall logic は実装せず、`uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <target>` へ委譲する thin wrapper とした。
+- `--apply`, `--keep-specs`, `--remove-specs`, `--json` を installer CLI へ forwarding し、stdout / stderr / exit code をそのまま伝播するようにした。
+- missing `uvx` は exit `127` と PATH/install guidance を返すようにした。
+
+#### 実行コマンド / 結果
+```bash
+python -m unittest tests.cli_runtime.test_uninstall -v
+
+Ran 8 tests
+OK
+
+python -m unittest tests.cli_runtime.test_update tests.cli_runtime.test_uninstall -v
+
+Ran 15 tests
+OK
+
+git diff --check -- src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py tests/cli_runtime/test_uninstall.py
+
+pass
+```
+
+#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
+| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|---|
+| S04 | 赤フェーズ | red-required | `tests.cli_runtime.test_uninstall` failed before implementation with runtime `invalid choice: 'uninstall'` | delegated dev-coder command | pass | command was not registered |
+| S04 | 緑フェーズ | runtime wrapper command | 8 uninstall runtime tests passed | `python -m unittest tests.cli_runtime.test_uninstall -v` | pass | tc-015/tc-016/tc-017/tc-025 covered |
+| S04 | リファクタリング | update wrapper parity | update + uninstall wrapper tests passed | `python -m unittest tests.cli_runtime.test_update tests.cli_runtime.test_uninstall -v` | pass | no wrapper common abstraction added |
+
+#### 発見されたテスト / リスク（Discovered Tests）
+| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
+|---|---|---|---|---|---|---|
+| S04 | unsupported `--from` / `--cache-dir` must not invoke uvx | test parity with update wrapper | added negative test in runtime uninstall suite | S04 wrapper hardening | no | `test_uninstall_rejects_source_and_cache_overrides_without_invoking_uvx` |
+
+#### ステップ契約の完了証跡（Step Contract Closure）
+| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|
+| S04 | tc-015, tc-016, tc-017, tc-025 | runtime tests pass, code-reviewer pass, report updated | red evidence captured by dev-coder; runtime 8-test command pass; report updated; code-reviewer Sartre pass | pass | S04 ready for step commit |
+
+#### テスト契約の完了証跡（Test Contract Closure）
+| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| tc-015 | S04 | yes | red-required | runtime command not registered | runtime uninstall tests | pass | uvx no-cache upstream uninstall invocation |
+| tc-016 | S04 | yes | red-required | runtime command not registered | runtime uninstall tests | pass | flag and stdout/stderr/exit propagation |
+| tc-017 | S04 | yes | red-required | runtime command not registered | runtime uninstall tests | pass | missing uvx guidance |
+| tc-025 | S04 | yes | red-required | runtime command not registered | runtime uninstall tests | pass | JSON forwarding and stdout preservation |
+
+#### クロージャ網羅（Closure Coverage）
+| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
+|---|---|---|---|---|
+| tc-015 | S04 | `test_uninstall_runs_uvx_no_cache_with_default_target`; `test_uninstall_passes_explicit_target_to_installer_uninstall` | pass | default and explicit target invocation covered |
+| tc-016 | S04 | `test_uninstall_forwards_apply_keep_specs_and_propagates_failure_output`; `test_uninstall_forwards_remove_specs_flag` | pass | flags and result propagation covered |
+| tc-017 | S04 | `test_uninstall_missing_uvx_fails_with_actionable_error` | pass | exit 127 guidance covered |
+| tc-025 | S04 | `test_uninstall_forwards_json_and_preserves_json_stdout` | pass | JSON forwarding covered |
+
+#### クロージャ差分（Closure Delta）
+| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
+|---|---|---|---|---|---|---|
+| added | S04 runtime wrapper tests | `tests/cli_runtime/test_uninstall.py` | tc-015, tc-016, tc-017, tc-025 | runtime thin wrapper closure | no | yes |
+
+#### 実装委任ゲート（Implementation Delegation Gate）
+| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S04 | delegated | runtime wrapper and tests change | dev-coder | repo-local runtime uninstall wrapper | `plan.md` S04 | runtime uninstall command/parser/registry and runtime tests | installer code, docs, package metadata, arbitrary uvx override options | `python -m unittest tests.cli_runtime.test_uninstall -v`; `git diff --check` | runtime needs to reimplement installer logic, accepted flags diverge from installer CLI | changed files, tests, Ledger Note | pass; reviewer pending |
+
+#### 委任 worker 証跡（Delegated Worker Evidence）
+| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
+|---|---|---|---|---|---|---|---|
+| S04 | dev-coder | Added repo-local runtime uninstall wrapper, parser/registry binding, and stubbed uvx tests | runtime uninstall command/parser/registry; `tests/cli_runtime/test_uninstall.py` | runtime uninstall tests -> pass (`Ran 8 tests`); update+uninstall wrapper tests -> pass (`Ran 15 tests`); diff check -> pass | Sartre final review passed with no findings | none identified; installer contract assumed stable from S01-S03 | accepted for S04 step commit |
+
+#### レビューゲート状態（Reviewer Gate Status）
+| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| S04 | step code review | code-reviewer | fresh | passed | N/A | proceed to S04 step commit | Sartre: review_status=pass; no findings |
+
+#### ステップ commit ゲート（Step Commit Gate）
+| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
+|---|---|---|---|---|---|---|---|---|
+| S04 | ready for commit | runtime uninstall command/parser/registry, `tests/cli_runtime/test_uninstall.py`, `report.md` S04 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
 
 ---
 

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/report.md
@@ -54,6 +54,8 @@ Disposition ごとの必須証跡:
 | D-003 | resolved | scope | user | design Q-001 asked whether `--json` belongs in initial implementation | human-readable only; include `--json` now | initial implementation must include JSON output because agents may execute uninstall | agent execution requires machine-readable plan/result output, so JSON is part of the primary command contract | applied | `discussions/20260531t144040z-interview-uninstall-json-output.md`; requirement/design/plan amendment | fresh spec-reviewer re-review |
 | D-004 | resolved | implementation | code-reviewer / dev-coder | S01 JSON preflight errors needed an explicit payload shape | separate minimal error object; reuse uninstall payload schema with `status: "error"` and empty `actions` | reuse the S01 uninstall payload schema for post-parse semantic/preflight errors | keeps the agent-readable JSON surface stable and avoids a second S01 error schema | applied | Volta P2 finding; `test_uninstall_json_preflight_errors_are_parseable_objects` | none |
 | D-005 | resolved | implementation | code-reviewer / dev-coder | shared target directory validation bypassed uninstall JSON for missing/file targets | leave as non-blocking P2; route uninstall target validation through uninstall preflight | route uninstall command through `_run_uninstall` before the shared init/update directory check | keeps `--json` output parseable for all uninstall preflight failures while preserving non-json stderr behavior | applied | Averroes P2 finding; `test_uninstall_json_missing_target_path_returns_json_error`; `test_uninstall_json_file_target_returns_json_error_without_mutation` | none |
+| D-006 | superseded | implementation | dev-coder / code-reviewer | keep-specs rerun after apply removes `spec-dock/spec-dock.version` but preserves `spec-dock/initiatives` | strict version preflight; relax all apply preflight; accept missing version only when initiatives remains | initiatives-only fallback is unsafe and is replaced by D-007 retry marker semantics | code-reviewer Faraday found initiatives-only fallback allows unmanaged deletion | superseded | Faraday P1; `test_uninstall_apply_rejects_unmanaged_initiatives_only_target_before_mutation` | superseded by D-007 |
+| D-007 | resolved | implementation | dev-coder / code-reviewer | remove-specs rerun needs managed retry evidence after specs and version file are removed | require re-init before rerun; keep initiatives fallback; create preserved retry marker | create and preserve exact non-symlink `spec-dock/.uninstall-retry.json` marker during apply; accept only exact marker content as retry evidence | preserves unmanaged-target rejection while satisfying AC-009 idempotent rerun for keep-specs and remove-specs; marker symlink is rejected before read/write | applied | Euclid Ledger Note; Ampere P1; Planck review_status=pass; `test_uninstall_apply_remove_specs_rerun_reports_already_removed_and_succeeds`; `test_uninstall_apply_rejects_symlinked_retry_marker_without_external_mutation` | none |
 
 ## 証跡採用台帳（Evidence Adoption Ledger / 必須）
 
@@ -399,7 +401,127 @@ reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
 #### ステップ commit ゲート（Step Commit Gate）
 | ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
 |---|---|---|---|---|---|---|---|---|
-| S02 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S02 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
+| S02 | committed | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S02 evidence | `b3e9549b7cf4b7da4a4a6c9b12ef975cd3ad9cb6` | `git status --short` after commit -> clean | N/A | N/A | N/A | N/A |
+
+---
+
+### セッションログ（2026-05-31 S03）
+
+#### 対象
+- Step: S03
+- AC/EC: AC-003, AC-004, AC-009, AC-010, EC-003, EC-004, EC-005, EC-008
+- closure ids: tc-010, tc-011, tc-012, tc-013, tc-014, tc-022, tc-024
+
+#### 実施内容
+- `--apply --keep-specs` / `--apply --remove-specs` の apply engine を追加した。
+- S02 action plan の `would_remove` を file / symlink / directory tree 削除へ適用し、`preserved` は untouched result として残すようにした。
+- removal result として `removed` / `already_removed` / `preserved` / `failed` / `empty_dir_removed` を text / JSON に反映した。
+- `.agents`, `.codex`, `.github`, `spec-dock` 内だけで empty directory cleanup を行い、repo root、`.git`、target parent、preserved file を越えないようにした。
+- partial failure は `status: "partial_failure"`、exit `1`、failed action details として返すようにした。
+- repo-local runtime が削除された後の recovery として installer CLI `spec-dock uninstall <target>` / `spec-dock init/update <target>` guidance を apply output に出すようにした。
+
+#### 実行コマンド / 結果
+```bash
+python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall
+
+Ran 28 tests in 2.477s
+OK
+
+git diff --check -- src/spec_dock/cli.py tests/test_init_update.py
+
+pass
+
+git diff --check
+
+pass
+
+./spec-dock/scripts/spec-dock validate
+
+spec-dock: ok (validate) nodes=74
+
+python -m unittest tests.test_init_update -v
+
+Ran 202 tests
+FAILED (failures=1)
+known unrelated observed failure: test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json
+reason: checked-in dogfooding .meta.json path set diverged from cutover snapshot
+```
+
+#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
+| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|---|
+| S03 | 赤フェーズ | red-required | new apply tests failed before implementation with `uninstall --apply is not implemented in S02; full apply behavior is deferred to S03` | delegated dev-coder command | pass | keep-specs and JSON apply tests reproduced S02 guard |
+| S03 | 緑フェーズ | focused uninstall command | 28 uninstall tests passed | `python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall` | pass | S01-S03 uninstall behavior plus Faraday/Ampere regression fixes passed |
+| S03 | リファクタリング | guardrail satisfied | apply logic limited to installer CLI and tests | diff inspection and `git diff --check` | pass | runtime wrapper/docs still pending |
+
+#### 発見されたテスト / リスク（Discovered Tests）
+| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
+|---|---|---|---|---|---|---|
+| S03 | keep-specs rerun after apply loses `spec-dock/spec-dock.version` but preserves spec history | code-reviewer Faraday | initiatives-only fallback rejected; replaced by exact retry marker semantics | tc-013 / D-006 / D-007 | no unless reviewer rejects marker | Faraday review_status=fail; Euclid follow-up |
+| S03 | remove-specs rerun has no durable managed marker after complete cleanup | code-reviewer Faraday | create and preserve exact `spec-dock/.uninstall-retry.json` marker, then require exact marker for rerun eligibility | tc-013 / D-007 | no unless reviewer rejects marker | `test_uninstall_apply_remove_specs_rerun_reports_already_removed_and_succeeds` |
+| S03 | symlinked boundary root can route deletion outside target | code-reviewer Faraday | reject symlinked uninstall boundary roots before apply and guard symlink containers | tc-012 | no | `test_uninstall_apply_rejects_symlinked_boundary_root_without_external_deletion` |
+| S03 | initiatives-only unmanaged target was accepted | code-reviewer Faraday | reject initiatives-only target before mutation; retry marker must match exact payload | tc-020 regression | no | `test_uninstall_apply_rejects_unmanaged_initiatives_only_target_before_mutation` |
+| S03 | symlinked retry marker can route marker write outside target | code-reviewer Ampere | reject symlinked `spec-dock/.uninstall-retry.json` before marker read/write | tc-012 / tc-024 regression | no | `test_uninstall_apply_rejects_symlinked_retry_marker_without_external_mutation` |
+| S03 | full `tests.test_init_update` still has dogfooding `.meta.json` snapshot drift failure | verification | recorded as broad-suite blocker to resolve before final S99 | N/A | no | `test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` failure |
+
+#### ステップ契約の完了証跡（Step Contract Closure）
+| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
+|---|---|---|---|---|---|
+| S03 | tc-010, tc-011, tc-012, tc-013, tc-014, tc-022, tc-024 | apply behavior tests pass, code-reviewer pass, report updated | red evidence captured by dev-coder; focused 28-test command pass; report updated with Faraday/Ampere fixes; code-reviewer Planck pass | pass | S03 ready for step commit |
+
+#### テスト契約の完了証跡（Test Contract Closure）
+| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| tc-010 | S03 | yes | red-required | S02 apply guard failure before implementation | focused uninstall command | pass | keep-specs preserves `spec-dock/initiatives/**` |
+| tc-011 | S03 | yes | red-required | S02 apply guard failure before implementation | focused uninstall command | pass | remove-specs removes spec history and reports it |
+| tc-012 | S03 | yes | red-required | S02 apply guard failure before implementation; Faraday found symlink boundary external deletion before follow-up | focused uninstall command | pass | bounded cleanup respects preserved files/root boundaries and rejects symlinked boundary roots |
+| tc-013 | S03 | yes | red-required | S02 apply guard failure before implementation; Faraday found remove-specs rerun failure before follow-up | focused uninstall command | pass | keep-specs and remove-specs rerun report already_removed and succeed via exact retry marker |
+| tc-014 | S03 | yes | red-required | S02 apply guard failure before implementation | focused uninstall command | pass | injected `Path.unlink` failure reports failed separately |
+| tc-022 | S03 | yes | red-required | S02 apply guard failure before implementation | focused uninstall command | pass | output provides installer-direct recovery guidance |
+| tc-024 | S03 | yes | red-required | S02 apply guard failure before implementation | focused uninstall command | pass | JSON apply result covers success, rerun, preserved, cleanup, failed |
+
+#### クロージャ網羅（Closure Coverage）
+| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
+|---|---|---|---|---|
+| tc-010 | S03 | `test_uninstall_apply_keep_specs_removes_tooling_and_preserves_spec_history` | pass | tooling removed, spec marker preserved |
+| tc-011 | S03 | `test_uninstall_apply_remove_specs_removes_spec_history_with_explicit_summary` | pass | spec history action removed and reported |
+| tc-012 | S03 | `test_uninstall_apply_bounded_cleanup_respects_preserved_files_and_roots` | pass | cleanup stayed in boundary roots |
+| tc-013 | S03 | `test_uninstall_apply_rerun_reports_already_removed_and_succeeds` | pass | keep-specs rerun covered |
+| tc-012 | S03 | `test_uninstall_apply_rejects_symlinked_boundary_root_without_external_deletion` | pass | symlinked boundary external deletion regression covered |
+| tc-012, tc-024 | S03 regression | `test_uninstall_apply_rejects_symlinked_retry_marker_without_external_mutation` | pass | retry marker symlink external write regression covered |
+| tc-013 | S03 | `test_uninstall_apply_remove_specs_rerun_reports_already_removed_and_succeeds` | pass | remove-specs rerun covered |
+| tc-020 | S03 regression | `test_uninstall_apply_rejects_unmanaged_initiatives_only_target_before_mutation` | pass | initiatives-only unmanaged target rejected before mutation |
+| tc-014 | S03 | `test_uninstall_apply_partial_unlink_failure_reports_failed_separately` | pass | injected unlink failure covered |
+| tc-022 | S03 | `test_uninstall_apply_output_provides_installer_direct_recovery_guidance` | pass | installer CLI guidance present |
+| tc-024 | S03 | `test_uninstall_apply_json_covers_success_rerun_and_partial_failure_statuses` | pass | completed / partial_failure JSON covered |
+
+#### クロージャ差分（Closure Delta）
+| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
+|---|---|---|---|---|---|---|
+| added | S03 apply tests | listed S03 uninstall apply tests | tc-010 through tc-014, tc-022, tc-024 | S03 apply/idempotency/failure/JSON closure | no | yes |
+| added | S03 reviewer regression tests | symlink boundary, initiatives-only unmanaged, remove-specs rerun, symlink marker tests | tc-012, tc-013, tc-020 regression, tc-024 regression | Faraday/Ampere findings | no | yes |
+
+#### 実装委任ゲート（Implementation Delegation Gate）
+| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S03 | delegated | apply engine and tests change | dev-coder | apply engine, idempotency, partial failure, bounded cleanup | `plan.md` S03 | `src/spec_dock/cli.py`, `tests/test_init_update.py` | runtime wrapper, docs, package/environment deletion, GitHub mutation | focused uninstall tests; `python -m unittest tests.test_init_update -v`; `git diff --check` | need to touch repo root/parent, inability to simulate failure, content policy conflict | changed files, tests, failure simulation, Ledger Note | pass; reviewer pending |
+
+#### 委任 worker 証跡（Delegated Worker Evidence）
+| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
+|---|---|---|---|---|---|---|---|
+| S03 | dev-coder | Added apply execution, idempotent rerun via exact non-symlink retry marker, bounded cleanup, symlink boundary/marker rejection, partial failure, JSON apply result, and recovery guidance | `src/spec_dock/cli.py`; `tests/test_init_update.py` | focused uninstall command -> pass (`Ran 28 tests`); full `tests.test_init_update` -> fail with known dogfooding `.meta.json` snapshot drift; `git diff --check` -> pass | Planck final review passed with P2 report-evidence fix applied | broad suite snapshot drift remains for S99 | accepted for S03 step commit |
+
+#### レビューゲート状態（Reviewer Gate Status）
+| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
+|---|---|---|---|---|---|---|---|
+| S03 | step code review | code-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Faraday: P1 symlink boundary external deletion; P1 initiatives-only unmanaged target; P2 remove-specs rerun |
+| S03 | step code re-review | code-reviewer | fresh | failed | N/A | blocked until fixes and re-review | Ampere: P1 symlinked retry marker external write |
+| S03 | step code second re-review | code-reviewer | fresh | passed | N/A | proceed to S03 step commit | Planck: review_status=pass; P2 report evidence inconsistency fixed |
+
+#### ステップ commit ゲート（Step Commit Gate）
+| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
+|---|---|---|---|---|---|---|---|---|
+| S03 | ready for commit | `src/spec_dock/cli.py`, `tests/test_init_update.py`, `report.md` S03 evidence | pending commit | pending post-commit check | N/A | N/A | N/A | N/A |
 
 ---
 

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/requirement.md
@@ -3,7 +3,7 @@
 ID: "iss-00147"
 タイトル: "SpecDock uninstall command"
 関連GitHub: ["#147"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-31"
 親: ["epic-00054", "init-local-00002"]
@@ -12,88 +12,393 @@ ID: "iss-00147"
 # iss-00147 SpecDock uninstall command — 要件定義（何を、なぜ行うか）
 
 ## 目的
-- （1〜3行）...
+- `spec-dock` 導入済み repo から、開発用の SpecDock agent / skill / tooling を安全に取り除ける repo-local uninstall capability を追加する。
+- 開発完了後、second brain / LLM wiki のように agent や skill 自体がプロダクト運用のノイズになり得る repo で、SpecDock 由来の開発支援設定を整理できるようにする。
+- 実行環境の Python package / global CLI / uvx cache を削除するのではなく、target repo 内に配置された SpecDock-managed artifacts の removal を扱う。
 
 ## 背景・現状
 - 現状の挙動:
-  - ...
+  - installer entrypoint は `spec-dock init [path]` と `spec-dock update [path]` により、target repo に `spec-dock/` scaffold と agent / skill assets を導入・更新する。
+  - repo-local runtime command には installer update を呼び出す `./spec-dock/scripts/spec-dock update` がある。
+  - local spec node deletion は既存の `delete` command が扱うが、repo から SpecDock の開発用 tooling 全体を取り外す command はない。
 - 現状の課題:
-  - ...
-- 再現手順:
-  1. ...
-  2. ...
-- 観測点:
-  - UI:
-  - HTTP:
-  - DB:
-  - ログ:
+  - 開発完了後の product repo に、`.agents/skills/**`、`.codex/agents/**`、`.github/agents/**` などの開発用 agent / skill assets が残り続ける。
+  - sub-agent や skill の稼働が product behavior の一部になる repo では、SpecDock の開発用 agent / skill が discovery や運用判断のノイズになる。
+  - 仕様履歴を残して再開発可能性を保ちたい repo と、使い捨てで履歴ごと消したい repo の両方があり、仕様履歴削除を暗黙 default にできない。
+  - `.codex/config.toml` など user edit が入り得る bootstrap-only file や、product repo に流用された CI / config / prompt / rule を誤削除するリスクがある。
 - 情報源:
-  - ...
+  - `spec-dock/active/epic/requirement.md`
+  - `spec-dock/active/epic/design.md`
+  - `src/spec_dock/cli.py`
+  - `src/spec_dock/assets/install_root/.agents/host-adapters/meta.json`
+  - `src/spec_dock/assets/install_root/`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/update.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/delete.py`
+  - `tests/test_init_update.py`
+  - `tests/cli_runtime/test_update.py`
+  - `tests/cli_runtime/test_delete.py`
+  - `discussions/20260531t133315z-interview-uninstall-command-scope.md`
+  - `discussions/20260531t133616z-interview-uninstall-removal-boundary.md`
+  - `discussions/20260531t134004z-interview-uninstall-user-owned-asset-boundary.md`
+  - `discussions/20260531t134206z-interview-uninstall-command-surface.md`
+  - `discussions/20260531t134650z-interview-uninstall-managed-asset-mismatch.md`
+  - `discussions/20260531t135206z-interview-uninstall-empty-directory-cleanup.md`
 
-## 対象ユーザー / 利用シナリオ（必要時）
+## 対象ユーザー / 利用シナリオ
 - 主な利用者:
-  - ...
+  - SpecDock を使って product development を進めた後、repo から開発用 agent / skill / tooling を整理したい maintainer。
+  - sub-agent / skill configuration が product behavior の一部になる repo の maintainer。
 - 代表シナリオ:
-  - ...
+  - 開発完了後、`./spec-dock/scripts/spec-dock uninstall` を実行し、SpecDock の agent / skill noise を target repo から取り除く。
+  - 将来の開発再開や機能追加に備えて仕様履歴を残したまま uninstall する。
+  - 使い捨て tool や今後の機能追加を想定しない repo で、仕様履歴を含めて SpecDock workspace を削除する。
+  - repo-local runtime が削除された後や uninstall が途中失敗した後、外側の `spec-dock uninstall [path]` で再実行 / 復旧する。
 
 ## スコープ
 - 必須:
-  - ...
+  - installer CLI に `spec-dock uninstall [path]` を追加する。
+  - repo-local runtime command に `./spec-dock/scripts/spec-dock uninstall` を追加し、installer CLI の uninstall implementation を呼び出す。
+  - uninstall は標準で dry-run / plan 表示を提供し、実削除時は仕様履歴を残すか削除するかの明示選択を必須にする。
+  - `--keep-specs` 相当の mode では、開発再開に必要な `spec-dock/initiatives/**` の仕様履歴を残す。
+  - `--remove-specs` 相当の mode では、使い捨て repo / 完全 cleanup のために仕様履歴を削除対象に含める。
+  - `.agents/skills/**`、`.codex/agents/**`、`.github/agents/**` のような agent / skill assets は uninstall の core removal target とし、content mismatch があっても削除する。
+  - repo-root `spec` shortcut は、SpecDock runtime script へ向く symlink の場合に削除対象にする。
+  - bootstrap-only / user-owned になり得る file は、現在の shipped asset と内容が完全一致する場合だけ自動削除し、差分がある場合は preserve + manual review にする。
+  - CI / config / prompt / rule など product repo へ流用されやすい managed assets は、現在の shipped asset と内容が完全一致する場合だけ自動削除し、差分がある場合は preserve + manual review にする。
+  - 削除対象 file の removal 後、既定の上限 root 内で空になった directory だけを bounded cleanup する。
+  - dry-run / execution result で、削除予定 / 削除済み、preserve された manual review 対象、削除された empty directory を operator が追えるようにする。
+  - 途中失敗時は、削除済み、未削除、preserved、failed を区別した summary と non-zero exit status を返す。
+  - uninstall 後に再実行しても、存在しない managed artifact を no-op / already removed として扱い、安全に現状を report できる。
 - 禁止:
-  - ...
+  - Python package / global CLI / uvx cache / pip environment の削除を自動実行しない。
+  - 仕様履歴を暗黙 default で削除しない。
+  - bootstrap-only / user-owned になり得る差分あり file を自動削除しない。
+  - CI / config / prompt / rule など product reuse 可能な差分あり file を自動削除しない。
+  - preserved file、user-authored file、content mismatch で残した file がある directory を削除しない。
+  - `.agents`、`.codex`、`.github`、`spec-dock` など既定の cleanup boundary root を越えて directory cleanup しない。
+  - repo root、`.git`、target repo の親 directory、unknown unmanaged paths を削除しない。
 - 対象外:
-  - ...
+  - GitHub issue close / delete。
+  - spec node 単体の local delete command の再設計。
+  - package manager 別の environment uninstall automation。
+  - legacy workspace の自動 migration。
+  - product repo 固有の agent / skill / CI 設定の意味解釈。
 
 ## 境界
 - 常に行う:
-  - ...
+  - target repo 内の SpecDock-managed artifacts を inventory 化し、dry-run / execution result に removal plan を表示する。
+  - agent / skill assets は primary objective の removal target として扱う。
+  - specs handling は実削除時に explicit mode selection を要求する。
+  - user edit protection と agent / skill noise removal の主従を明確にする。
+  - uninstall 後も、必要なら installer CLI から再 install / update して開発再開できる前提を守る。
 - 判断が必要:
-  - ...
+  - 新しい managed asset category を追加した場合、それが agent / skill noise として content mismatch でも削除すべきものか、product reuse 可能 asset として mismatch preserve すべきものか。
+  - 将来 package/environment uninstall guidance を docs に追加するか。
 - 行わない:
-  - ...
+  - repo 外の user environment を変更しない。
+  - hidden / unknown / unmanaged files を convenience で削除しない。
+  - dry-run だけで destructive operation を暗黙実行しない。
 
 ## 非交渉制約
-- ...
+- destructive operation は explicit mode と operator-visible plan を持つ。
+- agent / skill noise removal は primary objective とし、差分あり agent / skill assets も削除対象にする。
+- user-authored / product-reused file の誤削除を避けるため、bootstrap-only と product-reusable managed assets は content mismatch 時に preserve する。
+- specs deletion は explicit choice とし、開発再開可能性を失う操作であることを operator に示す。
+- uninstall は additive command として導入し、既存 `init` / `update` / `delete` / `sync` / `validate` の契約を壊さない。
+- remote GitHub state は変更しない。
 
 ## 前提
-- ...
+- target repo は `spec-dock init` または `spec-dock update` により SpecDock assets が配置された managed repo である。
+- current shipped assets と target files の content comparison が可能である。
+- content comparison は、実行中の installer package が持つ shipped asset を基準にする。
+- content comparison が判定不能な場合は、agent / skill core removal target を除いて preserve + manual review に倒す。
+- repo-local runtime wrapper が消えた後でも、installer CLI `spec-dock uninstall [path]` から再実行できる。
+- cleanup boundary roots は design で明示され、root を越えた directory cleanup は行わない。
+
+## 削除対象分類
+
+| path / category | 所有境界 | match required | mismatch 時の扱い | specs mode 依存 | report behavior |
+|---|---|---:|---|---|---|
+| `.agents/skills/**` | SpecDock-managed agent / skill | no | delete | none | removed / already removed |
+| `.codex/agents/**` | SpecDock-managed agent | no | delete | none | removed / already removed |
+| `.github/agents/**` | SpecDock-managed agent | no | delete | none | removed / already removed |
+| `.agents/host-adapters/meta.json` | SpecDock-managed metadata | yes | preserve + manual review | none | preserved: content mismatch |
+| `.codex/config.toml` | bootstrap-only / user-owned candidate | yes | preserve + manual review | none | preserved: content mismatch |
+| `.codex/prompts/**` | product-reusable managed prompt | yes | preserve + manual review | none | preserved: content mismatch |
+| `.codex/rules/**` | product-reusable managed rule | yes | preserve + manual review | none | preserved: content mismatch |
+| `.codex/AGENTS.md` | product-reusable managed guidance | yes | preserve + manual review | none | preserved: content mismatch |
+| `.github/workflows/**` | product-reusable managed CI | yes | preserve + manual review | none | preserved: content mismatch |
+| `spec` repo-root shortcut | SpecDock-managed shortcut if symlink points to `spec-dock/scripts/spec-dock` | target match | preserve if not matching SpecDock shortcut | none | removed / preserved: not spec-dock shortcut |
+| `spec-dock/docs/**`, `spec-dock/templates/**`, `spec-dock/system/**`, `spec-dock/scripts/**`, `spec-dock/spec-dock.version` | SpecDock runtime / scaffold | yes | preserve + manual review | none | removed or preserved reason |
+| `spec-dock/active/**`, `spec-dock/.agent/**` | generated active / state | no | delete when removable | remove with workspace cleanup; keep only if preserving specs requires a coherent resume state by design | removed / skipped with reason |
+| `spec-dock/initiatives/**` | specs / product development history | no | depends on explicit mode | `--keep-specs`: preserve; `--remove-specs`: delete | preserved: keep-specs / removed: remove-specs |
+| unknown files under `.agents`, `.codex`, `.github`, `spec-dock` | unmanaged / user-authored candidate | no automatic ownership | preserve | none | preserved: unmanaged |
+
+- agent / skill assets の mismatch deletion は、SpecDock-managed known paths に限る。unknown user-created agent / skill files は unmanaged として preserve する。
+- product-reusable managed assets は、content match する場合だけ自動削除する。content mismatch、symlink / file type mismatch、permission / comparison error など判定不能な場合は preserve + manual review とする。
+- repo-root `spec` は symlink target が SpecDock runtime shortcut と確認できる場合だけ削除する。通常 file、directory、または別 target の symlink は preserve + manual review とする。
+- exact flag names and output wording は design phase で既存 CLI style に合わせて固定する。
 
 ## 受け入れ条件
 - AC-001:
   - アクター:
+    - maintainer
   - 前提:
+    - SpecDock-managed agent / skill assets を持つ target repo がある。
   - 操作:
+    - `./spec-dock/scripts/spec-dock uninstall` または `spec-dock uninstall <target>` で dry-run / plan 表示を実行する。
   - 期待結果:
+    - 削除予定 files、preserve 予定 files、manual review 対象、empty directory cleanup plan が表示される。
+    - dry-run では filesystem mutation が発生しない。
   - 観測点:
+    - CLI output
+    - filesystem assertions
 - AC-002:
-  - ...
+  - アクター:
+    - maintainer
+  - 前提:
+    - target repo に `spec-dock/initiatives/**` の仕様履歴がある。
+  - 操作:
+    - 実削除を要求するが、specs handling mode を指定しない。
+  - 期待結果:
+    - command は fail-fast し、`--keep-specs` / `--remove-specs` 相当の明示選択を要求する。
+    - 仕様履歴も agent / skill assets も削除されない。
+  - 観測点:
+    - exit status
+    - CLI error
+    - filesystem assertions
+- AC-003:
+  - アクター:
+    - maintainer
+  - 前提:
+    - target repo に SpecDock-managed agent / skill assets と仕様履歴がある。
+  - 操作:
+    - `--keep-specs` 相当の mode で uninstall を実行する。
+  - 期待結果:
+    - agent / skill assets は content mismatch の有無にかかわらず削除される。
+    - `spec-dock/initiatives/**` は残る。
+    - repo-local runtime / scaffold / managed assets は、mode と category rule に従って削除または preserve される。
+    - 空になった managed directories は boundary root 内で cleanup される。
+  - 観測点:
+    - filesystem assertions
+    - CLI result summary
+- AC-004:
+  - アクター:
+    - maintainer
+  - 前提:
+    - target repo に SpecDock-managed assets と仕様履歴がある。
+  - 操作:
+    - `--remove-specs` 相当の mode で uninstall を実行する。
+  - 期待結果:
+    - agent / skill assets と仕様履歴が削除対象になる。
+    - deletion plan / result は仕様履歴削除を明示する。
+    - cleanup boundary root を越えた directory deletion は行われない。
+  - 観測点:
+    - filesystem assertions
+    - CLI result summary
+- AC-005:
+  - アクター:
+    - maintainer
+  - 前提:
+    - `.codex/config.toml` など bootstrap-only file が shipped asset と完全一致する。
+  - 操作:
+    - uninstall を実行する。
+  - 期待結果:
+    - 当該 file は自動削除対象になる。
+  - 観測点:
+    - filesystem assertions
+    - result summary
+- AC-006:
+  - アクター:
+    - maintainer
+  - 前提:
+    - bootstrap-only file または product-reusable managed asset が shipped asset と異なる内容を持つ。
+  - 操作:
+    - uninstall を実行する。
+  - 期待結果:
+    - 当該 file は自動削除されず、manual review 対象として result に表示される。
+  - 観測点:
+    - filesystem assertions
+    - result summary
+- AC-007:
+  - アクター:
+    - maintainer
+  - 前提:
+    - known SpecDock-managed agent / skill path の file が shipped asset と異なる内容を持つ。
+  - 操作:
+    - uninstall を実行する。
+  - 期待結果:
+    - 当該 agent / skill asset は削除される。
+    - unknown user-created agent / skill file は削除されず、unmanaged preserve として表示される。
+  - 観測点:
+    - filesystem assertions
+    - result summary
+- AC-008:
+  - アクター:
+    - maintainer
+  - 前提:
+    - repo-local runtime command が存在する。
+  - 操作:
+    - `./spec-dock/scripts/spec-dock uninstall` を実行する。
+  - 期待結果:
+    - repo-local command は installer `spec-dock uninstall <target>` implementation を呼び出す。
+    - repo-local runtime が削除対象になっても、operator は installer CLI から再実行 / 復旧できる案内を得る。
+  - 観測点:
+    - runtime command test
+    - subprocess args assertion
+    - CLI output
+- AC-009:
+  - アクター:
+    - maintainer
+  - 前提:
+    - uninstall 対象の一部が既に削除済み、または前回実行が途中で失敗している。
+  - 操作:
+    - installer CLI `spec-dock uninstall <target>` で再実行する。
+  - 期待結果:
+    - command は既に存在しない managed artifacts を no-op / already removed として扱う。
+    - 削除済み、未削除、preserved、failed が区別された summary が返る。
+    - 再実行できない destructive error にならない。
+  - 観測点:
+    - filesystem assertions
+    - CLI result summary
+    - exit status
+- AC-010:
+  - アクター:
+    - maintainer
+    - agent
+  - 前提:
+    - agent または自動化が uninstall の dry-run plan / apply result を機械的に解釈する必要がある。
+  - 操作:
+    - installer CLI または repo-local runtime command で `--json` を付けて uninstall を実行する。
+  - 期待結果:
+    - command は human-readable summary ではなく、machine-readable な JSON object を stdout に返す。
+    - JSON は dry-run plan と apply result の両方を表現できる。
+    - JSON は削除予定 / 削除済み / 既に削除済み / 保持 / 失敗 / 空 directory cleanup / guidance を agent が判別できる構造を持つ。
+    - `--json` は runtime wrapper から installer CLI へ forwarding される。
+  - 観測点:
+    - JSON parse assertion
+    - schema/key assertion
+    - runtime subprocess args assertion
+    - exit status
 
 ## 例外・エッジケース
 - EC-001:
   - 条件:
+    - target repo に `spec-dock/` が存在しない、または managed repo と判定できない。
   - 期待:
+    - command は fail-fast し、`spec-dock init` / target path の確認を案内する。
   - 観測点:
+    - exit status
+    - CLI error
 - EC-002:
-  - ...
+  - 条件:
+    - dry-run mode。
+  - 期待:
+    - CLI output は removal plan を表示するが、file / directory を変更しない。
+  - 観測点:
+    - filesystem snapshot comparison
+- EC-003:
+  - 条件:
+    - preserved file がある directory が cleanup candidate になる。
+  - 期待:
+    - directory は削除されない。
+  - 観測点:
+    - filesystem assertions
+- EC-004:
+  - 条件:
+    - cleanup traversal が `.agents`、`.codex`、`.github`、`spec-dock` などの boundary root に到達する。
+  - 期待:
+    - boundary root を越えて parent directory を削除しない。
+  - 観測点:
+    - filesystem assertions
+- EC-005:
+  - 条件:
+    - uninstall 途中で repo-local runtime wrapper が削除済みになった後に再実行が必要になる。
+  - 期待:
+    - installer CLI `spec-dock uninstall <target>` から再実行できる。
+  - 観測点:
+    - installer CLI test / docs inspection
+- EC-006:
+  - 条件:
+    - shipped asset との content comparison が file type mismatch、symlink、permission error、または読み取り失敗で判定不能になる。
+  - 期待:
+    - agent / skill core removal target を除き、対象 file は preserve + manual review として扱う。
+    - result summary に判定不能理由が表示される。
+  - 観測点:
+    - filesystem assertions
+    - CLI result summary
+- EC-007:
+  - 条件:
+    - repo-root `spec` が通常 file、directory、または SpecDock runtime 以外を指す symlink である。
+  - 期待:
+    - command は `spec` を自動削除せず、manual review 対象として表示する。
+  - 観測点:
+    - filesystem assertions
+    - CLI result summary
+- EC-008:
+  - 条件:
+    - `--json` が指定された command で failed removals、inventory/comparison/apply error、または preserved manual-review item が発生する。
+  - 期待:
+    - command は parse 可能な JSON object を stdout に返し、status / summary / actions / guidance / errors によって agent が次アクションを判定できる。
+    - human-readable 補足は JSON stdout に混在しない。
+  - 観測点:
+    - JSON parse assertion
+    - stdout/stderr separation
+    - exit status
 
-## 入力→出力例（必要時）
+## 入力→出力例
 - EX-001:
   - 入力:
+    - `./spec-dock/scripts/spec-dock uninstall --dry-run`
   - 出力:
+    - removed candidates、preserved manual review、required specs mode guidance を含む plan。
+- EX-002:
+  - 入力:
+    - `./spec-dock/scripts/spec-dock uninstall --apply --keep-specs`
+  - 出力:
+    - agent / skill assets removal、spec history preservation、bounded empty directory cleanup の result summary。
+- EX-003:
+  - 入力:
+    - `spec-dock uninstall /path/to/repo --apply --remove-specs`
+  - 出力:
+    - target repo の SpecDock artifacts と specs removal の result summary。
+- EX-004:
+  - 入力:
+    - `spec-dock uninstall /path/to/repo --json`
+  - 出力:
+    - agent が parse 可能な dry-run plan JSON。
+- EX-005:
+  - 入力:
+    - `spec-dock uninstall /path/to/repo --apply --keep-specs --json`
+  - 出力:
+    - agent が parse 可能な apply result JSON。
 
 ## 用語（ドメイン語彙）
-- TERM-001:
-  - ...
+- repo-local uninstall:
+  - target repo 内に導入された SpecDock-managed artifacts を取り外す操作。Python package / global CLI の削除は含まない。
+- repo-root shortcut:
+  - target repo root の `spec` symlink。SpecDock runtime script へ向く場合のみ SpecDock-managed shortcut として扱う。
+- specs:
+  - `spec-dock/initiatives/**` に蓄積された仕様履歴と開発再開のための canonical project history。
+- agent / skill assets:
+  - `.agents/skills/**`、`.codex/agents/**`、`.github/agents/**` など、agent discovery / sub-agent 稼働に影響する開発用 assets。
+- product-reusable assets:
+  - `.github/workflows/ci.yml`、`.codex/prompts/**`、`.codex/rules/**` など、SpecDock 由来でも product repo 側で編集・流用され得る assets。
+- bootstrap-only / user-owned file:
+  - installer が初回作成するが、以後の update では user edit を尊重する file。現時点の代表例は `.codex/config.toml`。
+- bounded empty-dir cleanup:
+  - 削除対象 file の親 directory から上に向かって空 directory を削除するが、既定の boundary root を越えない cleanup。
 
 ## 未確定事項
+- none.
+
+## 解決済み質問
 - Q-001:
   - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
+    - `--apply` / `--yes` / `--keep-specs` / `--remove-specs` などの具体的な flag 名をどうするか。
+  - 回答:
+    - design phase で `--apply`、`--keep-specs`、`--remove-specs`、`--json` として固定した。
   - 影響範囲:
-    - ...
+    - CLI help
+    - tests
+    - docs

--- a/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/requirement.md
+++ b/spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/requirement.md
@@ -21,6 +21,7 @@ ID: "epic-00054"
   - local spec node（issue / epic / initiative）を directory ごと削除できる。
   - destructive な local delete と、より安全な remote close を分離した lifecycle contract を提供する。
   - repo-local runtime command から upstream package 経由の self-update を実行できる。
+  - 導入済み repo から SpecDock の開発用 agent / skill / tooling を取り外す repo-local uninstall を実行できる。
   - review-only issue を分離せず、各 implementation issue の中で review と成功性確認を完結させる。
 
 ## ユースケース
@@ -29,10 +30,12 @@ ID: "epic-00054"
   - maintainer が不要になった issue / epic / initiative を local workspace から削除する際、対象 directory を command 経由で安全に除去できる。
   - issue / epic / initiative の local delete では、remote 側は delete ではなく close に留めることで、GitHub 履歴と事故防止のバランスを保てる。
   - maintainer が managed repo 内で `./spec-dock/scripts/spec-dock update` を実行し、upstream GitHub package から shipped docs / scripts / skills を更新できる。
+  - maintainer が開発完了後の repo 内で `./spec-dock/scripts/spec-dock uninstall` を実行し、product 運用時にノイズになる SpecDock agent / skill / tooling を取り外せる。
 - exception / operation scenario:
   - active target や dependency を持つ node を delete しようとした場合は、事前確認または fail-fast で誤操作を防ぐ。
   - linked GitHub issue を持たない local-only cleanup は local delete だけで完結する。
   - GitHub close が権限不足や `gh` 状態不備で失敗した場合、local delete との整合を崩さない安全境界が必要になる。
+  - uninstall では仕様履歴を残して開発再開可能性を維持する repo と、使い捨てで仕様履歴ごと削除したい repo の両方を扱う必要がある。
 
 ## Epic requirements
 - E-RQ-001:
@@ -48,13 +51,18 @@ ID: "epic-00054"
 - E-RQ-006:
   - GitHub-side issue delete はこの epic の対象外とし、docs / design / plan / acceptance criteria の success path に含めないこと。
 - E-RQ-007:
-  - epic の execution は close command、local delete command、self-update command の各 issue scope に分け、各 issue がそれぞれの scope に対する docs / tests / review / success verification を内包すること。
+  - epic の execution は close command、local delete command、self-update command、uninstall command の各 issue scope に分け、各 issue がそれぞれの scope に対する docs / tests / review / success verification を内包すること。
 - E-RQ-008:
   - epic 全体の final review / final validation / close-out evidence は、最後に完了する issue が保持すること。固定の第2 issue に閉じず、issue 追加時も close-out owner を明示して扱えること。
 - E-RQ-009:
   - SpecDock は repo-local runtime command から installer `spec-dock update [path]` を呼び出す self-update 操作を提供し、maintainer が long-form `uvx` invocation を覚えなくても managed assets を更新できること。
 - E-RQ-010:
   - self-update 操作は uvx cache による stale package 混入を避けるため、upstream GitHub package を `uvx --no-cache` で実行すること。
+- E-RQ-011:
+  - SpecDock は repo-local runtime command と installer CLI の両方から uninstall 操作を提供し、導入済み repo から SpecDock-managed development tooling / agent assets を安全に取り外せること。
+- E-RQ-012:
+  - uninstall 操作は project-wide garbage collection ではなく、SpecDock-managed assets と仕様履歴の明示 mode に限定された lifecycle operation として扱うこと。
+  - user-authored / product-reused files の誤削除を避ける guardrail、dry-run / result summary、再実行可能性を持つこと。
 
 ## Epic acceptance criteria
 - E-AC-001:
@@ -118,25 +126,44 @@ ID: "epic-00054"
     - runtime / CLI tests
     - subprocess args assertion
     - docs contract
+- E-AC-006:
+  - Given:
+    - `spec-dock/` workspace と installer-managed agent / skill assets を持つ managed repo がある
+  - When:
+    - maintainer が repo-local runtime command または installer CLI から uninstall を実行する
+  - Then:
+    - SpecDock の開発用 agent / skill / tooling が operator-visible plan と明示 mode に基づいて取り外される
+    - 仕様履歴を残す / 削除する選択は暗黙 default ではなく明示 mode として扱われる
+    - user-authored / product-reused files は guardrail により preserve / manual review される
+    - repo-local runtime が削除対象になった後も installer CLI から再実行 / 復旧できる
+  - 観測点:
+    - installer CLI tests
+    - runtime wrapper tests
+    - filesystem assertions
+    - docs contract
 
 ## スコープ
 - MUST:
   - command-side GitHub issue close
   - local issue / epic / initiative delete
   - repo-local runtime self-update command
+  - repo-local uninstall command and installer-side uninstall implementation
   - destructive guardrail、confirmation、docs/tests 整備
   - dogfooding での lifecycle completeness gap を埋めること
-  - close / delete / self-update の各 issue scope で進め、各 issue に review と成功性確認を内包すること
+  - close / delete / self-update / uninstall の各 issue scope で進め、各 issue に review と成功性確認を内包すること
 - MUST NOT:
   - remote GitHub issue delete を success path に含めない
   - destructive local delete を silent / implicit に実行しない
   - self-update で uvx cache を標準経路として使わない
+  - uninstall を project-wide garbage collection として扱わない
+  - uninstall で user-authored / product-reused files を silent deletion しない
   - review / validation だけを目的とする standalone issue を作らない
 - OUT OF SCOPE:
   - GitHub-side issue delete
   - GitHub issue 以外の remote artifact 削除
   - project-wide garbage collection の自動化
   - package update availability check / version comparison
+  - package manager / Python environment / global executable の automatic uninstall
   - legacy workspace の自動 migration
 
 ## 境界
@@ -144,6 +171,7 @@ ID: "epic-00054"
   - remote handling は close-only とし、GitHub 履歴保全と事故防止を優先する
   - local delete は directory removal を伴う destructive operation として扱う
   - self-update は upstream GitHub package を `uvx --no-cache` で呼び出し、cache stale による誤更新を避ける
+  - uninstall は repo-local development tooling removal として扱い、package/environment uninstall とは分離する
   - issue / epic / initiative の各階層差を docs / command contract で明示する
 - Ask:
   - active target や dependency を含む node を delete する前に、どの guardrail を必須にするか。

--- a/spec-dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/parser.py
@@ -55,6 +55,11 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
         registry,
         "update",
     )
+    _bind_leaf(
+        sub.add_parser("uninstall", help="Uninstall SpecDock-managed repo assets via the upstream spec-dock package"),
+        registry,
+        "uninstall",
+    )
 
     p_delegated = sub.add_parser("delegated-authoring", help="Check delegated discussion draft output")
     delegated_sub = p_delegated.add_subparsers(dest="delegated_authoring_cmd", required=True)

--- a/spec-dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/registry.py
@@ -10,6 +10,7 @@ from ..commands import import_cmd as import_commands
 from ..commands import issue as issue_commands
 from ..commands import new as new_commands
 from ..commands import sync as sync_commands
+from ..commands import uninstall as uninstall_commands
 from ..commands import update as update_commands
 from ..commands import validate as validate_commands
 from ..commands import worktree as worktree_commands
@@ -25,6 +26,7 @@ def build_registry() -> CommandRegistry:
     items.update(close_commands.command_specs())
     items.update(delegated_authoring_commands.command_specs())
     items.update(update_commands.command_specs())
+    items.update(uninstall_commands.command_specs())
     items.update(issue_commands.command_specs())
     items.update(worktree_commands.command_specs())
     items.update(sync_commands.command_specs())

--- a/spec-dock/scripts/spec_dock_runtime/commands/uninstall.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/uninstall.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..application.contracts import UseCases
+from ..presentation.contracts import CliText
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+
+
+UPSTREAM_SOURCE = "git+https://github.com/chemitaro/spec-dock"
+
+
+@dataclass(frozen=True)
+class UninstallArgs(CommandArgs):
+    target: str
+    apply: bool
+    keep_specs: bool
+    remove_specs: bool
+    json: bool
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "uninstall": CommandSpec(
+            add_arguments=_add_uninstall_arguments,
+            args_factory=_uninstall_args,
+            run=_run_uninstall,
+        )
+    }
+
+
+def _add_uninstall_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.description = (
+        "Uninstall SpecDock-managed repo assets by running "
+        f"uvx --no-cache --from {UPSTREAM_SOURCE} spec-dock uninstall TARGET. "
+        "TARGET defaults to the current working directory."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Managed repo target path to uninstall (default: current working directory)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the uninstall plan instead of showing a dry-run plan",
+    )
+    specs_mode = parser.add_mutually_exclusive_group()
+    specs_mode.add_argument(
+        "--keep-specs",
+        action="store_true",
+        help="Keep spec history while uninstalling managed tooling",
+    )
+    specs_mode.add_argument(
+        "--remove-specs",
+        action="store_true",
+        help="Remove spec history while uninstalling managed tooling",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Forward JSON output mode to the installer CLI",
+    )
+
+
+def _uninstall_args(ns: argparse.Namespace) -> CommandArgs:
+    return UninstallArgs(
+        target=str(getattr(ns, "path", ".")),
+        apply=bool(getattr(ns, "apply", False)),
+        keep_specs=bool(getattr(ns, "keep_specs", False)),
+        remove_specs=bool(getattr(ns, "remove_specs", False)),
+        json=bool(getattr(ns, "json", False)),
+    )
+
+
+def _run_uninstall(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    del use_cases
+    typed = _expect_uninstall_args(args)
+    target = Path(typed.target).expanduser().resolve()
+    command = [
+        "uvx",
+        "--no-cache",
+        "--from",
+        UPSTREAM_SOURCE,
+        "spec-dock",
+        "uninstall",
+        str(target),
+    ]
+    if typed.apply:
+        command.append("--apply")
+    if typed.keep_specs:
+        command.append("--keep-specs")
+    if typed.remove_specs:
+        command.append("--remove-specs")
+    if typed.json:
+        command.append("--json")
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        return CommandOutcome(
+            exit_code=127,
+            text=CliText(
+                stdout_lines=[],
+                stderr_lines=[
+                    "error: uvx could not be executed. Install uv/uvx or ensure uvx is on PATH, then retry."
+                ],
+                warnings=[],
+            ),
+        )
+    return CommandOutcome(
+        exit_code=int(result.returncode),
+        text=CliText(
+            stdout_lines=result.stdout.splitlines(),
+            stderr_lines=result.stderr.splitlines(),
+            warnings=[],
+        ),
+    )
+
+
+def _expect_uninstall_args(args: CommandArgs) -> UninstallArgs:
+    if not isinstance(args, UninstallArgs):
+        raise RuntimeError("Invalid command args for uninstall")
+    return args

--- a/src/spec_dock/assets/spec_dock/docs/reference_github.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_github.md
@@ -18,6 +18,8 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 - `./spec-dock/scripts/spec-dock update [path]` は GitHub を更新しない repo-local self-update path です。target 省略時は current directory を更新し、明示 path を渡すとその managed repo を更新します
 - runtime update は installer update の wrapper で、固定 upstream `git+https://github.com/chemitaro/spec-dock` を `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock update <target>` として実行します。arbitrary package source / cache option / `--force` は公開しません
 - update は managed files/docs/templates/scripts/skills を refresh しますが、`init --force` ではなく、old workspace の in-place migration も保証しません
+- `spec-dock uninstall [path]` / `./spec-dock/scripts/spec-dock uninstall [path]` は repo-local managed artifacts の removal です。GitHub Issue / remote state は変更せず、Python package / global CLI / environment / `uvx` cache の uninstall も行いません
+- runtime uninstall は installer uninstall の wrapper で、固定 upstream `git+https://github.com/chemitaro/spec-dock` を `uvx --no-cache --from git+https://github.com/chemitaro/spec-dock spec-dock uninstall <target>` として実行します。repo-local runtime が削除済みの場合の retry / reinstall / refresh は installer CLI の `spec-dock uninstall <target>` / `spec-dock init <target>` / `spec-dock update <target>` を使います
 - dependency metadata の canonical storage は `.meta.json` top-level `depends_on` であり、追加/削除/確認は `./spec-dock/scripts/spec-dock deps add/remove/check` の command-first mutation を使います（詳細: `reference_deps.md`）
 - legacy `meta.json`（旧名）、partial linkage、current-repo mismatch などの old contract 不整合は、`update` で吸収されず current create / import / validate / sync が reject / fail-fast しうる
 - その場合は auto-migrate を期待せず、手動で normalize するか workspace を rebuild してください
@@ -71,6 +73,7 @@ spec-dock は `gh` の全コマンドで一律に `--repo owner/repo` を省略�
 
 - `new {initiative,epic,issue} --github-issue <n>` は「既存番号へリンク」するだけで、GitHub Issue は作りません（`gh` を呼びません）
 - `./spec-dock/scripts/spec-dock update [path]` は `gh` を呼びません。固定 upstream の installer update を `uvx --no-cache` で呼び出し、managed files/docs/templates/scripts/skills を更新します
+- `spec-dock uninstall [path]` / `./spec-dock/scripts/spec-dock uninstall [path]` は `gh` を呼びません。target repo 内の SpecDock-managed artifacts を dry-run / explicit apply で取り外すだけで、GitHub Issue close/delete、package/environment uninstall、`uvx` cache cleanup は行いません
 - 生成される `epics/rules.md` / `issues/rules.md` / `discussions/rules.md` は `spec-dock/docs/rules/**` への symlink です。`rules.md` は入口/ナビゲーション用で、ルールの正本は `spec-dock/docs/rules/**` にあります。runtime command はサポートされた実行経路です
 
 ## 3. `import` の URL 入力に関する注意（事故防止）

--- a/src/spec_dock/assets/spec_dock/docs/reference_sync.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_sync.md
@@ -44,6 +44,10 @@ legacy v1 生成物（廃止）:
 
 上記3つは `sync` 実行時に常に削除されます（stale防止）。
 
+uninstall との関係:
+- `spec-dock/active/**` と `spec-dock/.agent/**` は `sync` / active 更新で再生成される状態であり、repo-local uninstall では generated state として cleanup 対象になります
+- uninstall は GitHub state や package/environment/`uvx` cache を変更しません。repo-local runtime が削除済みの場合の再実行や復旧は installer CLI の `spec-dock uninstall <target>` / `spec-dock init <target>` / `spec-dock update <target>` を使います
+
 ## 2. 全体 / TODO 投影（all / todo projection）
 
 `*-all.json` は全件を保持します。

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/parser.py
@@ -55,6 +55,11 @@ def build_parser(registry: CommandRegistry) -> argparse.ArgumentParser:
         registry,
         "update",
     )
+    _bind_leaf(
+        sub.add_parser("uninstall", help="Uninstall SpecDock-managed repo assets via the upstream spec-dock package"),
+        registry,
+        "uninstall",
+    )
 
     p_delegated = sub.add_parser("delegated-authoring", help="Check delegated discussion draft output")
     delegated_sub = p_delegated.add_subparsers(dest="delegated_authoring_cmd", required=True)

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/registry.py
@@ -10,6 +10,7 @@ from ..commands import import_cmd as import_commands
 from ..commands import issue as issue_commands
 from ..commands import new as new_commands
 from ..commands import sync as sync_commands
+from ..commands import uninstall as uninstall_commands
 from ..commands import update as update_commands
 from ..commands import validate as validate_commands
 from ..commands import worktree as worktree_commands
@@ -25,6 +26,7 @@ def build_registry() -> CommandRegistry:
     items.update(close_commands.command_specs())
     items.update(delegated_authoring_commands.command_specs())
     items.update(update_commands.command_specs())
+    items.update(uninstall_commands.command_specs())
     items.update(issue_commands.command_specs())
     items.update(worktree_commands.command_specs())
     items.update(sync_commands.command_specs())

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/uninstall.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..application.contracts import UseCases
+from ..presentation.contracts import CliText
+from .contracts import CommandArgs, CommandOutcome, CommandSpec
+
+
+UPSTREAM_SOURCE = "git+https://github.com/chemitaro/spec-dock"
+
+
+@dataclass(frozen=True)
+class UninstallArgs(CommandArgs):
+    target: str
+    apply: bool
+    keep_specs: bool
+    remove_specs: bool
+    json: bool
+
+
+def command_specs() -> dict[str, CommandSpec]:
+    return {
+        "uninstall": CommandSpec(
+            add_arguments=_add_uninstall_arguments,
+            args_factory=_uninstall_args,
+            run=_run_uninstall,
+        )
+    }
+
+
+def _add_uninstall_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.description = (
+        "Uninstall SpecDock-managed repo assets by running "
+        f"uvx --no-cache --from {UPSTREAM_SOURCE} spec-dock uninstall TARGET. "
+        "TARGET defaults to the current working directory."
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default=".",
+        help="Managed repo target path to uninstall (default: current working directory)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the uninstall plan instead of showing a dry-run plan",
+    )
+    specs_mode = parser.add_mutually_exclusive_group()
+    specs_mode.add_argument(
+        "--keep-specs",
+        action="store_true",
+        help="Keep spec history while uninstalling managed tooling",
+    )
+    specs_mode.add_argument(
+        "--remove-specs",
+        action="store_true",
+        help="Remove spec history while uninstalling managed tooling",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Forward JSON output mode to the installer CLI",
+    )
+
+
+def _uninstall_args(ns: argparse.Namespace) -> CommandArgs:
+    return UninstallArgs(
+        target=str(getattr(ns, "path", ".")),
+        apply=bool(getattr(ns, "apply", False)),
+        keep_specs=bool(getattr(ns, "keep_specs", False)),
+        remove_specs=bool(getattr(ns, "remove_specs", False)),
+        json=bool(getattr(ns, "json", False)),
+    )
+
+
+def _run_uninstall(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
+    del use_cases
+    typed = _expect_uninstall_args(args)
+    target = Path(typed.target).expanduser().resolve()
+    command = [
+        "uvx",
+        "--no-cache",
+        "--from",
+        UPSTREAM_SOURCE,
+        "spec-dock",
+        "uninstall",
+        str(target),
+    ]
+    if typed.apply:
+        command.append("--apply")
+    if typed.keep_specs:
+        command.append("--keep-specs")
+    if typed.remove_specs:
+        command.append("--remove-specs")
+    if typed.json:
+        command.append("--json")
+
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except FileNotFoundError:
+        return CommandOutcome(
+            exit_code=127,
+            text=CliText(
+                stdout_lines=[],
+                stderr_lines=[
+                    "error: uvx could not be executed. Install uv/uvx or ensure uvx is on PATH, then retry."
+                ],
+                warnings=[],
+            ),
+        )
+    return CommandOutcome(
+        exit_code=int(result.returncode),
+        text=CliText(
+            stdout_lines=result.stdout.splitlines(),
+            stderr_lines=result.stderr.splitlines(),
+            warnings=[],
+        ),
+    )
+
+
+def _expect_uninstall_args(args: CommandArgs) -> UninstallArgs:
+    if not isinstance(args, UninstallArgs):
+        raise RuntimeError("Invalid command args for uninstall")
+    return args

--- a/src/spec_dock/cli.py
+++ b/src/spec_dock/cli.py
@@ -791,6 +791,248 @@ class _ManagedSkillInstallPlan(NamedTuple):
     obsolete_exact_rel_paths: tuple[Path, ...]
 
 
+class _UninstallAction(NamedTuple):
+    rel_path: str
+    category: str
+    status: str
+    reason: str
+    error: str | None = None
+
+
+def _uninstall_specs_mode(ns: argparse.Namespace) -> str | None:
+    if getattr(ns, "keep_specs", False):
+        return "keep"
+    if getattr(ns, "remove_specs", False):
+        return "remove"
+    return None
+
+
+def _require_managed_specdock_for_uninstall(target_root: Path) -> Path:
+    try:
+        specdock_dir = _require_specdock(target_root)
+    except RuntimeError as e:
+        raise RuntimeError(f"target is not a managed SpecDock repo: {e}") from e
+
+    version_file = specdock_dir / "spec-dock.version"
+    if not version_file.is_file():
+        raise RuntimeError(
+            "target is not a managed SpecDock repo: missing managed "
+            "'spec-dock/spec-dock.version' state"
+        )
+    return specdock_dir
+
+
+def _build_uninstall_plan_skeleton(target_root: Path, *, specs_mode: str | None) -> tuple[_UninstallAction, ...]:
+    """Build the S01 dry-run skeleton without applying full inventory policy."""
+    actions: list[_UninstallAction] = []
+
+    representative_agent_path = Path(".agents/skills/spec-dock-issue-execution/SKILL.md")
+    if (target_root / representative_agent_path).exists():
+        actions.append(
+            _UninstallAction(
+                rel_path=representative_agent_path.as_posix(),
+                category="agent_skill",
+                status="would_remove",
+                reason="known SpecDock-managed agent/skill asset",
+            )
+        )
+
+    spec_history_path = Path("spec-dock/initiatives")
+    if (target_root / spec_history_path).exists():
+        if specs_mode == "remove":
+            actions.append(
+                _UninstallAction(
+                    rel_path=spec_history_path.as_posix(),
+                    category="spec_history",
+                    status="would_remove",
+                    reason="explicit remove-specs mode",
+                )
+            )
+        else:
+            reason = (
+                "keep-specs mode"
+                if specs_mode == "keep"
+                else "dry-run preserves specs unless remove-specs is explicit"
+            )
+            actions.append(
+                _UninstallAction(
+                    rel_path=spec_history_path.as_posix(),
+                    category="spec_history",
+                    status="preserved",
+                    reason=reason,
+                )
+            )
+
+    if not actions:
+        actions.append(
+            _UninstallAction(
+                rel_path=".",
+                category="unmanaged",
+                status="preserved",
+                reason="no S01 uninstall skeleton candidates found",
+            )
+        )
+    return tuple(actions)
+
+
+def _summarize_uninstall_actions(actions: tuple[_UninstallAction, ...]) -> dict[str, int]:
+    summary = {
+        "would_remove": 0,
+        "removed": 0,
+        "already_removed": 0,
+        "preserved": 0,
+        "failed": 0,
+        "empty_dir_removed": 0,
+    }
+    for action in actions:
+        if action.status not in summary:
+            summary[action.status] = 0
+        summary[action.status] += 1
+    return summary
+
+
+def _uninstall_payload(
+    target_root: Path,
+    *,
+    apply: bool,
+    specs_mode: str | None,
+    actions: tuple[_UninstallAction, ...],
+    status: str | None = None,
+    errors: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "target": str(target_root),
+        "mode": "apply" if apply else "dry-run",
+        "apply": apply,
+        "specs_mode": specs_mode,
+        "status": status or ("completed" if apply else "planned"),
+        "summary": _summarize_uninstall_actions(actions),
+        "actions": [
+            {
+                "path": action.rel_path,
+                "category": action.category,
+                "status": action.status,
+                "reason": action.reason,
+                "error": action.error,
+            }
+            for action in actions
+        ],
+        "guidance": [
+            "dry-run only; pass --apply with exactly one of --keep-specs or --remove-specs to mutate",
+            "S01 provides command surface and plan rendering only; full inventory/apply behavior follows in later steps",
+        ],
+        "errors": errors or [],
+    }
+
+
+def _emit_uninstall_preflight_error(
+    target_root: Path,
+    *,
+    apply: bool,
+    specs_mode: str | None,
+    json_requested: bool,
+    message: str,
+) -> int:
+    if json_requested:
+        payload = _uninstall_payload(
+            target_root,
+            apply=apply,
+            specs_mode=specs_mode,
+            actions=(),
+            status="error",
+            errors=[message],
+        )
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"error: {message}", file=sys.stderr)
+    return 2
+
+
+def _render_uninstall_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"spec-dock: uninstall plan ({payload['mode']}) -> {payload['target']}",
+        f"specs_mode: {payload['specs_mode'] or 'unspecified'}",
+        "summary:",
+    ]
+    for key, value in payload["summary"].items():
+        lines.append(f"  {key}: {value}")
+    lines.append("actions:")
+    for action in payload["actions"]:
+        lines.append(
+            "  "
+            f"[{action['status']}] {action['path']} "
+            f"category={action['category']} reason={action['reason']}"
+        )
+    lines.append("guidance:")
+    for item in payload["guidance"]:
+        lines.append(f"  - {item}")
+    return "\n".join(lines)
+
+
+def _run_uninstall(target_root: Path, ns: argparse.Namespace) -> int:
+    specs_mode = _uninstall_specs_mode(ns)
+    apply_requested = bool(ns.apply)
+    json_requested = bool(ns.json)
+
+    if not target_root.exists() or not target_root.is_dir():
+        return _emit_uninstall_preflight_error(
+            target_root,
+            apply=apply_requested,
+            specs_mode=specs_mode,
+            json_requested=json_requested,
+            message=f"target path is not a directory: {target_root}",
+        )
+
+    if apply_requested and specs_mode is None:
+        return _emit_uninstall_preflight_error(
+            target_root,
+            apply=apply_requested,
+            specs_mode=specs_mode,
+            json_requested=json_requested,
+            message=(
+                "uninstall --apply requires exactly one specs mode: "
+                "--keep-specs or --remove-specs"
+            ),
+        )
+
+    try:
+        _require_managed_specdock_for_uninstall(target_root)
+    except RuntimeError as e:
+        return _emit_uninstall_preflight_error(
+            target_root,
+            apply=apply_requested,
+            specs_mode=specs_mode,
+            json_requested=json_requested,
+            message=str(e),
+        )
+
+    if apply_requested:
+        return _emit_uninstall_preflight_error(
+            target_root,
+            apply=apply_requested,
+            specs_mode=specs_mode,
+            json_requested=json_requested,
+            message=(
+                "uninstall --apply is not implemented in S01; "
+                "full apply behavior is deferred to S03"
+            ),
+        )
+
+    actions = _build_uninstall_plan_skeleton(target_root, specs_mode=specs_mode)
+    payload = _uninstall_payload(
+        target_root,
+        apply=apply_requested,
+        specs_mode=specs_mode,
+        actions=actions,
+    )
+    if json_requested:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(_render_uninstall_text(payload))
+    return 0
+
+
 def _iter_install_root_files(assets_dir: Path) -> tuple[Path, ...]:
     install_root = assets_dir / "install_root"
     if not install_root.is_dir():
@@ -1317,6 +1559,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     p_update = sub.add_parser("update", help="Update managed files (docs/templates/scripts/skill) in an existing project")
     add_init_update_common(p_update)
 
+    p_uninstall = sub.add_parser("uninstall", help="Plan or remove managed spec-dock artifacts from a project")
+    p_uninstall.add_argument("path", nargs="?", default=".", help="Target project path (default: current directory)")
+    p_uninstall.add_argument("--apply", action="store_true", help="Apply the uninstall plan")
+    specs_group = p_uninstall.add_mutually_exclusive_group()
+    specs_group.add_argument("--keep-specs", action="store_true", help="Preserve spec history under spec-dock/initiatives")
+    specs_group.add_argument("--remove-specs", action="store_true", help="Include spec history in the uninstall plan")
+    p_uninstall.add_argument("--json", action="store_true", help="Emit exactly one JSON object on stdout")
+
     return parser.parse_args(argv)
 
 
@@ -1325,6 +1575,9 @@ def main(argv: list[str] | None = None) -> int:
     ns = _parse_args(sys.argv[1:] if argv is None else argv)
 
     target_root = Path(getattr(ns, "path", ".")).expanduser().resolve()
+    if ns.command == "uninstall":
+        return _run_uninstall(target_root, ns)
+
     if not target_root.exists() or not target_root.is_dir():
         print(f"error: target path is not a directory: {target_root}", file=sys.stderr)
         return 2

--- a/src/spec_dock/cli.py
+++ b/src/spec_dock/cli.py
@@ -60,6 +60,8 @@ _MANAGED_OBSOLETE_EXACT_PATH_PREFIXES = (
     ".github/agents/",
     ".github/workflows/",
 )
+_UNINSTALL_CLEANUP_BOUNDARY_ROOTS = (Path(".agents"), Path(".codex"), Path(".github"), Path("spec-dock"))
+_UNINSTALL_RETRY_MARKER_REL = Path("spec-dock/.uninstall-retry.json")
 _REQUIRED_MANAGED_NATIVE_SHIM_HOSTS = ("codex", "copilot")
 _HOST_ADAPTER_META_ASSET_REL = Path("install_root") / ".agents" / "host-adapters" / "meta.json"
 _REQUIRED_MANAGED_NATIVE_SHIM_OWNER = "spec-dock"
@@ -814,12 +816,59 @@ def _require_managed_specdock_for_uninstall(target_root: Path) -> Path:
         raise RuntimeError(f"target is not a managed SpecDock repo: {e}") from e
 
     version_file = specdock_dir / "spec-dock.version"
-    if not version_file.is_file():
+    if not version_file.is_file() and not _has_valid_uninstall_retry_marker(specdock_dir):
         raise RuntimeError(
             "target is not a managed SpecDock repo: missing managed "
-            "'spec-dock/spec-dock.version' state"
+            "'spec-dock/spec-dock.version' state or SpecDock uninstall retry marker"
         )
     return specdock_dir
+
+
+def _uninstall_retry_marker_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "managed_by": "spec-dock",
+        "purpose": "uninstall-rerun",
+    }
+
+
+def _has_valid_uninstall_retry_marker(specdock_dir: Path) -> bool:
+    marker = specdock_dir / _UNINSTALL_RETRY_MARKER_REL.relative_to("spec-dock")
+    if marker.is_symlink():
+        raise RuntimeError(
+            "target contains symlinked SpecDock uninstall retry marker: "
+            f"{_UNINSTALL_RETRY_MARKER_REL.as_posix()}"
+        )
+    if not marker.is_file():
+        return False
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return payload == _uninstall_retry_marker_payload()
+
+
+def _reject_symlinked_uninstall_retry_marker(target_root: Path) -> None:
+    marker = target_root / _UNINSTALL_RETRY_MARKER_REL
+    if marker.is_symlink():
+        raise RuntimeError(
+            "target contains symlinked SpecDock uninstall retry marker: "
+            f"{_UNINSTALL_RETRY_MARKER_REL.as_posix()}"
+        )
+
+
+def _write_uninstall_retry_marker(target_root: Path) -> None:
+    marker = target_root / _UNINSTALL_RETRY_MARKER_REL
+    _reject_symlinked_uninstall_retry_marker(target_root)
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(json.dumps(_uninstall_retry_marker_payload(), sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _symlinked_uninstall_boundary_root(target_root: Path) -> Path | None:
+    for boundary_root in _UNINSTALL_CLEANUP_BOUNDARY_ROOTS:
+        if (target_root / boundary_root).is_symlink():
+            return boundary_root
+    return None
 
 
 def _path_exists_for_uninstall(path: Path) -> bool:
@@ -847,9 +896,19 @@ def _add_exact_match_uninstall_action(
     *,
     category: str,
     expected: bytes,
+    include_missing_removals: bool = False,
 ) -> None:
     target_path = target_root / rel_path
     if not _path_exists_for_uninstall(target_path):
+        if include_missing_removals:
+            actions.append(
+                _UninstallAction(
+                    rel_path=rel_path.as_posix(),
+                    category=category,
+                    status="would_remove",
+                    reason="current shipped asset exact match",
+                )
+            )
         return
 
     is_match, preserve_reason = _compare_uninstall_bytes(target_path, expected)
@@ -906,6 +965,8 @@ def _is_delete_even_if_mismatch_uninstall_path(rel_path: Path) -> bool:
 def _iter_existing_files_or_symlinks(root: Path) -> tuple[Path, ...]:
     if not root.exists():
         return ()
+    if root.is_symlink():
+        return (root,)
     return tuple(sorted((path for path in root.rglob("*") if path.is_file() or path.is_symlink()), key=lambda p: p.as_posix()))
 
 
@@ -933,9 +994,10 @@ def _add_spec_history_uninstall_action(
     target_root: Path,
     *,
     specs_mode: str | None,
+    include_missing_removals: bool = False,
 ) -> None:
     spec_history_path = Path("spec-dock/initiatives")
-    if not (target_root / spec_history_path).exists():
+    if not (target_root / spec_history_path).exists() and not (specs_mode == "remove" and include_missing_removals):
         return
     if specs_mode == "remove":
         actions.append(
@@ -956,6 +1018,20 @@ def _add_spec_history_uninstall_action(
                 reason=reason,
             )
         )
+
+
+def _add_uninstall_retry_marker_action(actions: list[_UninstallAction], target_root: Path, known_rel_paths: set[Path]) -> None:
+    known_rel_paths.add(_UNINSTALL_RETRY_MARKER_REL)
+    if not _path_exists_for_uninstall(target_root / _UNINSTALL_RETRY_MARKER_REL):
+        return
+    actions.append(
+        _UninstallAction(
+            rel_path=_UNINSTALL_RETRY_MARKER_REL.as_posix(),
+            category="generated_state",
+            status="preserved",
+            reason="SpecDock uninstall retry marker for idempotent rerun",
+        )
+    )
 
 
 def _add_shortcut_uninstall_action(actions: list[_UninstallAction], target_root: Path) -> None:
@@ -987,8 +1063,7 @@ def _add_unknown_boundary_uninstall_actions(
     target_root: Path,
     known_rel_paths: set[Path],
 ) -> None:
-    boundary_roots = (Path(".agents"), Path(".codex"), Path(".github"), Path("spec-dock"))
-    for boundary_root in boundary_roots:
+    for boundary_root in _UNINSTALL_CLEANUP_BOUNDARY_ROOTS:
         for path in _iter_existing_files_or_symlinks(target_root / boundary_root):
             rel_path = path.relative_to(target_root)
             if rel_path in known_rel_paths:
@@ -1028,7 +1103,12 @@ def _build_scaffold_uninstall_sources(assets_dir: Path) -> tuple[tuple[Path, byt
     return tuple(sources)
 
 
-def _build_uninstall_plan(target_root: Path, *, specs_mode: str | None) -> tuple[_UninstallAction, ...]:
+def _build_uninstall_plan(
+    target_root: Path,
+    *,
+    specs_mode: str | None,
+    include_missing_removals: bool = False,
+) -> tuple[_UninstallAction, ...]:
     """Build the S02 dry-run inventory and classification plan."""
     actions: list[_UninstallAction] = []
     known_rel_paths: set[Path] = set()
@@ -1041,6 +1121,23 @@ def _build_uninstall_plan(target_root: Path, *, specs_mode: str | None) -> tuple
             known_rel_paths.add(rel_path)
             target_path = target_root / rel_path
             if not _path_exists_for_uninstall(target_path):
+                if include_missing_removals:
+                    category = _uninstall_category_for_install_root_path(
+                        rel_path,
+                        bootstrap_only_rel_paths=bootstrap_only_rel_paths,
+                    )
+                    actions.append(
+                        _UninstallAction(
+                            rel_path=rel_path.as_posix(),
+                            category=category,
+                            status="would_remove",
+                            reason=(
+                                "known SpecDock-managed agent/skill asset"
+                                if _is_delete_even_if_mismatch_uninstall_path(rel_path)
+                                else "current shipped asset exact match"
+                            ),
+                        )
+                    )
                 continue
             category = _uninstall_category_for_install_root_path(
                 rel_path,
@@ -1062,11 +1159,21 @@ def _build_uninstall_plan(target_root: Path, *, specs_mode: str | None) -> tuple
                 rel_path,
                 category=category,
                 expected=(assets_dir / mapping.source_asset_rel).read_bytes(),
+                include_missing_removals=include_missing_removals,
             )
 
         for rel_path in install_plan.obsolete_exact_rel_paths:
             known_rel_paths.add(rel_path)
             if not _path_exists_for_uninstall(target_root / rel_path):
+                if include_missing_removals:
+                    actions.append(
+                        _UninstallAction(
+                            rel_path=rel_path.as_posix(),
+                            category="obsolete_managed",
+                            status="would_remove",
+                            reason="known obsolete SpecDock-managed asset",
+                        )
+                    )
                 continue
             actions.append(
                 _UninstallAction(
@@ -1085,10 +1192,17 @@ def _build_uninstall_plan(target_root: Path, *, specs_mode: str | None) -> tuple
                 rel_path,
                 category="scaffold_managed",
                 expected=expected,
+                include_missing_removals=include_missing_removals,
             )
 
     _add_generated_state_uninstall_actions(actions, target_root, known_rel_paths)
-    _add_spec_history_uninstall_action(actions, target_root, specs_mode=specs_mode)
+    _add_spec_history_uninstall_action(
+        actions,
+        target_root,
+        specs_mode=specs_mode,
+        include_missing_removals=include_missing_removals,
+    )
+    _add_uninstall_retry_marker_action(actions, target_root, known_rel_paths)
     _add_shortcut_uninstall_action(actions, target_root)
     known_rel_paths.add(Path("spec"))
     _add_unknown_boundary_uninstall_actions(actions, target_root, known_rel_paths)
@@ -1110,6 +1224,99 @@ def _summarize_uninstall_actions(actions: tuple[_UninstallAction, ...]) -> dict[
             summary[action.status] = 0
         summary[action.status] += 1
     return summary
+
+
+def _is_safe_uninstall_rel_path(rel_path: Path) -> bool:
+    if rel_path.is_absolute() or ".." in rel_path.parts or rel_path.parts in {(), (".",)}:
+        return False
+    if rel_path.parts[0] == ".git":
+        return False
+    return rel_path.parts[0] in {root.parts[0] for root in _UNINSTALL_CLEANUP_BOUNDARY_ROOTS} or rel_path == Path("spec")
+
+
+def _has_symlink_uninstall_container(target_root: Path, rel_path: Path) -> bool:
+    current = target_root
+    last_index = len(rel_path.parts) - 1
+    for index, part in enumerate(rel_path.parts):
+        current = current / part
+        if current.is_symlink():
+            if index == last_index:
+                return False
+            return True
+    return False
+
+
+def _remove_uninstall_path(target_root: Path, action: _UninstallAction) -> _UninstallAction:
+    rel_path = Path(action.rel_path)
+    if not _is_safe_uninstall_rel_path(rel_path):
+        return action._replace(status="failed", error="unsafe uninstall path outside managed boundaries")
+    if _has_symlink_uninstall_container(target_root, rel_path):
+        return action._replace(status="failed", error="unsafe uninstall path through symlink container")
+
+    target_path = target_root / rel_path
+    if not _path_exists_for_uninstall(target_path):
+        return action._replace(status="already_removed", error=None)
+
+    try:
+        if target_path.is_dir() and not target_path.is_symlink():
+            shutil.rmtree(target_path)
+        else:
+            target_path.unlink()
+    except OSError as e:
+        return action._replace(status="failed", error=str(e))
+    return action._replace(status="removed", error=None)
+
+
+def _is_uninstall_cleanup_boundary_path(rel_path: Path) -> bool:
+    if rel_path.is_absolute() or ".." in rel_path.parts or rel_path.parts in {(), (".",)}:
+        return False
+    if rel_path.parts[0] == ".git":
+        return False
+    return rel_path.parts[0] in {root.parts[0] for root in _UNINSTALL_CLEANUP_BOUNDARY_ROOTS}
+
+
+def _cleanup_empty_uninstall_dirs(target_root: Path) -> tuple[_UninstallAction, ...]:
+    cleanup_actions: list[_UninstallAction] = []
+    candidates: set[Path] = set()
+    for boundary_root in _UNINSTALL_CLEANUP_BOUNDARY_ROOTS:
+        root = target_root / boundary_root
+        if not root.exists() or not root.is_dir() or root.is_symlink():
+            continue
+        candidates.add(boundary_root)
+        for path in root.rglob("*"):
+            if path.is_dir() and not path.is_symlink():
+                candidates.add(path.relative_to(target_root))
+
+    for rel_path in sorted(candidates, key=lambda path: len(path.parts), reverse=True):
+        if not _is_uninstall_cleanup_boundary_path(rel_path):
+            continue
+        target_path = target_root / rel_path
+        if not target_path.exists() or not target_path.is_dir() or target_path.is_symlink():
+            continue
+        try:
+            target_path.rmdir()
+        except OSError:
+            continue
+        cleanup_actions.append(
+            _UninstallAction(
+                rel_path=rel_path.as_posix(),
+                category="empty_dir",
+                status="empty_dir_removed",
+                reason="empty directory cleanup inside uninstall boundary",
+            )
+        )
+    return tuple(cleanup_actions)
+
+
+def _apply_uninstall_plan(target_root: Path, actions: tuple[_UninstallAction, ...]) -> tuple[_UninstallAction, ...]:
+    results: list[_UninstallAction] = []
+    for action in actions:
+        if action.status == "would_remove":
+            results.append(_remove_uninstall_path(target_root, action))
+        else:
+            results.append(action)
+    results.extend(_cleanup_empty_uninstall_dirs(target_root))
+    return tuple(sorted(results, key=lambda action: (action.rel_path, action.status)))
 
 
 def _uninstall_payload(
@@ -1140,8 +1347,12 @@ def _uninstall_payload(
             for action in actions
         ],
         "guidance": [
-            "dry-run only; pass --apply with exactly one of --keep-specs or --remove-specs to mutate",
-            "S02 provides dry-run inventory/classification only; full apply behavior follows in S03",
+            (
+                "dry-run only; pass --apply with exactly one of --keep-specs or --remove-specs to mutate"
+                if not apply
+                else "retry removal with installer CLI: spec-dock uninstall <target> --apply --keep-specs or --remove-specs"
+            ),
+            "reinstall or refresh with installer CLI: spec-dock init <target> or spec-dock update <target>",
         ],
         "errors": errors or [],
     }
@@ -1171,8 +1382,9 @@ def _emit_uninstall_preflight_error(
 
 
 def _render_uninstall_text(payload: dict[str, Any]) -> str:
+    noun = "result" if payload["apply"] else "plan"
     lines = [
-        f"spec-dock: uninstall plan ({payload['mode']}) -> {payload['target']}",
+        f"spec-dock: uninstall {noun} ({payload['mode']}) -> {payload['target']}",
         f"specs_mode: {payload['specs_mode'] or 'unspecified'}",
         "summary:",
     ]
@@ -1218,31 +1430,39 @@ def _run_uninstall(target_root: Path, ns: argparse.Namespace) -> int:
         )
 
     try:
+        if apply_requested:
+            symlink_boundary = _symlinked_uninstall_boundary_root(target_root)
+            if symlink_boundary is not None:
+                return _emit_uninstall_preflight_error(
+                    target_root,
+                    apply=apply_requested,
+                    specs_mode=specs_mode,
+                    json_requested=json_requested,
+                    message=(
+                        "target contains symlinked SpecDock uninstall boundary root: "
+                        f"{symlink_boundary.as_posix()}"
+                    ),
+                )
+            _reject_symlinked_uninstall_retry_marker(target_root)
         _require_managed_specdock_for_uninstall(target_root)
-    except RuntimeError as e:
+    except (OSError, RuntimeError) as e:
         return _emit_uninstall_preflight_error(
             target_root,
             apply=apply_requested,
             specs_mode=specs_mode,
             json_requested=json_requested,
             message=str(e),
-        )
-
-    if apply_requested:
-        return _emit_uninstall_preflight_error(
-            target_root,
-            apply=apply_requested,
-            specs_mode=specs_mode,
-            json_requested=json_requested,
-            message=(
-                "uninstall --apply is not implemented in S02; "
-                "full apply behavior is deferred to S03"
-            ),
         )
 
     try:
-        actions = _build_uninstall_plan(target_root, specs_mode=specs_mode)
-    except RuntimeError as e:
+        if apply_requested:
+            _write_uninstall_retry_marker(target_root)
+        actions = _build_uninstall_plan(
+            target_root,
+            specs_mode=specs_mode,
+            include_missing_removals=apply_requested,
+        )
+    except (OSError, RuntimeError) as e:
         return _emit_uninstall_preflight_error(
             target_root,
             apply=apply_requested,
@@ -1250,17 +1470,21 @@ def _run_uninstall(target_root: Path, ns: argparse.Namespace) -> int:
             json_requested=json_requested,
             message=str(e),
         )
+    if apply_requested:
+        actions = _apply_uninstall_plan(target_root, actions)
+    has_failures = any(action.status == "failed" for action in actions)
     payload = _uninstall_payload(
         target_root,
         apply=apply_requested,
         specs_mode=specs_mode,
         actions=actions,
+        status="partial_failure" if has_failures else None,
     )
     if json_requested:
         print(json.dumps(payload, sort_keys=True))
     else:
         print(_render_uninstall_text(payload))
-    return 0
+    return 1 if has_failures else 0
 
 
 def _iter_install_root_files(assets_dir: Path) -> tuple[Path, ...]:

--- a/src/spec_dock/cli.py
+++ b/src/spec_dock/cli.py
@@ -822,57 +822,278 @@ def _require_managed_specdock_for_uninstall(target_root: Path) -> Path:
     return specdock_dir
 
 
-def _build_uninstall_plan_skeleton(target_root: Path, *, specs_mode: str | None) -> tuple[_UninstallAction, ...]:
-    """Build the S01 dry-run skeleton without applying full inventory policy."""
-    actions: list[_UninstallAction] = []
+def _path_exists_for_uninstall(path: Path) -> bool:
+    return path.exists() or path.is_symlink()
 
-    representative_agent_path = Path(".agents/skills/spec-dock-issue-execution/SKILL.md")
-    if (target_root / representative_agent_path).exists():
+
+def _compare_uninstall_bytes(target_path: Path, expected: bytes) -> tuple[bool, str | None]:
+    if target_path.is_symlink():
+        return False, "comparison error: symlink requires manual review"
+    if not target_path.is_file():
+        return False, "comparison error: not a regular file; manual review required"
+    try:
+        actual = target_path.read_bytes()
+    except OSError as e:
+        return False, f"comparison error: {e}; manual review required"
+    if actual == expected:
+        return True, None
+    return False, "content mismatch; manual review required"
+
+
+def _add_exact_match_uninstall_action(
+    actions: list[_UninstallAction],
+    target_root: Path,
+    rel_path: Path,
+    *,
+    category: str,
+    expected: bytes,
+) -> None:
+    target_path = target_root / rel_path
+    if not _path_exists_for_uninstall(target_path):
+        return
+
+    is_match, preserve_reason = _compare_uninstall_bytes(target_path, expected)
+    if is_match:
         actions.append(
             _UninstallAction(
-                rel_path=representative_agent_path.as_posix(),
-                category="agent_skill",
+                rel_path=rel_path.as_posix(),
+                category=category,
                 status="would_remove",
-                reason="known SpecDock-managed agent/skill asset",
+                reason="current shipped asset exact match",
             )
         )
-
-    spec_history_path = Path("spec-dock/initiatives")
-    if (target_root / spec_history_path).exists():
-        if specs_mode == "remove":
-            actions.append(
-                _UninstallAction(
-                    rel_path=spec_history_path.as_posix(),
-                    category="spec_history",
-                    status="would_remove",
-                    reason="explicit remove-specs mode",
-                )
-            )
-        else:
-            reason = (
-                "keep-specs mode"
-                if specs_mode == "keep"
-                else "dry-run preserves specs unless remove-specs is explicit"
-            )
-            actions.append(
-                _UninstallAction(
-                    rel_path=spec_history_path.as_posix(),
-                    category="spec_history",
-                    status="preserved",
-                    reason=reason,
-                )
-            )
-
-    if not actions:
+    else:
         actions.append(
             _UninstallAction(
-                rel_path=".",
-                category="unmanaged",
+                rel_path=rel_path.as_posix(),
+                category=category,
                 status="preserved",
-                reason="no S01 uninstall skeleton candidates found",
+                reason=preserve_reason or "manual review required",
             )
         )
-    return tuple(actions)
+
+
+def _uninstall_category_for_install_root_path(
+    rel_path: Path,
+    *,
+    bootstrap_only_rel_paths: set[Path],
+) -> str:
+    if rel_path.parts[:2] == (".agents", "skills"):
+        return "agent_skill"
+    if rel_path.parts[:2] in {(".codex", "agents"), (".github", "agents")}:
+        return "native_agent"
+    if rel_path in bootstrap_only_rel_paths:
+        return "bootstrap_only"
+    if rel_path == Path(".agents/host-adapters/meta.json"):
+        return "bootstrap_only"
+    if rel_path.parts[:2] in {
+        (".codex", "prompts"),
+        (".codex", "rules"),
+        (".github", "workflows"),
+    } or rel_path == Path(".codex/AGENTS.md"):
+        return "product_reusable"
+    return "product_reusable"
+
+
+def _is_delete_even_if_mismatch_uninstall_path(rel_path: Path) -> bool:
+    return rel_path.parts[:2] in {
+        (".agents", "skills"),
+        (".codex", "agents"),
+        (".github", "agents"),
+    }
+
+
+def _iter_existing_files_or_symlinks(root: Path) -> tuple[Path, ...]:
+    if not root.exists():
+        return ()
+    return tuple(sorted((path for path in root.rglob("*") if path.is_file() or path.is_symlink()), key=lambda p: p.as_posix()))
+
+
+def _add_generated_state_uninstall_actions(
+    actions: list[_UninstallAction],
+    target_root: Path,
+    known_rel_paths: set[Path],
+) -> None:
+    for rel_root in (Path("spec-dock/active"), Path("spec-dock/.agent")):
+        for path in _iter_existing_files_or_symlinks(target_root / rel_root):
+            rel_path = path.relative_to(target_root)
+            known_rel_paths.add(rel_path)
+            actions.append(
+                _UninstallAction(
+                    rel_path=rel_path.as_posix(),
+                    category="generated_state",
+                    status="would_remove",
+                    reason="SpecDock generated state",
+                )
+            )
+
+
+def _add_spec_history_uninstall_action(
+    actions: list[_UninstallAction],
+    target_root: Path,
+    *,
+    specs_mode: str | None,
+) -> None:
+    spec_history_path = Path("spec-dock/initiatives")
+    if not (target_root / spec_history_path).exists():
+        return
+    if specs_mode == "remove":
+        actions.append(
+            _UninstallAction(
+                rel_path=spec_history_path.as_posix(),
+                category="spec_history",
+                status="would_remove",
+                reason="explicit remove-specs mode",
+            )
+        )
+    else:
+        reason = "keep-specs mode" if specs_mode == "keep" else "dry-run preserves specs unless remove-specs is explicit"
+        actions.append(
+            _UninstallAction(
+                rel_path=spec_history_path.as_posix(),
+                category="spec_history",
+                status="preserved",
+                reason=reason,
+            )
+        )
+
+
+def _add_shortcut_uninstall_action(actions: list[_UninstallAction], target_root: Path) -> None:
+    shortcut = target_root / "spec"
+    if not _path_exists_for_uninstall(shortcut):
+        return
+    if shortcut.is_symlink() and os.readlink(shortcut) == f"{_SPEC_DOCK_DIRNAME}/scripts/spec-dock":
+        actions.append(
+            _UninstallAction(
+                rel_path="spec",
+                category="shortcut",
+                status="would_remove",
+                reason="repo-root shortcut targets spec-dock/scripts/spec-dock",
+            )
+        )
+    else:
+        actions.append(
+            _UninstallAction(
+                rel_path="spec",
+                category="shortcut",
+                status="preserved",
+                reason="not spec-dock shortcut; manual review required",
+            )
+        )
+
+
+def _add_unknown_boundary_uninstall_actions(
+    actions: list[_UninstallAction],
+    target_root: Path,
+    known_rel_paths: set[Path],
+) -> None:
+    boundary_roots = (Path(".agents"), Path(".codex"), Path(".github"), Path("spec-dock"))
+    for boundary_root in boundary_roots:
+        for path in _iter_existing_files_or_symlinks(target_root / boundary_root):
+            rel_path = path.relative_to(target_root)
+            if rel_path in known_rel_paths:
+                continue
+            if rel_path.parts[:2] == ("spec-dock", "initiatives"):
+                continue
+            if rel_path.parts[:2] in {("spec-dock", "active"), ("spec-dock", ".agent")}:
+                continue
+            actions.append(
+                _UninstallAction(
+                    rel_path=rel_path.as_posix(),
+                    category="unmanaged",
+                    status="preserved",
+                    reason="unmanaged file under managed boundary root",
+                )
+            )
+
+
+def _build_scaffold_uninstall_sources(assets_dir: Path) -> tuple[tuple[Path, bytes], ...]:
+    src_spec_dock = assets_dir / "spec_dock"
+    sources: list[tuple[Path, bytes]] = []
+    for managed_dir in _MANAGED_DIRS:
+        src_root = src_spec_dock / managed_dir
+        if not src_root.is_dir():
+            raise RuntimeError(f"Missing asset directory: {src_root}")
+        for source_path in sorted((path for path in src_root.rglob("*") if path.is_file()), key=lambda p: p.as_posix()):
+            rel_path = Path("spec-dock") / source_path.relative_to(src_spec_dock)
+            sources.append((rel_path, source_path.read_bytes()))
+
+    src_gitignore = src_spec_dock / ".gitignore"
+    if src_gitignore.exists():
+        gitignore_bytes = src_gitignore.read_bytes()
+    else:
+        gitignore_bytes = _DEFAULT_SPEC_DOCK_GITIGNORE.encode("utf-8")
+    sources.append((Path("spec-dock/.gitignore"), gitignore_bytes))
+    sources.append((Path("spec-dock/spec-dock.version"), f"{_tool_version()}\n".encode("utf-8")))
+    return tuple(sources)
+
+
+def _build_uninstall_plan(target_root: Path, *, specs_mode: str | None) -> tuple[_UninstallAction, ...]:
+    """Build the S02 dry-run inventory and classification plan."""
+    actions: list[_UninstallAction] = []
+    known_rel_paths: set[Path] = set()
+
+    with _assets_dir() as assets_dir:
+        install_plan = _build_managed_skill_install_plan(assets_dir)
+        bootstrap_only_rel_paths = set(install_plan.bootstrap_only_rel_paths)
+        for mapping in install_plan.current_file_mappings:
+            rel_path = mapping.target_rel
+            known_rel_paths.add(rel_path)
+            target_path = target_root / rel_path
+            if not _path_exists_for_uninstall(target_path):
+                continue
+            category = _uninstall_category_for_install_root_path(
+                rel_path,
+                bootstrap_only_rel_paths=bootstrap_only_rel_paths,
+            )
+            if _is_delete_even_if_mismatch_uninstall_path(rel_path):
+                actions.append(
+                    _UninstallAction(
+                        rel_path=rel_path.as_posix(),
+                        category=category,
+                        status="would_remove",
+                        reason="known SpecDock-managed agent/skill asset",
+                    )
+                )
+                continue
+            _add_exact_match_uninstall_action(
+                actions,
+                target_root,
+                rel_path,
+                category=category,
+                expected=(assets_dir / mapping.source_asset_rel).read_bytes(),
+            )
+
+        for rel_path in install_plan.obsolete_exact_rel_paths:
+            known_rel_paths.add(rel_path)
+            if not _path_exists_for_uninstall(target_root / rel_path):
+                continue
+            actions.append(
+                _UninstallAction(
+                    rel_path=rel_path.as_posix(),
+                    category="obsolete_managed",
+                    status="would_remove",
+                    reason="known obsolete SpecDock-managed asset",
+                )
+            )
+
+        for rel_path, expected in _build_scaffold_uninstall_sources(assets_dir):
+            known_rel_paths.add(rel_path)
+            _add_exact_match_uninstall_action(
+                actions,
+                target_root,
+                rel_path,
+                category="scaffold_managed",
+                expected=expected,
+            )
+
+    _add_generated_state_uninstall_actions(actions, target_root, known_rel_paths)
+    _add_spec_history_uninstall_action(actions, target_root, specs_mode=specs_mode)
+    _add_shortcut_uninstall_action(actions, target_root)
+    known_rel_paths.add(Path("spec"))
+    _add_unknown_boundary_uninstall_actions(actions, target_root, known_rel_paths)
+
+    return tuple(sorted(actions, key=lambda action: action.rel_path))
 
 
 def _summarize_uninstall_actions(actions: tuple[_UninstallAction, ...]) -> dict[str, int]:
@@ -920,7 +1141,7 @@ def _uninstall_payload(
         ],
         "guidance": [
             "dry-run only; pass --apply with exactly one of --keep-specs or --remove-specs to mutate",
-            "S01 provides command surface and plan rendering only; full inventory/apply behavior follows in later steps",
+            "S02 provides dry-run inventory/classification only; full apply behavior follows in S03",
         ],
         "errors": errors or [],
     }
@@ -1014,12 +1235,21 @@ def _run_uninstall(target_root: Path, ns: argparse.Namespace) -> int:
             specs_mode=specs_mode,
             json_requested=json_requested,
             message=(
-                "uninstall --apply is not implemented in S01; "
+                "uninstall --apply is not implemented in S02; "
                 "full apply behavior is deferred to S03"
             ),
         )
 
-    actions = _build_uninstall_plan_skeleton(target_root, specs_mode=specs_mode)
+    try:
+        actions = _build_uninstall_plan(target_root, specs_mode=specs_mode)
+    except RuntimeError as e:
+        return _emit_uninstall_preflight_error(
+            target_root,
+            apply=apply_requested,
+            specs_mode=specs_mode,
+            json_requested=json_requested,
+            message=str(e),
+        )
     payload = _uninstall_payload(
         target_root,
         apply=apply_requested,

--- a/src/spec_dock/cli.py
+++ b/src/spec_dock/cli.py
@@ -130,11 +130,19 @@ def _copy_file(src: Path, dest: Path) -> None:
     shutil.copy2(src, dest)
 
 
+def _is_generated_python_cache_path(path: Path) -> bool:
+    return "__pycache__" in path.parts or path.name.endswith(".pyc")
+
+
+def _ignore_generated_python_caches(_dir: str, names: list[str]) -> set[str]:
+    return {name for name in names if name == "__pycache__" or name.endswith(".pyc")}
+
+
 def _sync_tree(src: Path, dest: Path) -> None:
     """Replace `dest` directory with a full copy of `src`."""
     if dest.exists():
         shutil.rmtree(dest)
-    shutil.copytree(src, dest)
+    shutil.copytree(src, dest, ignore=_ignore_generated_python_caches)
 
 
 def _make_executable(path: Path) -> None:
@@ -722,7 +730,10 @@ def _install_spec_dock(target_root: Path, *, force: bool) -> None:
         # The actual spec tree (`spec-dock/initiatives/**`) must be persistent and is
         # never removed by this installer.
         for src, dest in managed_scaffold_sync_plan:
-            _sync_tree(src, dest) if (dest.exists() or force) else shutil.copytree(src, dest)
+            if dest.exists() or force:
+                _sync_tree(src, dest)
+            else:
+                shutil.copytree(src, dest, ignore=_ignore_generated_python_caches)
 
         src_gitignore = src_spec_dock / ".gitignore"
         if src_gitignore.exists():
@@ -959,7 +970,7 @@ def _is_delete_even_if_mismatch_uninstall_path(rel_path: Path) -> bool:
         (".agents", "skills"),
         (".codex", "agents"),
         (".github", "agents"),
-    }
+    } or rel_path == Path("spec-dock/spec-dock.version")
 
 
 def _iter_existing_files_or_symlinks(root: Path) -> tuple[Path, ...]:
@@ -1089,7 +1100,14 @@ def _build_scaffold_uninstall_sources(assets_dir: Path) -> tuple[tuple[Path, byt
         src_root = src_spec_dock / managed_dir
         if not src_root.is_dir():
             raise RuntimeError(f"Missing asset directory: {src_root}")
-        for source_path in sorted((path for path in src_root.rglob("*") if path.is_file()), key=lambda p: p.as_posix()):
+        for source_path in sorted(
+            (
+                path
+                for path in src_root.rglob("*")
+                if path.is_file() and not _is_generated_python_cache_path(path.relative_to(src_spec_dock))
+            ),
+            key=lambda p: p.as_posix(),
+        ):
             rel_path = Path("spec-dock") / source_path.relative_to(src_spec_dock)
             sources.append((rel_path, source_path.read_bytes()))
 
@@ -1186,6 +1204,17 @@ def _build_uninstall_plan(
 
         for rel_path, expected in _build_scaffold_uninstall_sources(assets_dir):
             known_rel_paths.add(rel_path)
+            if _is_delete_even_if_mismatch_uninstall_path(rel_path):
+                if _path_exists_for_uninstall(target_root / rel_path) or include_missing_removals:
+                    actions.append(
+                        _UninstallAction(
+                            rel_path=rel_path.as_posix(),
+                            category="scaffold_managed",
+                            status="would_remove",
+                            reason="SpecDock managed state",
+                        )
+                    )
+                continue
             _add_exact_match_uninstall_action(
                 actions,
                 target_root,
@@ -1493,7 +1522,11 @@ def _iter_install_root_files(assets_dir: Path) -> tuple[Path, ...]:
         raise RuntimeError(f"Missing asset directory: {install_root}")
     return tuple(
         sorted(
-            (candidate for candidate in install_root.rglob("*") if candidate.is_file()),
+            (
+                candidate
+                for candidate in install_root.rglob("*")
+                if candidate.is_file() and not _is_generated_python_cache_path(candidate.relative_to(install_root))
+            ),
             key=lambda candidate: candidate.relative_to(install_root).as_posix(),
         )
     )

--- a/tests/cli_runtime/test_uninstall.py
+++ b/tests/cli_runtime/test_uninstall.py
@@ -1,0 +1,177 @@
+import shlex
+import tempfile
+from pathlib import Path
+
+from tests.cli_runtime.harness import CliRuntimeHarness, main
+
+
+class UninstallCommandTests(CliRuntimeHarness):
+    def test_uninstall_help_describes_upstream_no_cache_and_default_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            p = self._run_runtime_capture(target, ["uninstall", "--help"])
+
+            self.assertEqual(p.returncode, 0, msg=f"stdout:\n{p.stdout}\nstderr:\n{p.stderr}")
+            self.assertIn("uninstall", p.stdout)
+            self.assertIn("uvx --no-cache", p.stdout)
+            self.assertIn("git+https://github.com/chemitaro/spec-dock", p.stdout)
+            self.assertIn("current working directory", p.stdout)
+
+    def test_uninstall_runs_uvx_no_cache_with_default_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            bin_dir = target / ".test-bin"
+            args_log = target / "uvx-args.txt"
+            self._make_uvx_stub(bin_dir, args_log=args_log)
+
+            p = self._run_runtime_capture(target, ["uninstall"], env={"PATH": str(bin_dir)})
+
+            self.assertEqual(p.returncode, 0, msg=f"stdout:\n{p.stdout}\nstderr:\n{p.stderr}")
+            self.assertEqual(
+                args_log.read_text(encoding="utf-8").splitlines(),
+                [
+                    "--no-cache",
+                    "--from",
+                    "git+https://github.com/chemitaro/spec-dock",
+                    "spec-dock",
+                    "uninstall",
+                    str(target.resolve()),
+                ],
+            )
+
+    def test_uninstall_passes_explicit_target_to_installer_uninstall(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            managed = root / "managed"
+            explicit_target = root / "target-project"
+            managed.mkdir()
+            explicit_target.mkdir()
+            self.assertEqual(main(["init", str(managed)]), 0)
+            bin_dir = root / ".test-bin"
+            args_log = root / "uvx-args.txt"
+            self._make_uvx_stub(bin_dir, args_log=args_log)
+
+            p = self._run_runtime_capture(managed, ["uninstall", "../target-project"], env={"PATH": str(bin_dir)})
+
+            self.assertEqual(p.returncode, 0, msg=f"stdout:\n{p.stdout}\nstderr:\n{p.stderr}")
+            self.assertEqual(args_log.read_text(encoding="utf-8").splitlines()[-1], str(explicit_target.resolve()))
+
+    def test_uninstall_forwards_apply_keep_specs_and_propagates_failure_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            bin_dir = target / ".test-bin"
+            args_log = target / "uvx-args.txt"
+            self._make_uvx_stub(bin_dir, args_log=args_log, stdout="stub stdout", stderr="stub stderr", exit_code=7)
+
+            p = self._run_runtime_capture(
+                target,
+                ["uninstall", "--apply", "--keep-specs"],
+                env={"PATH": str(bin_dir)},
+            )
+
+            self.assertEqual(p.returncode, 7)
+            self.assertIn("stub stdout", p.stdout)
+            self.assertIn("stub stderr", p.stderr)
+            self.assertEqual(
+                args_log.read_text(encoding="utf-8").splitlines()[-3:],
+                [str(target.resolve()), "--apply", "--keep-specs"],
+            )
+
+    def test_uninstall_forwards_remove_specs_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            bin_dir = target / ".test-bin"
+            args_log = target / "uvx-args.txt"
+            self._make_uvx_stub(bin_dir, args_log=args_log)
+
+            p = self._run_runtime_capture(target, ["uninstall", "--remove-specs"], env={"PATH": str(bin_dir)})
+
+            self.assertEqual(p.returncode, 0, msg=f"stdout:\n{p.stdout}\nstderr:\n{p.stderr}")
+            self.assertEqual(
+                args_log.read_text(encoding="utf-8").splitlines()[-2:],
+                [str(target.resolve()), "--remove-specs"],
+            )
+
+    def test_uninstall_forwards_json_and_preserves_json_stdout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            bin_dir = target / ".test-bin"
+            args_log = target / "uvx-args.txt"
+            json_stdout = '{"schema_version":1,"status":"completed"}'
+            self._make_uvx_stub(bin_dir, args_log=args_log, stdout=json_stdout)
+
+            p = self._run_runtime_capture(
+                target,
+                ["uninstall", "--json", "--apply", "--keep-specs"],
+                env={"PATH": str(bin_dir)},
+            )
+
+            self.assertEqual(p.returncode, 0, msg=f"stdout:\n{p.stdout}\nstderr:\n{p.stderr}")
+            self.assertEqual(p.stdout, json_stdout + "\n")
+            self.assertEqual(
+                args_log.read_text(encoding="utf-8").splitlines()[-4:],
+                [str(target.resolve()), "--apply", "--keep-specs", "--json"],
+            )
+
+    def test_uninstall_missing_uvx_fails_with_actionable_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            empty_bin = target / ".empty-bin"
+            empty_bin.mkdir()
+
+            p = self._run_runtime_capture(target, ["uninstall"], env={"PATH": str(empty_bin)})
+
+            self.assertEqual(p.returncode, 127)
+            self.assertIn("uvx could not be executed", p.stderr)
+            self.assertIn("PATH", p.stderr)
+
+    def test_uninstall_rejects_source_and_cache_overrides_without_invoking_uvx(self) -> None:
+        cases = (
+            (["uninstall", "--from", "git+https://example.invalid/spec-dock"], "--from"),
+            (["uninstall", "--cache-dir", ".uv-cache"], "--cache-dir"),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            bin_dir = target / ".test-bin"
+            args_log = target / "uvx-args.txt"
+            self._make_uvx_stub(bin_dir, args_log=args_log)
+
+            for args, rejected_option in cases:
+                with self.subTest(args=args):
+                    args_log.unlink(missing_ok=True)
+
+                    p = self._run_runtime_capture(target, args, env={"PATH": str(bin_dir)})
+
+                    self.assertNotEqual(p.returncode, 0)
+                    self.assertIn(f"unrecognized arguments: {rejected_option}", p.stderr)
+                    self.assertFalse(args_log.exists(), "uvx must not be invoked for rejected options")
+
+    def _make_uvx_stub(
+        self,
+        bin_dir: Path,
+        *,
+        args_log: Path | None = None,
+        stdout: str | None = None,
+        stderr: str | None = None,
+        exit_code: int = 0,
+    ) -> None:
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        lines = ["#!/bin/sh"]
+        if args_log is not None:
+            lines.append(f"printf '%s\\n' \"$@\" > {shlex.quote(str(args_log))}")
+        if stdout is not None:
+            lines.append(f"printf '%s\\n' {shlex.quote(stdout)}")
+        if stderr is not None:
+            lines.append(f"printf '%s\\n' {shlex.quote(stderr)} >&2")
+        lines.append(f"exit {exit_code}")
+        uvx_path = bin_dir / "uvx"
+        uvx_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        uvx_path.chmod(0o755)

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -286,6 +286,14 @@ class TestInitUpdate(CliRuntimeHarness):
                 else:
                     snapshot[rel] = path.read_text(encoding="utf-8")
         return snapshot
+
+    def _uninstall_json_actions(self, target: Path, *args: str) -> dict[str, dict[str, object]]:
+        exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json", *args])
+        self.assertEqual(exit_code, 0, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(payload["status"], "planned")
+        return {action["path"]: action for action in payload["actions"]}
     _DOGFOODING_MIRROR_PROVIDER_ASSET_MAP = {
         "spec-dock/.gitignore": "src/spec_dock/assets/spec_dock/.gitignore",
         "spec-dock/templates/README.md": "src/spec_dock/assets/spec_dock/templates/README.md",
@@ -13383,6 +13391,182 @@ exit 44
             self.assertEqual(payload["status"], "error")
             self.assertIn("spec-dock/spec-dock.version", payload["errors"][0])
             self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_removes_known_agent_skill_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            managed_skill = target / ".agents" / "skills" / "spec-dock-issue-execution" / "SKILL.md"
+            managed_skill.write_text("user edited managed skill\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            action = actions[".agents/skills/spec-dock-issue-execution/SKILL.md"]
+            self.assertEqual(action["category"], "agent_skill")
+            self.assertEqual(action["status"], "would_remove")
+            self.assertIn("agent/skill", action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_preserves_unknown_files_under_managed_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            unknown_paths = [
+                target / ".agents" / "skills" / "custom-product-agent" / "SKILL.md",
+                target / ".codex" / "notes" / "product.md",
+                target / ".github" / "ISSUE_TEMPLATE" / "bug.md",
+                target / "spec-dock" / "custom" / "notes.md",
+            ]
+            for path in unknown_paths:
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("user content\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            for path in unknown_paths:
+                rel = path.relative_to(target).as_posix()
+                with self.subTest(rel=rel):
+                    action = actions[rel]
+                    self.assertEqual(action["category"], "unmanaged")
+                    self.assertEqual(action["status"], "preserved")
+                    self.assertIn("unmanaged", action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_removes_exact_match_bootstrap_and_product_reusable_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            expected = {
+                ".codex/config.toml": "bootstrap_only",
+                ".codex/prompts/execute-issue.md": "product_reusable",
+                ".github/workflows/ci.yml": "product_reusable",
+            }
+            for rel, category in expected.items():
+                with self.subTest(rel=rel):
+                    action = actions[rel]
+                    self.assertEqual(action["category"], category)
+                    self.assertEqual(action["status"], "would_remove")
+                    self.assertIn("exact match", action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_preserves_mismatch_bootstrap_and_product_reusable_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            edited = [
+                target / ".codex" / "config.toml",
+                target / ".github" / "workflows" / "ci.yml",
+            ]
+            for path in edited:
+                path.write_text("product-owned edit\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            for path in edited:
+                rel = path.relative_to(target).as_posix()
+                with self.subTest(rel=rel):
+                    action = actions[rel]
+                    self.assertEqual(action["status"], "preserved")
+                    self.assertIn("content mismatch", action["reason"])
+                    self.assertIn("manual review", action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_preserves_non_core_comparison_errors_for_manual_review(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            config = target / ".codex" / "config.toml"
+            config.unlink()
+            config.mkdir()
+            workflow = target / ".github" / "workflows" / "ci.yml"
+            workflow.unlink()
+            symlink_created = False
+            try:
+                os.symlink("../product-ci.yml", workflow)
+                symlink_created = True
+            except OSError:
+                workflow.mkdir()
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            for rel in (".codex/config.toml", ".github/workflows/ci.yml"):
+                with self.subTest(rel=rel):
+                    action = actions[rel]
+                    self.assertEqual(action["status"], "preserved")
+                    self.assertIn("comparison error", action["reason"])
+                    self.assertIn("manual review", action["reason"])
+            if symlink_created:
+                self.assertEqual(os.readlink(workflow), "../product-ci.yml")
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_scaffold_managed_exact_match_removes_and_mismatch_preserves(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            edited_doc = target / "spec-dock" / "docs" / "guide.md"
+            edited_doc.write_text("product docs edit\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            exact_action = actions["spec-dock/scripts/spec-dock"]
+            self.assertEqual(exact_action["category"], "scaffold_managed")
+            self.assertEqual(exact_action["status"], "would_remove")
+            self.assertIn("exact match", exact_action["reason"])
+            edited_action = actions["spec-dock/docs/guide.md"]
+            self.assertEqual(edited_action["category"], "scaffold_managed")
+            self.assertEqual(edited_action["status"], "preserved")
+            self.assertIn("content mismatch", edited_action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_spec_shortcut_only_removes_matching_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cases = (
+                ("matching", "symlink", "spec-dock/scripts/spec-dock", "would_remove"),
+                ("nonmatching", "symlink", "scripts/spec", "preserved"),
+                ("file", "file", None, "preserved"),
+                ("directory", "directory", None, "preserved"),
+            )
+            for name, kind, link_target, expected_status in cases:
+                with self.subTest(name=name):
+                    target = Path(tmp) / name
+                    target.mkdir()
+                    self.assertEqual(main(["init", str(target)]), 0)
+                    shortcut = target / "spec"
+                    if shortcut.is_symlink() or shortcut.is_file():
+                        shortcut.unlink()
+                    elif shortcut.is_dir():
+                        shutil.rmtree(shortcut)
+
+                    if kind == "symlink":
+                        try:
+                            os.symlink(link_target, shortcut)
+                        except OSError:
+                            self.skipTest("symlink creation is unavailable")
+                    elif kind == "file":
+                        shortcut.write_text("product shortcut\n", encoding="utf-8")
+                    else:
+                        shortcut.mkdir()
+                    before = self._relative_file_snapshot(target)
+
+                    actions = self._uninstall_json_actions(target)
+
+                    action = actions["spec"]
+                    self.assertEqual(action["category"], "shortcut")
+                    self.assertEqual(action["status"], expected_status)
+                    if expected_status == "would_remove":
+                        self.assertIn("spec-dock/scripts/spec-dock", action["reason"])
+                    else:
+                        self.assertIn("not spec-dock shortcut", action["reason"])
+                    self.assertEqual(self._relative_file_snapshot(target), before)
 
     def _clear_active_entrypoints(self, target: Path) -> Path:
         active_dir = target / "spec-dock" / "active"

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -287,6 +287,48 @@ class TestInitUpdate(CliRuntimeHarness):
                     snapshot[rel] = path.read_text(encoding="utf-8")
         return snapshot
 
+    @contextmanager
+    def _temporary_provider_cache_files(self):
+        import spec_dock.cli as cli
+
+        with cli._assets_dir() as assets_dir:
+            cache_files = (
+                assets_dir
+                / "spec_dock"
+                / "scripts"
+                / "spec_dock_runtime"
+                / "commands"
+                / "__pycache__"
+                / "generated.cpython-310.pyc",
+                assets_dir
+                / "install_root"
+                / ".agents"
+                / "skills"
+                / "spec-dock-issue-execution"
+                / "__pycache__"
+                / "generated.cpython-310.pyc",
+            )
+            for cache_file in cache_files:
+                cache_file.parent.mkdir(parents=True, exist_ok=True)
+                cache_file.write_bytes(b"\x00\x00\x00\x00pyc-cache-fixture")
+            try:
+                yield
+            finally:
+                for cache_file in cache_files:
+                    cache_file.unlink(missing_ok=True)
+                    try:
+                        cache_file.parent.rmdir()
+                    except OSError:
+                        pass
+
+    def _assert_no_generated_python_caches(self, root: Path) -> None:
+        copied = sorted(
+            path.relative_to(root).as_posix()
+            for path in root.rglob("*")
+            if "__pycache__" in path.parts or path.name.endswith(".pyc")
+        )
+        self.assertEqual(copied, [])
+
     def _uninstall_json_actions(self, target: Path, *args: str) -> dict[str, dict[str, object]]:
         exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json", *args])
         self.assertEqual(exit_code, 0, stderr)
@@ -1059,6 +1101,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00056-delete-local-spec-nodes-with-safeguards-and-epic-final-closeout/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00096-self-update-command/.meta.json",
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json",
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json",
@@ -1136,6 +1179,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00056-delete-local-spec-nodes-with-safeguards-and-epic-final-closeout/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00088-issue-lifecycle-start-and-finish-commands/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00096-self-update-command/.meta.json": [],
+        "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00054-github-lifecycle-command-expansion/issues/iss-00147-spec-dock-uninstall-command/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00074-multi-host-agent-and-config-asset-expansion/issues/iss-00075-multi-host-agent-and-config-asset-install/.meta.json": [],
         "spec-dock/initiatives/init-local-00002-prototype-feature-expansion/epics/epic-00107-worktree-provisioning/.meta.json": [],
@@ -13152,6 +13196,14 @@ exit 44
             # Second init without --force should fail.
             self.assertNotEqual(main(["init", str(target)]), 0)
 
+    def test_init_does_not_copy_generated_python_caches_from_provider_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, self._temporary_provider_cache_files():
+            target = Path(tmp)
+
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            self._assert_no_generated_python_caches(target)
+
     def test_update_keeps_initiatives_by_default(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)
@@ -13181,6 +13233,16 @@ exit 44
             self.assertFalse(legacy_workflow.exists())
             if created_symlink:
                 self.assertFalse(legacy_symlink.is_symlink())
+
+    def test_update_does_not_copy_generated_python_caches_from_provider_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            with self._temporary_provider_cache_files():
+                self.assertEqual(main(["update", str(target)]), 0)
+
+            self._assert_no_generated_python_caches(target)
 
     def test_uninstall_dry_run_prints_plan_and_mutates_no_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -13424,6 +13486,38 @@ exit 44
             self.assertIn("injected unlink failure", failed_action["error"])
             self.assertTrue(failing.is_file())
 
+    def test_uninstall_apply_partial_rmtree_failure_reports_failed_spec_history_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("remove\n", encoding="utf-8")
+            failing = (target / "spec-dock" / "initiatives").resolve()
+            original_rmtree = shutil.rmtree
+
+            def fail_one(path: Path, *args: object, **kwargs: object) -> object:
+                if Path(path).resolve() == failing:
+                    raise OSError("injected rmtree failure")
+                return original_rmtree(path, *args, **kwargs)
+
+            with patch("src.spec_dock.cli.shutil.rmtree", fail_one):
+                payload = self._uninstall_json_payload(
+                    target,
+                    "--apply",
+                    "--remove-specs",
+                    expected_exit_code=1,
+                )
+
+            actions = self._actions_by_path(payload)
+            failed_action = actions["spec-dock/initiatives"]
+            self.assertEqual(payload["status"], "partial_failure")
+            self.assertGreater(payload["summary"]["failed"], 0)  # type: ignore[index]
+            self.assertGreater(payload["summary"]["removed"], 0)  # type: ignore[index]
+            self.assertEqual(failed_action["category"], "spec_history")
+            self.assertEqual(failed_action["status"], "failed")
+            self.assertIn("injected rmtree failure", failed_action["error"])
+            self.assertTrue(marker.is_file())
+
     def test_uninstall_apply_output_provides_installer_direct_recovery_guidance(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)
@@ -13458,6 +13552,8 @@ exit 44
             self.assertIn("preserved", success_statuses)
             self.assertIn("empty_dir_removed", success_statuses)
             self.assertIn("already_removed", {action["status"] for action in rerun_payload["actions"]})  # type: ignore[index]
+            self.assertTrue(preserved.is_file())
+            self.assertEqual(preserved.read_text(encoding="utf-8"), "product-owned config\n")
             for payload in (success_payload, rerun_payload):
                 for action in payload["actions"]:  # type: ignore[index]
                     for key in ("path", "category", "status", "reason", "error"):
@@ -13792,6 +13888,22 @@ exit 44
             self.assertEqual(edited_action["category"], "scaffold_managed")
             self.assertEqual(edited_action["status"], "preserved")
             self.assertIn("content mismatch", edited_action["reason"])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_removes_stale_specdock_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            version_file = target / "spec-dock" / "spec-dock.version"
+            version_file.write_text("0.0.0\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            actions = self._uninstall_json_actions(target)
+
+            action = actions["spec-dock/spec-dock.version"]
+            self.assertEqual(action["category"], "scaffold_managed")
+            self.assertEqual(action["status"], "would_remove")
+            self.assertIn("managed state", action["reason"])
             self.assertEqual(self._relative_file_snapshot(target), before)
 
     def test_uninstall_dry_run_spec_shortcut_only_removes_matching_symlink(self) -> None:

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -294,6 +294,22 @@ class TestInitUpdate(CliRuntimeHarness):
         payload = json.loads(stdout)
         self.assertEqual(payload["status"], "planned")
         return {action["path"]: action for action in payload["actions"]}
+
+    def _uninstall_json_payload(
+        self,
+        target: Path,
+        *args: str,
+        expected_exit_code: int = 0,
+    ) -> dict[str, object]:
+        exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json", *args])
+        self.assertEqual(exit_code, expected_exit_code, stderr)
+        self.assertEqual(stderr, "")
+        payload = json.loads(stdout)
+        self.assertEqual(stdout.count("\n"), 1)
+        return payload
+
+    def _actions_by_path(self, payload: dict[str, object]) -> dict[str, dict[str, object]]:
+        return {str(action["path"]): action for action in payload["actions"]}  # type: ignore[index]
     _DOGFOODING_MIRROR_PROVIDER_ASSET_MAP = {
         "spec-dock/.gitignore": "src/spec_dock/assets/spec_dock/.gitignore",
         "spec-dock/templates/README.md": "src/spec_dock/assets/spec_dock/templates/README.md",
@@ -13199,26 +13215,278 @@ exit 44
             self.assertIn("--remove-specs", stderr)
             self.assertEqual(self._relative_file_snapshot(target), before)
 
-    def test_uninstall_apply_with_specs_mode_is_deferred_before_mutation(self) -> None:
+    def test_uninstall_apply_keep_specs_removes_tooling_and_preserves_spec_history(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)
             self.assertEqual(main(["init", str(target)]), 0)
             marker = target / "spec-dock" / "initiatives" / "marker.txt"
             marker.write_text("keep\n", encoding="utf-8")
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--apply", "--keep-specs"])
+
+            self.assertEqual(exit_code, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertIn("spec-dock: uninstall result", stdout)
+            self.assertIn("removed", stdout)
+            self.assertIn("preserved", stdout)
+            self.assertFalse((target / ".agents" / "skills" / "spec-dock-issue-execution" / "SKILL.md").exists())
+            self.assertFalse((target / "spec-dock" / "scripts" / "spec-dock").exists())
+            self.assertTrue(marker.is_file())
+            self.assertEqual(marker.read_text(encoding="utf-8"), "keep\n")
+
+    def test_uninstall_apply_remove_specs_removes_spec_history_with_explicit_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("remove\n", encoding="utf-8")
+
+            payload = self._uninstall_json_payload(target, "--apply", "--remove-specs")
+            actions = self._actions_by_path(payload)
+
+            self.assertEqual(payload["status"], "completed")
+            self.assertEqual(payload["specs_mode"], "remove")
+            spec_action = actions["spec-dock/initiatives"]
+            self.assertEqual(spec_action["category"], "spec_history")
+            self.assertEqual(spec_action["status"], "removed")
+            self.assertIn("remove-specs", spec_action["reason"])
+            self.assertFalse(marker.exists())
+            self.assertFalse((target / "spec-dock" / "initiatives").exists())
+
+    def test_uninstall_apply_rejects_symlinked_boundary_root_without_external_deletion(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "repo"
+            target.mkdir()
+            self.assertEqual(main(["init", str(target)]), 0)
+            outside_specdock = Path(tmp) / "outside" / "spec-dock"
+            outside_specdock.parent.mkdir()
+            shutil.move(str(target / "spec-dock"), outside_specdock)
+            try:
+                os.symlink("../outside/spec-dock", target / "spec-dock")
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+            outside_script = outside_specdock / "scripts" / "spec-dock"
+            self.assertTrue(outside_script.is_file())
+
+            payload = self._uninstall_json_payload(
+                target,
+                "--apply",
+                "--keep-specs",
+                expected_exit_code=2,
+            )
+
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("symlink", payload["errors"][0])
+            self.assertTrue((target / "spec-dock").is_symlink())
+            self.assertTrue(outside_script.is_file())
+            self.assertTrue(outside_specdock.is_dir())
+
+    def test_uninstall_apply_rejects_symlinked_retry_marker_without_external_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "repo"
+            target.mkdir()
+            self.assertEqual(main(["init", str(target)]), 0)
+            outside_file = Path(tmp) / "outside-marker.json"
+            outside_file.write_text("outside\n", encoding="utf-8")
+            retry_marker = target / "spec-dock" / ".uninstall-retry.json"
+            try:
+                os.symlink(outside_file, retry_marker)
+            except OSError:
+                self.skipTest("symlink creation is unavailable")
+
+            payload = self._uninstall_json_payload(
+                target,
+                "--apply",
+                "--keep-specs",
+                expected_exit_code=2,
+            )
+
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("symlinked SpecDock uninstall retry marker", payload["errors"][0])
+            self.assertTrue(retry_marker.is_symlink())
+            self.assertEqual(outside_file.read_text(encoding="utf-8"), "outside\n")
+
+    def test_uninstall_apply_rejects_unmanaged_initiatives_only_target_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            user_file = target / "spec-dock" / "initiatives" / "user-created" / "notes.md"
+            user_file.parent.mkdir(parents=True)
+            user_file.write_text("user specs\n", encoding="utf-8")
             before = self._relative_file_snapshot(target)
 
-            for specs_flag in ("--keep-specs", "--remove-specs"):
-                with self.subTest(specs_flag=specs_flag):
-                    exit_code, stdout, stderr = self._capture_installer_main(
-                        ["uninstall", str(target), "--apply", specs_flag]
-                    )
+            payload = self._uninstall_json_payload(
+                target,
+                "--apply",
+                "--remove-specs",
+                expected_exit_code=2,
+            )
 
-                    self.assertEqual(exit_code, 2)
-                    self.assertEqual(stdout, "")
-                    self.assertIn("not implemented", stderr)
-                    self.assertIn("S03", stderr)
-                    self.assertNotIn("completed", stdout)
-                    self.assertEqual(self._relative_file_snapshot(target), before)
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("not a managed SpecDock repo", payload["errors"][0])
+            self.assertEqual(self._relative_file_snapshot(target), before)
+            self.assertTrue(user_file.is_file())
+
+    def test_uninstall_apply_bounded_cleanup_respects_preserved_files_and_roots(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "repo"
+            target.mkdir()
+            self.assertEqual(main(["init", str(target)]), 0)
+            (target / ".git").mkdir()
+            (target / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+            parent_sentinel = target.parent / "parent-sentinel.txt"
+            parent_sentinel.write_text("parent\n", encoding="utf-8")
+            preserved = target / ".codex" / "notes" / "product.md"
+            preserved.parent.mkdir(parents=True, exist_ok=True)
+            preserved.write_text("preserve\n", encoding="utf-8")
+
+            payload = self._uninstall_json_payload(target, "--apply", "--keep-specs")
+
+            self.assertEqual(payload["status"], "completed")
+            cleanup_actions = [
+                action
+                for action in payload["actions"]  # type: ignore[index]
+                if action["status"] == "empty_dir_removed"
+            ]
+            self.assertTrue(cleanup_actions)
+            for action in cleanup_actions:
+                self.assertRegex(action["path"], r"^(\.agents|\.codex|\.github|spec-dock)(/|$)")
+                self.assertNotEqual(action["path"], ".git")
+            self.assertTrue(target.is_dir())
+            self.assertTrue((target / ".git" / "HEAD").is_file())
+            self.assertTrue(parent_sentinel.is_file())
+            self.assertTrue(preserved.is_file())
+            self.assertTrue(preserved.parent.is_dir())
+
+    def test_uninstall_apply_rerun_reports_already_removed_and_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+
+            first_payload = self._uninstall_json_payload(target, "--apply", "--keep-specs")
+            second_payload = self._uninstall_json_payload(target, "--apply", "--keep-specs")
+
+            self.assertEqual(first_payload["status"], "completed")
+            self.assertEqual(second_payload["status"], "completed")
+            self.assertGreater(second_payload["summary"]["already_removed"], 0)  # type: ignore[index]
+            self.assertEqual(second_payload["summary"]["failed"], 0)  # type: ignore[index]
+            self.assertIn(
+                "already_removed",
+                {action["status"] for action in second_payload["actions"]},  # type: ignore[index]
+            )
+
+    def test_uninstall_apply_remove_specs_rerun_reports_already_removed_and_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("remove\n", encoding="utf-8")
+
+            first_payload = self._uninstall_json_payload(target, "--apply", "--remove-specs")
+            second_payload = self._uninstall_json_payload(target, "--apply", "--remove-specs")
+
+            self.assertEqual(first_payload["status"], "completed")
+            self.assertEqual(second_payload["status"], "completed")
+            self.assertGreater(second_payload["summary"]["already_removed"], 0)  # type: ignore[index]
+            self.assertEqual(second_payload["summary"]["failed"], 0)  # type: ignore[index]
+            self.assertIn(
+                "already_removed",
+                {action["status"] for action in second_payload["actions"]},  # type: ignore[index]
+            )
+
+    def test_uninstall_apply_partial_unlink_failure_reports_failed_separately(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            failing = (target / ".agents" / "skills" / "spec-dock-issue-execution" / "SKILL.md").resolve()
+            original_unlink = Path.unlink
+
+            def fail_one(path: Path, *args: object, **kwargs: object) -> object:
+                if path.resolve() == failing:
+                    raise OSError("injected unlink failure")
+                return original_unlink(path, *args, **kwargs)
+
+            with patch("src.spec_dock.cli.Path.unlink", fail_one):
+                payload = self._uninstall_json_payload(
+                    target,
+                    "--apply",
+                    "--keep-specs",
+                    expected_exit_code=1,
+                )
+
+            actions = self._actions_by_path(payload)
+            failed_action = actions[".agents/skills/spec-dock-issue-execution/SKILL.md"]
+            self.assertEqual(payload["status"], "partial_failure")
+            self.assertGreater(payload["summary"]["failed"], 0)  # type: ignore[index]
+            self.assertGreater(payload["summary"]["removed"], 0)  # type: ignore[index]
+            self.assertEqual(failed_action["status"], "failed")
+            self.assertIn("injected unlink failure", failed_action["error"])
+            self.assertTrue(failing.is_file())
+
+    def test_uninstall_apply_output_provides_installer_direct_recovery_guidance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--apply", "--keep-specs"])
+
+            self.assertEqual(exit_code, 0, stderr)
+            self.assertEqual(stderr, "")
+            self.assertFalse((target / "spec-dock" / "scripts" / "spec-dock").exists())
+            self.assertIn("spec-dock uninstall", stdout)
+            self.assertIn("spec-dock init", stdout)
+            self.assertIn("spec-dock update", stdout)
+            self.assertNotIn("./spec-dock/scripts/spec-dock uninstall", stdout)
+
+    def test_uninstall_apply_json_covers_success_rerun_and_partial_failure_statuses(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            success_target = Path(tmp) / "success"
+            success_target.mkdir()
+            self.assertEqual(main(["init", str(success_target)]), 0)
+            marker = success_target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+            preserved = success_target / ".codex" / "config.toml"
+            preserved.write_text("product-owned config\n", encoding="utf-8")
+
+            success_payload = self._uninstall_json_payload(success_target, "--apply", "--keep-specs")
+            rerun_payload = self._uninstall_json_payload(success_target, "--apply", "--keep-specs")
+
+            self.assertEqual(success_payload["status"], "completed")
+            success_statuses = {action["status"] for action in success_payload["actions"]}  # type: ignore[index]
+            self.assertIn("removed", success_statuses)
+            self.assertIn("preserved", success_statuses)
+            self.assertIn("empty_dir_removed", success_statuses)
+            self.assertIn("already_removed", {action["status"] for action in rerun_payload["actions"]})  # type: ignore[index]
+            for payload in (success_payload, rerun_payload):
+                for action in payload["actions"]:  # type: ignore[index]
+                    for key in ("path", "category", "status", "reason", "error"):
+                        self.assertIn(key, action)
+
+            failure_target = Path(tmp) / "failure"
+            failure_target.mkdir()
+            self.assertEqual(main(["init", str(failure_target)]), 0)
+            failing = (failure_target / ".agents" / "skills" / "spec-dock-issue-execution" / "SKILL.md").resolve()
+            original_unlink = Path.unlink
+
+            def fail_one(path: Path, *args: object, **kwargs: object) -> object:
+                if path.resolve() == failing:
+                    raise OSError("injected unlink failure")
+                return original_unlink(path, *args, **kwargs)
+
+            with patch("src.spec_dock.cli.Path.unlink", fail_one):
+                failure_payload = self._uninstall_json_payload(
+                    failure_target,
+                    "--apply",
+                    "--keep-specs",
+                    expected_exit_code=1,
+                )
+
+            failure_statuses = {action["status"] for action in failure_payload["actions"]}  # type: ignore[index]
+            self.assertEqual(failure_payload["status"], "partial_failure")
+            self.assertIn("failed", failure_statuses)
+            self.assertIn("removed", failure_statuses)
+            self.assertGreater(failure_payload["summary"]["failed"], 0)  # type: ignore[index]
 
     def test_uninstall_keep_and_remove_specs_are_mutually_exclusive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -13289,7 +13557,6 @@ exit 44
 
             cases = (
                 (["uninstall", str(target), "--json", "--apply"], "--keep-specs"),
-                (["uninstall", str(target), "--json", "--apply", "--keep-specs"], "S03"),
             )
             for args, expected_error_text in cases:
                 with self.subTest(args=args):

--- a/tests/test_init_update.py
+++ b/tests/test_init_update.py
@@ -10,7 +10,7 @@ import sys
 import tarfile
 import tempfile
 import zipfile
-from contextlib import contextmanager, redirect_stderr
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -265,6 +265,27 @@ class TestInitUpdate(CliRuntimeHarness):
             "src/spec_dock/assets/spec_dock/docs/rules/issue/discussions.md"
         ),
     }
+
+    def _capture_installer_main(self, args: list[str]) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                exit_code = main(args)
+            except SystemExit as exc:
+                exit_code = int(exc.code or 0)
+        return exit_code, stdout.getvalue(), stderr.getvalue()
+
+    def _relative_file_snapshot(self, root: Path) -> dict[str, str]:
+        snapshot: dict[str, str] = {}
+        for path in sorted(root.rglob("*")):
+            if path.is_file() or path.is_symlink():
+                rel = path.relative_to(root).as_posix()
+                if path.is_symlink():
+                    snapshot[rel] = f"symlink:{os.readlink(path)}"
+                else:
+                    snapshot[rel] = path.read_text(encoding="utf-8")
+        return snapshot
     _DOGFOODING_MIRROR_PROVIDER_ASSET_MAP = {
         "spec-dock/.gitignore": "src/spec_dock/assets/spec_dock/.gitignore",
         "spec-dock/templates/README.md": "src/spec_dock/assets/spec_dock/templates/README.md",
@@ -13136,6 +13157,232 @@ exit 44
             self.assertFalse(legacy_workflow.exists())
             if created_symlink:
                 self.assertFalse(legacy_symlink.is_symlink())
+
+    def test_uninstall_dry_run_prints_plan_and_mutates_no_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target)])
+
+            self.assertEqual(exit_code, 0, stderr)
+            self.assertIn("spec-dock: uninstall plan", stdout)
+            self.assertIn("would_remove", stdout)
+            self.assertIn("preserved", stdout)
+            self.assertEqual(stderr, "")
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_apply_without_specs_mode_fails_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--apply"])
+
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(stdout, "")
+            self.assertIn("--keep-specs", stderr)
+            self.assertIn("--remove-specs", stderr)
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_apply_with_specs_mode_is_deferred_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            for specs_flag in ("--keep-specs", "--remove-specs"):
+                with self.subTest(specs_flag=specs_flag):
+                    exit_code, stdout, stderr = self._capture_installer_main(
+                        ["uninstall", str(target), "--apply", specs_flag]
+                    )
+
+                    self.assertEqual(exit_code, 2)
+                    self.assertEqual(stdout, "")
+                    self.assertIn("not implemented", stderr)
+                    self.assertIn("S03", stderr)
+                    self.assertNotIn("completed", stdout)
+                    self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_keep_and_remove_specs_are_mutually_exclusive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            before = self._relative_file_snapshot(target)
+
+            exit_code, _stdout, stderr = self._capture_installer_main(
+                ["uninstall", str(target), "--apply", "--keep-specs", "--remove-specs"]
+            )
+
+            self.assertEqual(exit_code, 2)
+            self.assertIn("not allowed with argument", stderr)
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_unmanaged_target_fails_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "notes.txt").write_text("user content\n", encoding="utf-8")
+            before = self._relative_file_snapshot(target)
+
+            for args in (
+                ["uninstall", str(target)],
+                ["uninstall", str(target), "--apply", "--keep-specs"],
+            ):
+                with self.subTest(args=args):
+                    exit_code, stdout, stderr = self._capture_installer_main(args)
+                    self.assertEqual(exit_code, 2)
+                    self.assertEqual(stdout, "")
+                    self.assertIn("not a managed SpecDock repo", stderr)
+                    self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_dry_run_json_is_one_parseable_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            marker = target / "spec-dock" / "initiatives" / "marker.txt"
+            marker.write_text("keep\n", encoding="utf-8")
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json"])
+
+            self.assertEqual(exit_code, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(stdout.count("\n"), 1)
+            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["target"], str(target.resolve()))
+            self.assertEqual(payload["mode"], "dry-run")
+            self.assertFalse(payload["apply"])
+            self.assertEqual(payload["status"], "planned")
+            for key in ("summary", "actions", "guidance", "errors"):
+                self.assertIn(key, payload)
+
+            actions_by_status = {action["status"]: action for action in payload["actions"]}
+            self.assertIn("would_remove", actions_by_status)
+            self.assertIn("preserved", actions_by_status)
+            for action in (actions_by_status["would_remove"], actions_by_status["preserved"]):
+                self.assertIn("path", action)
+                self.assertIn("category", action)
+                self.assertIn("reason", action)
+                self.assertIn("error", action)
+
+    def test_uninstall_json_preflight_errors_are_parseable_objects(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            before = self._relative_file_snapshot(target)
+
+            cases = (
+                (["uninstall", str(target), "--json", "--apply"], "--keep-specs"),
+                (["uninstall", str(target), "--json", "--apply", "--keep-specs"], "S03"),
+            )
+            for args, expected_error_text in cases:
+                with self.subTest(args=args):
+                    exit_code, stdout, stderr = self._capture_installer_main(args)
+
+                    self.assertEqual(exit_code, 2)
+                    self.assertEqual(stderr, "")
+                    payload = json.loads(stdout)
+                    self.assertEqual(stdout.count("\n"), 1)
+                    self.assertEqual(payload["schema_version"], 1)
+                    self.assertEqual(payload["target"], str(target.resolve()))
+                    self.assertEqual(payload["mode"], "apply")
+                    self.assertTrue(payload["apply"])
+                    self.assertEqual(payload["status"], "error")
+                    self.assertIn(expected_error_text, payload["errors"][0])
+                    self.assertEqual(payload["actions"], [])
+                    self.assertEqual(self._relative_file_snapshot(target), before)
+
+            unmanaged = target / "unmanaged"
+            unmanaged.mkdir()
+            (unmanaged / "notes.txt").write_text("user content\n", encoding="utf-8")
+            unmanaged_before = self._relative_file_snapshot(unmanaged)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(unmanaged), "--json"])
+
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(stdout.count("\n"), 1)
+            self.assertEqual(payload["mode"], "dry-run")
+            self.assertFalse(payload["apply"])
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("not a managed SpecDock repo", payload["errors"][0])
+            self.assertEqual(payload["actions"], [])
+            self.assertEqual(self._relative_file_snapshot(unmanaged), unmanaged_before)
+
+    def test_uninstall_json_missing_target_path_returns_json_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "missing"
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json"])
+
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(stdout.count("\n"), 1)
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("target path is not a directory", payload["errors"][0])
+            self.assertIn(str(target.resolve()), payload["errors"][0])
+            self.assertEqual(payload["actions"], [])
+
+    def test_uninstall_json_file_target_returns_json_error_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp) / "target.txt"
+            target.write_text("user content\n", encoding="utf-8")
+            before = target.read_text(encoding="utf-8")
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json"])
+
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(stdout.count("\n"), 1)
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("target path is not a directory", payload["errors"][0])
+            self.assertIn(str(target.resolve()), payload["errors"][0])
+            self.assertEqual(payload["actions"], [])
+            self.assertTrue(target.is_file())
+            self.assertEqual(target.read_text(encoding="utf-8"), before)
+
+    def test_uninstall_accepts_recovery_target_when_scripts_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            self.assertEqual(main(["init", str(target)]), 0)
+            shutil.rmtree(target / "spec-dock" / "scripts")
+            before = self._relative_file_snapshot(target)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json"])
+
+            self.assertEqual(exit_code, 0, stderr)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["status"], "planned")
+            self.assertEqual(payload["target"], str(target.resolve()))
+            self.assertEqual(self._relative_file_snapshot(target), before)
+
+    def test_uninstall_rejects_target_missing_version_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            (target / "spec-dock").mkdir()
+            (target / "spec-dock" / "scripts").mkdir()
+            before = self._relative_file_snapshot(target)
+
+            exit_code, stdout, stderr = self._capture_installer_main(["uninstall", str(target), "--json"])
+
+            self.assertEqual(exit_code, 2)
+            self.assertEqual(stderr, "")
+            payload = json.loads(stdout)
+            self.assertEqual(payload["status"], "error")
+            self.assertIn("spec-dock/spec-dock.version", payload["errors"][0])
+            self.assertEqual(self._relative_file_snapshot(target), before)
 
     def _clear_active_entrypoints(self, target: Path) -> Path:
         active_dir = target / "spec-dock" / "active"


### PR DESCRIPTION
## 概要
- `spec-dock uninstall` を追加し、dry-run 既定、`--apply` 明示、`--keep-specs` / `--remove-specs` 必須、JSON 出力に対応しました。
- agent / skill / scaffold / product-reusable asset の削除・保持ポリシーと repo-local wrapper を実装しました。
- provider docs、dogfooding mirror、issue report、回帰テストを更新しました。

## 検証
- `python -m unittest tests.test_init_update.TestInitUpdate -v -k uninstall` -> 30 tests OK
- `python -m unittest tests.test_init_update -v` -> 210 tests OK
- `python -m unittest discover -v` -> 1026 tests OK
- `./spec-dock/scripts/spec-dock validate` -> ok, nodes=74
- `./spec-dock/scripts/spec-dock sync --no-github` -> ok
- `git diff --check` -> pass

Refs #147