### PR TITLE
GitHub token capability preflightを追加

### DIFF
--- a/.agents/skills/github-pr-observation/SKILL.md
+++ b/.agents/skills/github-pr-observation/SKILL.md
@@ -44,6 +44,25 @@ Triage and judgment over collected evidence belong to
   machine-readable `limitations`.
 - `summary.md` is never generated.
 
+## Permission Limitations
+
+- The final JSON written to `stdout` is the authority for permission limitation
+  semantics; `stderr` progress is non-authoritative.
+- GitHub token permission failures are reported with
+  `limitations[].code="github_token_permission_denied"` and
+  `recommended_next_action="fix_github_token_permissions"`.
+- Read permission failures for checks, statuses, or status rollup keep process
+  exit success when final JSON can be built, but return semantic non-success:
+  `normalized_status="unknown"` and `overall_status="unknown"`.
+- The fixed `@codex review` trigger comment write failure is separate from read
+  collection failures. It returns `normalized_status="human_gate"`,
+  `overall_status="human_gate"`, and a
+  `limitations[].capability="trigger_comment_write"` permission limitation.
+- These scripts remain a fixed PR observation surface, not an arbitrary GitHub
+  permission scanner. Do not add caller-provided endpoints, methods, GraphQL,
+  headers, request bodies, `jq`, or raw `gh` arguments.
+- Token values, `hosts.yml` secrets, and private payloads must never be emitted.
+
 ## Entry Points
 
 ```bash

--- a/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -308,7 +308,11 @@ def has_permission_limitation():
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def classify_github_stderr(stderr):

--- a/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -307,6 +307,107 @@ def has_permission_limitation():
     )
 
 
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def classify_github_stderr(stderr):
+    lowered = (stderr or "").lower()
+    if (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    ):
+        return "permission_denied"
+    if (
+        "requires authentication" in lowered
+        or "authentication required" in lowered
+        or "not logged into" in lowered
+        or "http 401" in lowered
+    ):
+        return "auth_missing"
+    if "rate limit" in lowered or "http 429" in lowered:
+        return "rate_limited"
+    if "unknown json field" in lowered:
+        return "schema_unavailable"
+    if (
+        "http 5" in lowered
+        or "timeout" in lowered
+        or "timed out" in lowered
+        or "temporarily unavailable" in lowered
+        or "connection reset" in lowered
+    ):
+        return "transient_unknown"
+    return "unknown"
+
+
+def pr_metadata_failure_limitation(*, exit_code, stderr, default_code, default_message):
+    classification = classify_github_stderr(stderr)
+    stderr_sha256 = hashlib.sha256((stderr or "").encode()).hexdigest()
+    base = {
+        "capability": "pull_request_read",
+        "api": "gh pr view --json headRefOid,url,state,isDraft,number",
+        "source": "gh_pr_view",
+        "token_source": token_source(),
+        "secret_redacted": True,
+        "stderr_sha256": stderr_sha256,
+        "exit_code": exit_code,
+    }
+    if classification == "permission_denied":
+        return {
+            **base,
+            "code": "github_token_permission_denied",
+            "status": "permission_denied",
+            "severity": "blocking",
+            "message": "GitHub token lacks permission for fixed PR metadata API",
+            "recommended_next_action": "fix_github_token_permissions",
+        }
+    if classification == "auth_missing":
+        return {
+            **base,
+            "code": "github_auth_missing",
+            "status": "auth_missing",
+            "severity": "blocking",
+            "message": "GitHub authentication is unavailable for fixed PR metadata API",
+            "recommended_next_action": "authenticate_github_cli",
+        }
+    if classification == "rate_limited":
+        return {
+            **base,
+            "code": "github_rate_limited",
+            "status": "rate_limited",
+            "severity": "blocking",
+            "message": "GitHub rate limit blocked fixed PR metadata API",
+            "recommended_next_action": "wait_or_retry_later",
+        }
+    if classification == "schema_unavailable":
+        return {
+            **base,
+            "code": "github_api_schema_unavailable",
+            "status": "schema_unavailable",
+            "severity": "blocking",
+            "message": "fixed read-only PR metadata schema is unavailable",
+            "recommended_next_action": "inspect_github_api_schema",
+        }
+    if classification == "transient_unknown":
+        return {
+            **base,
+            "code": "github_transient_unknown",
+            "status": "transient_unknown",
+            "severity": "blocking",
+            "message": "transient GitHub failure blocked fixed PR metadata API",
+            "recommended_next_action": "retry_observation",
+        }
+    return {
+        "code": default_code,
+        "source": "gh_pr_view",
+        "severity": "blocking",
+        "message": default_message,
+        "exit_code": exit_code,
+        "stderr_sha256": stderr_sha256,
+    }
+
+
 def classify_snapshot():
     ci_status = ci_payload.get("status") or summary.get("ci") or "unknown"
     review_status = review_payload.get("status") or summary.get("review") or "unknown"
@@ -360,14 +461,12 @@ if gh_exit != 0:
         except OSError:
             stderr_text = ""
     limitations.append(
-        {
-            "code": "pr_metadata_collection_failed",
-            "source": "gh_pr_view",
-            "severity": "blocking",
-            "message": "fixed read-only PR metadata collection failed",
-            "exit_code": gh_exit,
-            "stderr_sha256": hashlib.sha256(stderr_text.encode()).hexdigest(),
-        }
+        pr_metadata_failure_limitation(
+            exit_code=gh_exit,
+            stderr=stderr_text,
+            default_code="pr_metadata_collection_failed",
+            default_message="fixed read-only PR metadata collection failed",
+        )
     )
 elif not metadata or not current_head_sha:
     limitations.append(
@@ -404,14 +503,12 @@ else:
             except OSError:
                 stderr_text = ""
         limitations.append(
-            {
-                "code": "pr_head_revalidation_failed",
-                "source": "gh_pr_view",
-                "severity": "blocking",
-                "message": "fixed read-only PR head revalidation failed after snapshot collection",
-                "exit_code": final_gh_exit,
-                "stderr_sha256": hashlib.sha256(stderr_text.encode()).hexdigest(),
-            }
+            pr_metadata_failure_limitation(
+                exit_code=final_gh_exit,
+                stderr=stderr_text,
+                default_code="pr_head_revalidation_failed",
+                default_message="fixed read-only PR head revalidation failed after snapshot collection",
+            )
         )
     elif not final_current_head_sha:
         limitations.append(

--- a/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -299,6 +299,14 @@ def has_blocking_limitation(ignored_codes=None):
     )
 
 
+def has_permission_limitation():
+    return any(
+        item.get("code") == "github_token_permission_denied"
+        for item in limitations
+        if isinstance(item, dict)
+    )
+
+
 def classify_snapshot():
     ci_status = ci_payload.get("status") or summary.get("ci") or "unknown"
     review_status = review_payload.get("status") or summary.get("review") or "unknown"
@@ -323,8 +331,12 @@ def classify_snapshot():
         return "failed", "fix_ci", False
     if ci_status in {"pending", "running", "none"}:
         if has_blocking_limitation(ignored_codes={"required_checks_missing_or_pending"}):
+            if has_permission_limitation():
+                return "unknown", "fix_github_token_permissions", False
             return "unknown", "human_gate", False
         return ci_status, "wait", False
+    if has_permission_limitation():
+        return "unknown", "fix_github_token_permissions", False
     if has_blocking_limitation():
         return "unknown", "human_gate", False
     if ci_status != "passed":

--- a/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
+++ b/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
@@ -74,12 +74,20 @@ expected_head_sha_lower = expected_head_sha.lower()
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def classify_github_stderr(stderr):
     lowered = (stderr or "").lower()
-    if "resource not accessible by personal access token" in lowered or "permission denied" in lowered:
+    if (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    ):
         return "permission_denied"
     if (
         "requires authentication" in lowered

--- a/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
+++ b/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
@@ -73,6 +73,136 @@ expected_head_sha = os.environ["OBS_HEAD_SHA"]
 expected_head_sha_lower = expected_head_sha.lower()
 
 
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def classify_github_stderr(stderr):
+    lowered = (stderr or "").lower()
+    if "resource not accessible by personal access token" in lowered or "permission denied" in lowered:
+        return "permission_denied"
+    if (
+        "requires authentication" in lowered
+        or "authentication required" in lowered
+        or "not logged into" in lowered
+        or "http 401" in lowered
+    ):
+        return "auth_missing"
+    if "rate limit" in lowered or "http 429" in lowered:
+        return "rate_limited"
+    if "unknown json field" in lowered:
+        return "schema_unavailable"
+    if (
+        "http 5" in lowered
+        or "timeout" in lowered
+        or "timed out" in lowered
+        or "temporarily unavailable" in lowered
+        or "connection reset" in lowered
+    ):
+        return "transient_unknown"
+    return "unknown"
+
+
+def capability_for_api(api):
+    if api == "gh_pr_view.statusCheckRollup":
+        return "status_check_rollup_read"
+    if api.endswith("/check-runs"):
+        return "check_runs_read"
+    if api.endswith("/status"):
+        return "commit_statuses_read"
+    if "/actions/runs/" in api and api.endswith("/jobs"):
+        return "actions_read"
+    return "unknown"
+
+
+def github_failure_limitation(*, api, source, exit_code, stderr, default_code, default_message, default_severity):
+    classification = classify_github_stderr(stderr)
+    stderr_sha256 = hashlib.sha256((stderr or "").encode()).hexdigest()
+    if classification == "permission_denied":
+        return {
+            "code": "github_token_permission_denied",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "permission_denied",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub token lacks permission for fixed PR observation API",
+            "recommended_next_action": "fix_github_token_permissions",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "auth_missing":
+        return {
+            "code": "github_auth_missing",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "auth_missing",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub authentication is unavailable for fixed PR observation API",
+            "recommended_next_action": "authenticate_github_cli",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "rate_limited":
+        return {
+            "code": "github_rate_limited",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "rate_limited",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub rate limit blocked fixed PR observation API",
+            "recommended_next_action": "wait_or_retry_later",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "schema_unavailable":
+        return {
+            "code": "github_api_schema_unavailable",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "schema_unavailable",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "fixed read-only GitHub API schema is unavailable",
+            "recommended_next_action": "inspect_github_api_schema",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "transient_unknown":
+        return {
+            "code": "github_transient_unknown",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "transient_unknown",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "transient GitHub failure blocked fixed PR observation API",
+            "recommended_next_action": "retry_observation",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    return {
+        "code": default_code,
+        "source": source,
+        "severity": default_severity,
+        "message": default_message,
+        "exit_code": exit_code,
+        "stderr_sha256": stderr_sha256,
+    }
+
+
 def sha_prefix_matches(left, right):
     left_lower = str(left or "").lower()
     right_lower = str(right or "").lower()
@@ -85,14 +215,15 @@ def gh_api(path):
     command = ["gh", "api", path, "--paginate"]
     completed = subprocess.run(command, capture_output=True, text=True, check=False)
     if completed.returncode != 0:
-        return None, {
-            "code": "github_api_collection_failed",
-            "source": path,
-            "severity": "blocking",
-            "message": "fixed read-only GitHub API collection failed",
-            "exit_code": completed.returncode,
-            "stderr_sha256": hashlib.sha256(completed.stderr.encode()).hexdigest(),
-        }
+        return None, github_failure_limitation(
+            api=path,
+            source=path,
+            exit_code=completed.returncode,
+            stderr=completed.stderr,
+            default_code="github_api_collection_failed",
+            default_message="fixed read-only GitHub API collection failed",
+            default_severity="blocking",
+        )
     try:
         return parse_gh_paginated_stdout(completed.stdout), None
     except json.JSONDecodeError:
@@ -108,14 +239,15 @@ def gh_pr_view():
     command = ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "mergeStateStatus,statusCheckRollup"]
     completed = subprocess.run(command, capture_output=True, text=True, check=False)
     if completed.returncode != 0:
-        return {}, {
-            "code": "pr_required_check_state_unavailable",
-            "source": "gh_pr_view",
-            "severity": "informational",
-            "message": "fixed read-only PR required check state collection failed",
-            "exit_code": completed.returncode,
-            "stderr_sha256": hashlib.sha256(completed.stderr.encode()).hexdigest(),
-        }
+        return {}, github_failure_limitation(
+            api="gh_pr_view.statusCheckRollup",
+            source="gh_pr_view",
+            exit_code=completed.returncode,
+            stderr=completed.stderr,
+            default_code="pr_required_check_state_unavailable",
+            default_message="fixed read-only PR required check state collection failed",
+            default_severity="informational",
+        )
     try:
         payload = json.loads(completed.stdout or "{}")
     except json.JSONDecodeError:
@@ -487,7 +619,9 @@ elif merge_state_blocking:
         }
     )
 
-if (
+if any(item.get("code") == "github_token_permission_denied" for item in limitations):
+    ci_status = "unknown"
+elif (
     check_counts["failed"]
     or status_counts["failure"]
     or status_counts["error"]

--- a/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
+++ b/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
@@ -159,12 +159,20 @@ def limitation(code, message, **extra):
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def is_permission_denied(stderr):
     lowered = (stderr or "").lower()
-    return "resource not accessible by personal access token" in lowered or "permission denied" in lowered
+    return (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    )
 
 
 def trigger_permission_limitation(stderr, exit_code):

--- a/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
+++ b/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
@@ -68,6 +68,7 @@ TRIGGER_PR="$pr" \
 TRIGGER_HEAD_SHA="$head_sha" \
 python3 - <<'PY'
 import json
+import hashlib
 import os
 import subprocess
 from datetime import datetime, timezone
@@ -147,8 +148,39 @@ def emit(payload):
 
 def limitation(code, message, **extra):
     payload = {"code": code, "message": message, "source": "trigger_codex_review.sh"}
-    payload.update(extra)
+    sanitized_extra = {}
+    for key, value in extra.items():
+        if key.endswith("gh_stderr") or key == "gh_stderr":
+            sanitized_extra[f"{key}_sha256"] = hashlib.sha256(str(value or "").encode()).hexdigest()
+        else:
+            sanitized_extra[key] = value
+    payload.update(sanitized_extra)
     return payload
+
+
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def is_permission_denied(stderr):
+    lowered = (stderr or "").lower()
+    return "resource not accessible by personal access token" in lowered or "permission denied" in lowered
+
+
+def trigger_permission_limitation(stderr, exit_code):
+    return limitation(
+        "github_token_permission_denied",
+        "GitHub token lacks permission to post the fixed Codex review trigger comment",
+        capability="trigger_comment_write",
+        api=endpoint,
+        status="permission_denied",
+        token_source=token_source(),
+        severity="blocking",
+        recommended_next_action="fix_github_token_permissions",
+        secret_redacted=True,
+        stderr_sha256=hashlib.sha256((stderr or "").encode()).hexdigest(),
+        exit_code=exit_code,
+    )
 
 
 def head_matches(actual, expected):
@@ -296,6 +328,8 @@ if post_exit == 0 and isinstance(post_payload, dict):
 else:
     payload["trigger"]["action"] = "failed"
     payload["overall_status"] = "trigger_post_failed"
+    if is_permission_denied(post_stderr):
+        payload["limitations"].append(trigger_permission_limitation(post_stderr, post_exit))
     payload["limitations"].append(
         limitation(
             "trigger_post_failed",

--- a/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh
+++ b/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh
@@ -250,6 +250,13 @@ def has_zero_check_limitation(payload: dict) -> bool:
     )
 
 
+def has_permission_limitation(payload: dict) -> bool:
+    return any(
+        isinstance(item, dict) and item.get("code") == "github_token_permission_denied"
+        for item in payload.get("limitations", [])
+    )
+
+
 def sanitized_review_signals(payload: dict) -> list:
     review = payload.get("review")
     if not isinstance(review, dict):
@@ -626,7 +633,10 @@ def trigger_failure_result(trigger_payload: dict, trigger_stdout: str, trigger_s
     normalized_status = trigger_payload.get("overall_status") or trigger_payload.get("status") or "unknown"
     if normalized_status == "trigger_posted":
         normalized_status = "unknown"
-    if normalized_status == "stale_head":
+    if has_permission_limitation(trigger_payload):
+        normalized_status = "human_gate"
+        next_action = "fix_github_token_permissions"
+    elif normalized_status == "stale_head":
         next_action = "rerun_for_current_head"
     elif normalized_status == "draft_pr":
         normalized_status = "human_gate"
@@ -809,6 +819,8 @@ def classify(payload: dict, poll: int, zero_check_grace_polls: int) -> tuple[str
         return "human_gate", "human_gate", top_level_next_action, False, True
     if ci_status == "none" and has_zero_check_limitation(payload):
         if has_blocking_limitation(payload, ignored_codes={"zero_checks_s03_non_success"}):
+            if has_permission_limitation(payload):
+                return "unknown", "unknown", "fix_github_token_permissions", False, True
             return "unknown", "unknown", "human_gate", False, True
         if poll < zero_check_grace_polls:
             return "none", "none", "wait", False, False
@@ -817,8 +829,12 @@ def classify(payload: dict, poll: int, zero_check_grace_polls: int) -> tuple[str
         return "failed", "failed", "fix_ci", False, True
     if ci_status in {"pending", "running", "none"}:
         if has_blocking_limitation(payload, ignored_codes={"required_checks_missing_or_pending"}):
+            if has_permission_limitation(payload):
+                return "unknown", "unknown", "fix_github_token_permissions", False, True
             return "unknown", "unknown", "human_gate", False, True
         return ci_status, ci_status, "wait", False, False
+    if has_permission_limitation(payload):
+        return "unknown", "unknown", "fix_github_token_permissions", False, True
     if has_blocking_limitation(payload):
         return "unknown", "unknown", "human_gate", False, True
     if ci_status != "passed":

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/design.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/design.md
@@ -3,7 +3,7 @@
 ID: "iss-00180"
 タイトル: "Github Token Capability Preflight"
 関連GitHub: ["#180"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-11"
 依存: ["requirement.md"]
@@ -12,177 +12,320 @@ ID: "iss-00180"
 
 # iss-00180 Github Token Capability Preflight — 設計（どう実現するか）
 
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
 ## 親図（Diagram）参照
 - Epic 図:
-  - ...
-- Initiative 図:
-  - ...
+  - `epic-00067` は provider-side `install_root` と dogfooding mirror の parity、agent-tooling assets の source-of-truth、managed install shape を固定する。
 - 再利用する決定:
-  - ...
+  - `github-pr-observation` は PR observation の primary result を stdout final JSON に置く。
+  - `github-pr-observation` の scripts は caller-provided endpoint / method / raw `gh` args を受け付けない fixed contract を維持する。
+  - `doctor` は repo-local runtime diagnosis command として structural findings / warnings を返す。
 
 ## 目的・制約
 - 目的:
-  - ...
-- 必須 / 禁止:
-  - ...
+  - GitHub token capability を fixed probe として分類し、`doctor` と PR observation の両 surface で同じ語彙を使って表示する。
+  - `GH_TOKEN` 優先 token の権限不足を、secret を出さずに token source / capability / failing API / next action として観測できるようにする。
+- 必須:
+  - Core probe は repository metadata / PR read / check-runs / commit statuses / `statusCheckRollup` に限定する。
+  - Doctor optional extended checks は `actions_read` と `issue_comments_read` に限定する。
+  - Fixed `@codex review` trigger write failure / success は doctor では扱わず、PR observation final JSON だけで扱う。
+  - Process exit と semantic status を分離する。
+- 禁止:
+  - arbitrary GitHub API checker 化。
+  - token value / hosts.yml secret / private payload 出力。
+  - doctor standalone probe による write operation。
+  - PR observation の permission limitation を merge-prepared evidence として扱うこと。
 - 非交渉制約:
-  - ...
-- 前提:
-  - ...
+  - stdout final JSON は PR observation の authority であり、stderr progress は authority ではない。
+  - No-target doctor は PR core probe を permission failure として扱わない。
 
 ## 既存実装 / 規約の理解
 - 参照した実装 / docs:
-  - ...
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh`
 - 現状理解:
-  - ...
+  - `DoctorFinding.code` は structural finding 用の Literal に閉じており、`DoctorResult.ok=False` は command exit 1 へつながる。
+  - Existing `doctor` command は引数なしで structural diagnosis を実行する。
+  - Checks collector は `gh api repos/<repo>/commits/<sha>/check-runs --paginate`、commit `status`、`gh pr view --json mergeStateStatus,statusCheckRollup` を固定実行し、failure を `limitations[]` に入れる。
+  - Checks collector の GitHub API failure は現在 `github_api_collection_failed` / `pr_required_check_state_unavailable` などの generic limitation であり、permission denied を token capability issue としては分類しない。
 - 採用するパターン:
-  - ...
+  - Runtime 側は domain/application contract を dataclass で明示し、presentation が CLI text に変換する。
+  - Agent-tooling script 側は Python-in-shell の fixed contract を維持し、stdout JSON に machine-readable limitations を返す。
 - 採用しないもの:
-  - ...
-- 影響範囲:
-  - ...
+  - Raw `gh` args passthrough。
+  - GitHub write preflight。
+  - Token secret introspection。
 
 ## 採用方針 / トレードオフ
 - 論点:
-  - ...
-- 選択肢:
-  - ...
+  - `doctor` と PR observation の両方で同じ分類語彙を使いつつ、実装境界は runtime Python と shell script に分かれる。
 - 決定:
-  - ...
+  - Shared classification vocabulary を固定し、runtime Python と PR observation scripts が同じ code / status names を使う。
+  - Runtime package と installed agent script の間に import dependency は作らない。Shell script から runtime Python module を import すると consumer repo / packaged install / dogfooding mirror の実行前提が複雑になるため。
+  - `doctor` は GitHub capability diagnostic を structural `DoctorFinding` と分ける。Capability finding だけでは doctor process を exit 1 にしない。
+  - PR observation は process exit 0 + final JSON semantic non-success を維持する。Usage error / malformed input / JSON construction failure は non-zero。
+- Status policy:
+  - 新しい top-level normalized status `permission_denied` は導入しない。
+  - Checks / statuses / `statusCheckRollup` の read permission failure は `normalized_status="unknown"`、`overall_status="unknown"`、`recommended_next_action="fix_github_token_permissions"` とし、`limitations[].code="github_token_permission_denied"` で表す。
+  - Fixed `@codex review` trigger comment write の permission failure は core read failure と分け、`normalized_status="human_gate"`、`overall_status="human_gate"`、`recommended_next_action="fix_github_token_permissions"` とし、`capability="trigger_comment_write"` の limitation で表す。
+  - これにより existing callers の status enum を広げずに、permission issue を machine-readable にできる。
+
+## Capability Result Model
+- 共通 capability code:
+  - `repo_metadata_read`
+  - `pull_request_read`
+  - `check_runs_read`
+  - `commit_statuses_read`
+  - `status_check_rollup_read`
+  - `actions_read`
+  - `issue_comments_read`
+  - `trigger_comment_write`
+- 共通 status:
+  - `ok`
+  - `permission_denied`
+  - `auth_missing`
+  - `rate_limited`
+  - `target_unavailable`
+  - `transient_unknown`
+  - `schema_unavailable`
+  - `skipped`
+- 共通 limitation / diagnostic fields:
+  - `code`
+  - `capability`
+  - `status`
+  - `token_source`
+  - `api`
+  - `severity`
+  - `message`
+  - `recommended_next_action`
+  - `secret_redacted`
+  - `stderr_sha256`
+- Token source:
+  - `GH_TOKEN`
+  - `gh_saved_auth`
+  - `unknown`
+- Secret policy:
+  - token value は保持しない。
+  - stderr 全文は出さず hash だけを出す。ユーザー向け message は sanitizer 後の分類文にする。
 
 ## 依存関係分析
 - module 依存:
-  - ...
-- class 依存（必要時）:
-  - ...
-- function 依存（必要時）:
-  - ...
+  - Runtime doctor:
+    - `commands/doctor.py` -> `application.doctor` -> `application.ports.GitHubCapabilityGateway` -> `infra.github_capability_cli` -> `presentation.cli_text`
+    - 新しい capability diagnostics は `application.contracts` に追加し、`application/ports.py` に fixed probe 用の Protocol を追加する。
+    - `cli/bootstrap.py` が infra adapter を `Ports.github_capability_gateway` として注入し、tests は fake gateway を注入する。
+  - PR observation:
+    - `fetch_pr_observation_snapshot.sh` -> `lib/fetch_pr_checks_snapshot.sh`
+    - `wait_pr_observation.sh` は snapshot payload の limitations / normalized status / recommended next action を集約する。
 - file 依存:
-  - ...
-- 上流 / 前提:
-  - ...
-- 下流 / 依存先:
-  - ...
+  - Provider source:
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py`
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py`
+    - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh`
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh`
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh`
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - Dogfooding mirror:
+    - `.agents/skills/github-pr-observation/...`
+    - `spec-dock/scripts/spec_dock_runtime/...`
+  - Tests:
+    - `tests/cli_runtime/test_runtime_doctor_s04.py`
+    - `tests/unit/infra/test_init_update.py`
 - 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
+  - Classification helper / result model を先に固定し、doctor と PR observation の両方が同じ limitation code を出すようにする。
 - 順序への影響:
-  - plan では upstream / prerequisite から順に step を組む
+  - S01: runtime doctor capability diagnostic model。
+  - S02: PR observation checks/trigger limitation classification。
+  - S03: docs / skill guidance / parity。
 
 ## モジュール依存図（Module Dependency Diagram）
-- タイトル:
-  - ...
-- 答える問い:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
-- 範囲:
-  - ...
-- 含めない詳細:
-  - 網羅的な call graph / 全 method / 全 import は描かない
-- 更新条件:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- 図:
-  - 下の `plantuml` block を更新する
-
-### 図表（UML / 原則: モジュール依存 / パッケージ依存差分）
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
 
-rectangle "対象module-a" as A
-rectangle "対象module-b" as B
-A --> B : depends_on
+rectangle "commands/doctor.py" as CmdDoctor
+rectangle "application/doctor.py" as AppDoctor
+rectangle "application/contracts.py" as Contracts
+rectangle "application/ports.py" as Ports
+rectangle "presentation/cli_text.py" as CliText
+rectangle "infra/github_capability_cli.py" as Probe
+
+rectangle "fetch_pr_observation_snapshot.sh" as ObsSnapshot
+rectangle "fetch_pr_checks_snapshot.sh" as Checks
+rectangle "wait_pr_observation.sh" as Wait
+rectangle "trigger_codex_review.sh" as Trigger
+
+CmdDoctor --> AppDoctor : DoctorRequest
+AppDoctor --> Contracts : DoctorResult + capability diagnostics
+AppDoctor --> Ports : GitHubCapabilityGateway
+Ports --> Probe : fixed core/extended probe
+CliText --> Contracts : render diagnostics
+
+ObsSnapshot --> Checks : fixed checks/statuses collection
+Wait --> ObsSnapshot : poll final JSON
+Wait --> Trigger : fixed @codex review write
+Checks ..> Contracts : shared vocabulary only
+Trigger ..> Contracts : shared vocabulary only
 @enduml
 ```
 
-## ローカル図の差分（Local Diagram Delta / 必要時）
-- 変更する境界 / 責務 / 相互作用:
-  - N/A: 理由
-
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
+- `DoctorRequest`:
+  - Keep default no-arg structural diagnosis valid.
+  - Add optional GitHub PR probe target fields or equivalent command arguments:
+    - `github_repo`
+    - `github_pr`
+    - `github_head_sha`
+  - If target fields are absent, PR core probe is `target_unavailable` / `skipped`.
+- `DoctorResult`:
+  - Add `github_capability_diagnostics` separate from structural `findings`.
+  - `ok` continues to represent structural doctor success. Capability diagnostics alone do not make `ok=False`.
+- `GitHubCapabilityGateway`:
+  - Add a Protocol in `application/ports.py` and a nullable `github_capability_gateway` field on `Ports`.
+  - The gateway accepts only typed target fields and fixed boolean switches for core / optional extended probe groups.
+  - The default infra implementation lives in `infra/github_capability_cli.py` and shells out to fixed `gh` commands; it never accepts caller-provided endpoint / method / raw `gh` args.
+  - When the gateway is unavailable, `doctor` returns skipped diagnostics rather than treating capability probe absence as structural failure.
+- `doctor` command:
+  - Add optional arguments only for fixed target fields. Do not accept raw API args.
+  - Exit code remains based on structural `ok`.
+- PR observation final JSON:
+  - Keep existing final JSON shape.
+  - Add limitation objects for permission failures:
+    - `code="github_token_permission_denied"`
+    - `capability`
+    - `api`
+    - `token_source`
+    - `severity="blocking"`
+    - `recommended_next_action="fix_github_token_permissions"`
+    - `secret_redacted=true`
+  - For read probe permission failure in `fetch_pr_checks_snapshot.sh`:
+    - `ci.status="unknown"`
+    - `ci.progress_status="unknown"`
+    - `normalized_status="unknown"`
+    - `overall_status="unknown"`
+    - `recommended_next_action="fix_github_token_permissions"`
+    - `observation_complete=false`
+    - `limitations[].code="github_token_permission_denied"`
+  - For fixed trigger comment write permission failure in `wait_pr_observation.sh`:
+    - `normalized_status="human_gate"`
+    - `overall_status="human_gate"`
+    - `recommended_next_action="fix_github_token_permissions"`
+    - `limitations[].code="github_token_permission_denied"`
+    - `limitations[].capability="trigger_comment_write"`
+  - Malformed input / script misuse / final JSON construction failure remains non-zero process exit and is not encoded as GitHub token capability limitation.
 
-## シーケンス差分（Sequence Delta / 必要時）
-- 変更する相互作用:
-  - N/A: 理由
-- retry / transaction / external API / queue:
-  - ...
-- UML:
-  - N/A: 理由
+## シーケンス差分
+```plantuml
+@startuml
+actor Maintainer
+participant "spec-dock doctor" as Doctor
+participant "GitHubCapabilityProbe" as Probe
+participant "GitHub API" as GH
 
-## ドメインモデル差分（Domain Model Delta / 必要時）
-- 親 model 参照:
-  - ...
-- aggregate / entity / value object 変更:
-  - N/A: 理由
-- domain event / policy / specification 変更:
-  - ...
-- 不変条件の変更:
-  - ...
-- UML:
-  - N/A: 理由
+Maintainer -> Doctor : doctor --github-repo --github-pr --github-head-sha
+Doctor -> Probe : fixed core + optional extended reads
+Probe -> GH : fixed read-only endpoints
+GH --> Probe : ok / permission denied / auth missing / rate limited
+Probe --> Doctor : capability diagnostics
+Doctor --> Maintainer : structural findings + capability diagnostics
+@enduml
+```
 
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- 責務:
-  - ...
-- 連携:
-  - ...
-- UML:
-  - N/A: 理由
+```plantuml
+@startuml
+actor Orchestrator
+participant "wait_pr_observation.sh" as Wait
+participant "fetch_pr_observation_snapshot.sh" as Snapshot
+participant "fetch_pr_checks_snapshot.sh" as Checks
+participant "GitHub API" as GH
+
+Orchestrator -> Wait : wait repo/pr/head
+Wait -> Snapshot : poll
+Snapshot -> Checks : collect checks/statuses/rollup
+Checks -> GH : fixed read-only endpoints
+GH --> Checks : permission denied
+Checks --> Snapshot : ci=unknown + limitation
+Snapshot --> Wait : final-compatible JSON
+Wait --> Orchestrator : stdout final JSON semantic non-success
+@enduml
+```
 
 ## ディレクトリ / ファイル変更計画
 ```text
 .
-|-- src/
-|   |-- package/
-|   |   |-- new_module.py        # 追加: 目的; 依存: ...
-|   |   |-- existing_module.py   # 変更: 目的; 依存: ...
-|   |   `-- renamed_module.py    # 移動/rename 元: src/package/old_module.py; 目的
-|   `-- tests/
-|       `-- test_new_module.py   # 追加/変更: 目的; 依存: src/package/new_module.py
-|-- docs/
-|   `-- reference.md             # 読取のみ: 目的
-`-- legacy/
-    `-- obsolete_file.py         # 削除: 目的; 依存: 代替準備完了
+|-- src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/
+|   |-- application/
+|   |   |-- contracts.py        # 変更: doctor capability diagnostic model
+|   |   |-- ports.py            # 変更: GitHubCapabilityGateway Protocol / Ports field
+|   |   `-- doctor.py           # 変更: fixed GitHub probe orchestration
+|   |-- commands/
+|   |   `-- doctor.py           # 変更: optional fixed probe target arguments
+|   |-- cli/
+|   |   `-- bootstrap.py        # 変更: infra gateway injection
+|   |-- infra/
+|   |   `-- github_capability_cli.py # 追加: fixed gh probe adapter
+|   `-- presentation/
+|       `-- cli_text.py         # 変更: capability diagnostics rendering
+|-- src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/
+|   |-- SKILL.md                # 変更: permission limitation guidance
+|   `-- scripts/
+|       |-- fetch_pr_observation_snapshot.sh
+|       |-- wait_pr_observation.sh
+|       |-- trigger_codex_review.sh
+|       `-- lib/
+|           `-- fetch_pr_checks_snapshot.sh
+|-- spec-dock/scripts/spec_dock_runtime/... # dogfooding mirror refresh / parity check
+|-- .agents/skills/github-pr-observation/... # dogfooding mirror refresh / parity check
+|-- tests/cli_runtime/test_runtime_doctor_s04.py
+`-- tests/unit/infra/test_init_update.py
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- AC-001 -> `DoctorRequest` optional target fields、capability diagnostics render。
+- AC-001b -> no-target `target_unavailable` / `skipped` diagnostic。
+- AC-002 -> checks collector permission classification + snapshot/wait propagation。
+- AC-003 -> trigger script / wait trigger failure limitation separated from core read failure。
+- AC-004 -> secret redaction, stderr hash, no token value output assertions。
+- AC-005 -> fixed argument validation and no raw endpoint / method / jq / header surface。
+- AC-006 -> usage / malformed / JSON failure remains command/runtime error.
+- AC-007 -> doctor optional extended checks limited to `actions_read` and `issue_comments_read`.
+- EC-001 -> token source `gh_saved_auth` / `unknown` fallback.
+- EC-002 -> `auth_missing` classification.
+- EC-003 -> `rate_limited` / `transient_unknown` / `schema_unavailable`.
+- EC-004 -> per-capability result model.
+- EC-005 -> optional extended result does not affect core.
 
 ## テスト戦略
-- 単体:
-  - ...
-- 統合:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
+- 単体 / runtime:
+  - `tests/cli_runtime/test_runtime_doctor_s04.py` で `doctor` targetless skipped diagnostic、permission denied diagnostic、optional extended separated render、exit code semantics を確認する。
+  - Ports / stub adapter を使い、live GitHub API に依存しない。
+- Script / installed asset:
+  - `tests/unit/infra/test_init_update.py` の existing PR observation stub harness に permission denied stderr / exit code fixture を追加する。
+  - `fetch_pr_checks_snapshot.sh` が permission denied を `github_token_permission_denied` limitation に分類することを確認する。
+  - `wait_pr_observation.sh` が final JSON semantic non-success と recommended action を維持することを確認する。
+- Parity:
+  - provider-side `install_root` と dogfooding `.agents` mirror、provider runtime と dogfooding `spec-dock/scripts/spec_dock_runtime` の必要差分を確認する。
+- Security:
+  - output に token-like value が含まれない forbidden-token assertion を置く。
+  - raw stderr は hash 化され、secret-bearing stderr body を JSON / CLI text に出さない。
 
-## 要件 / 例外 -> 検証マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
-
-## リスク / 移行 / ロールバック（必要時）
-- ...
+## リスク / 移行 / ロールバック
+- リスク:
+  - `doctor` の `ok` と capability diagnostics を分離するため、既存 doctor result semantics を読み違える caller があると混乱する。
+  - Script 側と runtime 側で vocabulary が drift すると、agent が limitation を正しく解釈できない。
+  - GitHub CLI / API の error text は変わり得るため、permission classification は exact text だけに依存しすぎない。
+- 移行:
+  - Existing `doctor` no-arg behavior は structural diagnosis として維持する。
+  - Existing PR observation JSON fields は維持し、limitation object を追加する additive change とする。
+- ロールバック:
+  - Capability diagnostics と limitation classification は additive なので、問題があれば new diagnostic fields / new limitation code の追加分を戻す。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - Requirement reviewer の指摘により target resolution、optional extended set、trigger write surface は requirement で確定済み。

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135317z-interview-github-token-capability-scope.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135317z-interview-github-token-capability-scope.md
@@ -1,0 +1,172 @@
+---
+種別: interview
+ID: "20260611t135317z-interview"
+タイトル: "Github Token Capability Scope"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-11"
+親: ["iss-00180"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00180"
+created_at: "2026-06-11THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to: ["requirement.md", "design.md", "plan.md", "report.md"]
+---
+
+# 20260611t135317z-interview Github Token Capability Scope
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の source-grounded 正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- この artifact は answer capture / adoption target / reflection の evidence surface であり、main orchestrator が canonical docs / accepted ADR / `report.md` Evidence Adoption Ledger へ採用するまでは canonical authority ではない。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には one essential question / 一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - `iss-00180` の必須 scope を `doctor` 中心にするか、PR observation workflow の preflight / limitation 表示まで含めるかが変わる。
+  - `design.md`:
+    - runtime `doctor` command の診断として設計するか、`.agents/skills/github-pr-observation` scripts の実行前 capability probe として設計するかが変わる。
+  - `plan.md`:
+    - 実装順序、テスト対象、provider-side source と dogfooding mirror の parity 対象が変わる。
+  - `ADR`:
+    - 現時点では不要。`doctor` と workflow preflight の責務境界を長期 contract として固定する場合のみ ADR 候補になる。
+- chat 上の軽微な一問では足りない理由:
+  - 回答によって issue の実装 surface と受け入れ条件が変わり、後続の requirement / design / plan に採用証跡が必要になるため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - `spec-dock` maintainer。
+- 何を明確にする質問か:
+  - GitHub token capability check をどの実行面の product contract として定義するか。
+- 回答が後続判断へ与える影響:
+  - `doctor` の環境診断を先に作るのか、PR observation / merge-preparer の `unknown` 低減を先に作るのか、または両方を 1 issue に含めるのかが決まる。
+
+## 質問 (必須)
+- pressure-test question:
+  - この issue の成功条件は「手動で `spec-dock doctor` を実行したときに token 権限不足を診断できること」か、「PR observation / merge-preparer の通常 workflow が `unknown` の前に permission 問題を示すこと」か。
+- 質問:
+  - `iss-00180` では、GitHub token capability check の必須 scope をどこまで含めたいですか？
+- 回答してほしいこと:
+  - 下の Option A / B / C のどれを採用するか。必要なら「A を先に、この issue では B は docs だけ」などの組み合わせで回答してよい。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - GitHub issue `#180`: `GH_TOKEN` 優先の fine-grained PAT で `check-runs`、`statusCheckRollup`、`gh pr checks` が `Resource not accessible by personal access token` になり、`GH_TOKEN` を外すと取得できた。
+  - `spec-dock/active/issue/requirement.md`: 現在は scaffold のままで、要件は未具体化。
+  - 親 epic `epic-00067`: `.agents` / `.codex` / `.github` の installed layout と agent-tooling assets の hardening が中心。
+  - `iss-00170`: `github-pr-observation` の deterministic PR observation、CI / review collection、`unknown` / limitation / stdout JSON 境界を定義済み。
+  - `iss-00176`: `wait_pr_observation.sh` が `@codex review` trigger と PR observation を担い、GitHub auth / permission / rate limit / schema failure を non-success / limitation として JSON 表現する前提を持つ。
+  - `iss-00178`: observation result は evidence であり、triage / repair 判断は `github-pr-merge-preparer` 側に置く境界を定義している。
+  - runtime `doctor`: 既に構造・metadata・active pointer などの診断 command として存在する。
+- local context で解決できたこと:
+  - GitHub API の失敗対象と症状は `#180` 本文で十分具体化されている。
+  - PR observation 側には既に `unknown` / limitation を final JSON に含める設計文脈がある。
+  - `doctor` 側には環境診断の入口があるが、GitHub token capability probe は現時点の主要 contract としてはまだ固定されていない。
+- まだ人間判断が必要な理由:
+  - `doctor` に入れると手動診断として扱いやすい一方、実際に困った workflow は PR observation / merge-preparer の実行中であり、どちらを issue の「必須成功条件」にするかは product intent の判断になる。
+
+## 回答案 (必須)
+- Option A:
+  - `doctor` first。`spec-dock doctor` に GitHub token capability check を追加し、`GH_TOKEN` 優先状態、必要 API の read probe、permission 不足の説明、fine-grained PAT permission 目安を出す。
+- Option B:
+  - PR workflow first。`github-pr-observation` / `github-pr-merge-preparer` の通常 path で、`check-runs` / `statusCheckRollup` / `gh pr checks` などの permission failure を `unknown` ではなく token permission limitation として final JSON / progress / guidance に出す。
+- Option C:
+  - 両方。ただし 1 issue 内で、共通 capability probe を小さく設計し、`doctor` は手動診断、PR observation は runtime limitation 表示として同じ判定語彙を使う。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - 利用者がどの時点で原因に気づけるべきか。
+  - GitHub write/read 境界を広げずに read-only probe として保てるか。
+  - provider-side `.agents` scripts と runtime `doctor` の両方にまたがる場合、diff と test scope が過大にならないか。
+- tradeoff:
+  - Option A は実装と説明が比較的閉じるが、PR observation 実行中の `unknown` 体験は直接は改善しない。
+  - Option B は実害の出た workflow に効くが、手動 diagnosis と permission 目安の発見性は弱い。
+  - Option C は product 体験として最も一貫するが、runtime command と installed agent-tooling script の両方に触れるため、issue scope が広がる。
+- リスク:
+  - capability probe が broad な GitHub API checker になると、固定 endpoint / no arbitrary API の既存安全境界を弱める。
+  - `GH_TOKEN` / hosts.yml token の詳細を出しすぎると secret 漏洩リスクがある。表示は token source と capability 結果に留める必要がある。
+  - permission 不足と一時的 GitHub failure / rate limit / repo setting を誤分類すると、利用者の判断を誤らせる。
+- 具体シナリオ / edge case:
+  - `GH_TOKEN` が設定されているが fine-grained PAT に Checks / Actions read が不足している。
+  - `GH_TOKEN` を外すと `gh auth` の保存済み token では同じ API が読める。
+  - Issue / PR read はできるが commit check-runs / statusCheckRollup だけ読めない。
+  - 権限不足時も raw token や hosts.yml の秘密値は出さない。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option C。ただし実装は共通 probe を小さくし、まず `doctor` と PR observation の permission limitation 表示に限定する。
+- 理由:
+  - `#180` の問題は「手動で診断したい」と「実行中に unknown へ落ちる前に原因を出したい」の両方を含んでいるため。片方だけだと、発見性または実害低減のどちらかが残る。
+- 未回答時の影響:
+  - 要件を `doctor` only に狭めるか PR workflow まで含めるかを決められず、requirement / design / plan の scope が曖昧なままになる。
+
+## ユーザー回答 (回答後に必須)
+- answer capture:
+  - チャットで `option Cを採用します。` と回答。
+- 回答:
+  - Option C を採用する。`iss-00180` は `doctor` と PR observation workflow の両方を scope に含める。
+  - 共通 capability probe を小さく設計し、`doctor` は手動診断、PR observation は runtime limitation 表示として同じ判定語彙を使う。
+- 回答日時:
+  - 2026-06-11T13:55:00Z
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - Capability probe の最小必須 API セットを issue 内で固定するか、`doctor` と PR observation で probe profile を分けるか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- adoption target:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md` Evidence Adoption Ledger
+- 採用 / 棄却 / deferred の理由:
+  - GitHub issue `#180` は手動診断と PR observation 実行中の `unknown` 低減の両方を問題としているため、Option C が issue intent と最も一致する。
+  - ただし安全境界を保つため、実装は read-only capability probe と permission limitation 表示に限定する。
+- `report.md` Evidence Adoption Ledger への反映要否:
+  - yes
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - MUST に `spec-dock doctor` と PR observation workflow の両方で GitHub token capability 不足を診断 / 表示できることを入れる。
+  - MUST に共通判定語彙、`GH_TOKEN` 優先状態の表示、read-only fixed probe、secret 非表示を入れる。
+  - MUST NOT に arbitrary GitHub API checker 化、raw token / hosts.yml secret 出力、GitHub write operation を入れる。
+- `design.md`:
+  - 共通 capability probe を小さな contract として設計し、`doctor` と `github-pr-observation` が同じ結果語彙を参照する。
+  - `doctor` は手動診断 surface、PR observation は final JSON / limitation / guidance surface として扱う。
+  - probe failure は permission denied / auth missing / rate limited / transient unknown を分け、permission denied を `Resource not accessible by personal access token` と対応づける。
+- `plan.md`:
+  - 先に capability probe contract と unit tests を作り、次に `doctor` integration、最後に PR observation limitation 表示へ広げる。
+  - provider-side source、dogfooding mirror、runtime tests / script stub tests の対象を明記する。
+- `ADR`:
+  - 現時点では不要。scope 採用は issue-level decision として `report.md` に記録する。
+- reflected_to 更新方針:
+  - requirement / design / plan 作成時にこの interview を採用 evidence として参照し、`report.md` Evidence Adoption Ledger に採用済みとして記録する。
+- adoption reflection:
+  - `iss-00180` の headline は `doctor` だけの環境診断ではなく、GitHub token capability を shared diagnostic contract として扱う issue にする。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135608z-interview-github-capability-probe-profile.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135608z-interview-github-capability-probe-profile.md
@@ -1,0 +1,173 @@
+---
+種別: interview
+ID: "20260611t135608z-interview"
+タイトル: "Github Capability Probe Profile"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-11"
+親: ["iss-00180"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00180"
+created_at: "2026-06-11THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to: ["requirement.md", "design.md", "plan.md", "report.md"]
+---
+
+# 20260611t135608z-interview Github Capability Probe Profile
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の source-grounded 正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- この artifact は answer capture / adoption target / reflection の evidence surface であり、main orchestrator が canonical docs / accepted ADR / `report.md` Evidence Adoption Ledger へ採用するまでは canonical authority ではない。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には one essential question / 一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - capability check が固定最小 API セットなのか、workflow 別 profile なのかで MUST / OUT OF SCOPE が変わる。
+  - `design.md`:
+    - 共通 probe contract の入力、出力、判定語彙、`doctor` と PR observation の使い方が変わる。
+  - `plan.md`:
+    - test fixture、stubbed `gh` call、script integration の数と順序が変わる。
+  - `ADR`:
+    - 現時点では不要。probe profile policy を長期 architecture contract にする場合のみ候補。
+- chat 上の軽微な一問では足りない理由:
+  - probe 対象の粒度は実装範囲と安全境界に直結し、後続 docs へ採用証跡が必要になるため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - `spec-dock` maintainer。
+- 何を明確にする質問か:
+  - `doctor` と PR observation で同じ fixed probe を使うのか、必要 capability が異なる profile を持つのか。
+- 回答が後続判断へ与える影響:
+  - API call set、output schema、permission guidance、テスト matrix が決まる。
+
+## 質問 (必須)
+- pressure-test question:
+  - `doctor` は広い GitHub workflow 前提を診断し、PR observation は PR checks に必要な capability だけを診断する、という profile 分離を許すか。
+- 質問:
+  - GitHub token capability probe は、固定の最小必須 API セット 1 種にしますか。それとも `doctor` 用と PR observation 用の profile を分けますか？
+- 回答してほしいこと:
+  - Option A / B / C のどれを採用するか。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - GitHub issue `#180` は、`check-runs`、`statusCheckRollup`、`gh pr checks` の permission failure を具体例として挙げている。
+  - 同 issue は capability 候補として Repository metadata read、Issues read/write、Pull requests read、Actions read、Checks read、Commit statuses read を挙げている。
+  - `iss-00176` は `wait_pr_observation.sh` が fixed trigger write と read-only observation を行う contract を持つため、PR observation 側には issue comment write capability も関係する。
+  - `iss-00170` は CI/check/status collection と review/comment/thread collection を扱うが、arbitrary endpoint / method / raw gh args は受け付けない境界を持つ。
+- local context で解決できたこと:
+  - `#180` の直接原因は PR checks / statuses 系 API の read 権限不足。
+  - PR observation workflow は fixed set の GitHub calls を持つため、profile 化しても arbitrary API checker にする必要はない。
+  - `doctor` は環境診断なので、PR observation に限らない Issues write などを確認したい要求があり得る。
+- まだ人間判断が必要な理由:
+  - fixed minimal set は実装が小さいが将来不足しやすく、profile 分離は正確だが scope と出力が複雑になる。
+
+## 回答案 (必須)
+- Option A:
+  - Fixed minimal profile。`doctor` と PR observation の両方で、まず repo metadata、PR read、check-runs read、commit statuses read、statusCheckRollup read だけを確認する。Issue comment write などは docs guidance に留める。
+- Option B:
+  - Two profiles。`doctor` は broader workflow profile として repo metadata、issues read/write、pull requests read、actions/checks/statuses read を確認し、PR observation は PR observation profile として check-runs/statusCheckRollup/statuses と trigger comment write availability を確認する。
+- Option C:
+  - Fixed core + optional profile extensions。共通 core は metadata / PR read / check-runs / statuses / statusCheckRollup に固定し、`doctor` だけ optional extended checks として Issues write / trigger comment write / Actions read を明示的に表示する。PR observation は core + 必要時の trigger write failure を limitation 化する。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - `#180` の直接症状を過不足なく検出できるか。
+  - `doctor` の発見性と PR observation の実害低減を両立できるか。
+  - broad permission checker になりすぎないか。
+- tradeoff:
+  - Option A は小さいが、`@codex review` trigger 投稿権限不足や Issue close/comment 権限不足の診断が弱い。
+  - Option B は正確だが、profile 定義と output matrix が大きくなる。
+  - Option C は direct cause を core で固定しつつ、`doctor` の発見性を optional extension に逃がせる。
+- リスク:
+  - Issues write probe が実際に書き込む形になると危険なので、write capability は原則として read-only に近い検査か dry capability inference に留める必要がある。
+  - GitHub API permission model は fine-grained PAT / classic PAT / GitHub App token で見え方が異なるため、permission 名を断定しすぎない。
+- 具体シナリオ / edge case:
+  - `statusCheckRollup` は読めないが check-runs は読める。
+  - check-runs は読めないが PR metadata は読める。
+  - PR observation の trigger comment POST だけ失敗する。
+  - rate limit / transient failure は permission denied と分ける。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option C。
+- 理由:
+  - `#180` の直接問題に効く core probe を固定しつつ、`doctor` の broader diagnosis も表現できる。PR observation 側は core failure と trigger write failure を limitation として返せば、arbitrary checker 化を避けられる。
+- 未回答時の影響:
+  - capability probe の API call set と output schema を要件に落とせず、設計が過剰または不足する。
+
+## ユーザー回答 (回答後に必須)
+- answer capture:
+  - チャットで `オプションCを採用します。` と回答。
+- 回答:
+  - Option C を採用する。
+  - 共通 core probe は metadata / PR read / check-runs / statuses / statusCheckRollup に固定する。
+  - `doctor` だけ optional extended checks を表示し、PR observation は core failure と trigger write failure を limitation 化する。
+- 回答日時:
+  - 2026-06-11T13:58:00Z
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - yes
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - Capability probe failure を command failure にするか、warning / limitation として non-zero にしないか。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- adoption target:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md` Evidence Adoption Ledger
+- 採用 / 棄却 / deferred の理由:
+  - `#180` の直接症状は PR checks / statuses 系 API の read 権限不足であり、core probe に固定できる。
+  - 一方で `doctor` は環境診断として broader capability を示したいので、optional extended checks を持てる形にする。
+  - PR observation は observation workflow の安全境界を維持し、core probe failure と trigger write failure を limitation として返す。
+- `report.md` Evidence Adoption Ledger への反映要否:
+  - yes
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - MUST に fixed core probe を定義する。
+  - MUST に `doctor` の optional extended checks を、core とは分けて表示することを入れる。
+  - MUST に PR observation が core failure / trigger write failure を machine-readable limitation として返すことを入れる。
+  - MUST NOT に arbitrary GitHub API checker 化、raw token 出力、probe のための不要な write operation を入れる。
+- `design.md`:
+  - capability probe result は `core` と `extended` を分けた model にする。
+  - core は metadata / PR read / check-runs / statuses / statusCheckRollup の固定 endpoint 群にする。
+  - extended は `doctor` 表示用で、Issue comment write / Actions read などを optional capability として扱う。
+  - PR observation は core failure を permission limitation として final JSON に入れ、trigger comment POST failure は trigger write limitation として別扱いする。
+- `plan.md`:
+  - core probe の unit / stub tests を先に作る。
+  - `doctor` integration は core + extended 表示を検証する。
+  - PR observation integration は core failure と trigger write failure の limitation 表示を検証する。
+- `ADR`:
+  - 現時点では不要。profile policy は issue-level decision として `report.md` に記録する。
+- reflected_to 更新方針:
+  - requirement / design / plan 作成時にこの interview を採用 evidence として参照し、`report.md` Evidence Adoption Ledger に採用済みとして記録する。
+- adoption reflection:
+  - `iss-00180` の capability check は broad checker ではなく、fixed core + doctor-only optional extended checks として扱う。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135901z-interview-github-capability-failure-semantics.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t135901z-interview-github-capability-failure-semantics.md
@@ -1,0 +1,170 @@
+---
+種別: interview
+ID: "20260611t135901z-interview"
+タイトル: "Github Capability Failure Semantics"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-11"
+親: ["iss-00180"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00180"
+created_at: "2026-06-11THH:MM:SSZ"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from: []
+reflected_to: ["requirement.md", "design.md", "plan.md", "report.md"]
+---
+
+# 20260611t135901z-interview Github Capability Failure Semantics
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の source-grounded 正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- この artifact は answer capture / adoption target / reflection の evidence surface であり、main orchestrator が canonical docs / accepted ADR / `report.md` Evidence Adoption Ledger へ採用するまでは canonical authority ではない。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には one essential question / 一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - capability probe failure を fatal にするか warning / limitation にするかで受け入れ条件が変わる。
+  - `design.md`:
+    - `doctor` の exit code、PR observation final JSON の normalized status / recommended action / limitation の扱いが変わる。
+  - `plan.md`:
+    - CLI tests と script tests の expected return code / JSON status が変わる。
+  - `ADR`:
+    - 現時点では不要。
+- chat 上の軽微な一問では足りない理由:
+  - failure semantics は automation の制御フローと人間への報告に直接影響するため。
+
+## 質問の目的 (必須)
+- 対象者:
+  - `spec-dock` maintainer。
+- 何を明確にする質問か:
+  - GitHub token capability failure をコマンド失敗として扱うか、diagnostic / limitation として扱うか。
+- 回答が後続判断へ与える影響:
+  - `doctor` / PR observation の終了コード、JSON status、human gate への遷移、テスト期待値が決まる。
+
+## 質問 (必須)
+- pressure-test question:
+  - 権限不足が見つかったときに、`doctor` や PR observation は即 non-zero / failed にするべきか、それとも「環境診断は成功したが finding / limitation がある」として返すべきか。
+- 質問:
+  - Capability probe failure の扱いはどれにしますか？
+- 回答してほしいこと:
+  - Option A / B / C のどれを採用するか。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - GitHub issue `#180` は、現在の `unknown` が原因切り分けを難しくしていることを問題にしている。
+  - `iss-00170` / `iss-00176` は `unknown`、`limitation`、`human_gate`、non-success を final JSON で表現する文脈を持つ。
+  - 既存 `doctor` は findings がある場合に診断結果として stderr へ出す command surface を持つ。
+- local context で解決できたこと:
+  - 権限不足そのものはコードや spec tree の破損ではなく、GitHub workflow を正しく観測できない環境状態である。
+  - PR observation においては required capability が欠けると merge-prepared evidence としては成功扱いできない。
+- まだ人間判断が必要な理由:
+  - `doctor` は診断 command なので finding があるだけで non-zero にすべきか曖昧であり、PR observation は automation gate なので permission limitation を success 扱いしない必要がある。
+
+## 回答案 (必須)
+- Option A:
+  - Fatal everywhere。core capability が欠けたら `doctor` も PR observation も non-zero / failed とする。
+- Option B:
+  - Diagnostic non-fatal。`doctor` は finding を返して exit 0、PR observation も limitation を返すが command 自体は exit 0 とし、final JSON の status / recommended action で human gate にする。
+- Option C:
+  - Surface-specific semantics。`doctor` は diagnosis command として exit 0 + findings を返す。PR observation は stdout final JSON を返すため process は原則 exit 0 を維持するが、normalized status は `unknown` / `human_gate` / `permission_denied` 相当にし、merge-prepared evidence には使えない non-success とする。Malformed input / script misuse / JSON construction failure は non-zero。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - コマンド実行そのものの成功と、観測対象 workflow の成功を分離できるか。
+  - automation が permission limitation を merge-prepared と誤認しないか。
+  - 人間が原因を直すための情報を確実に受け取れるか。
+- tradeoff:
+  - Option A は単純だが、diagnostic command と observation command の出力を受け取れずに失敗扱いで止まる可能性がある。
+  - Option B は扱いやすいが、PR observation で limitation を成功扱いする誤用リスクが残る。
+  - Option C は exit code と semantic status を分離でき、既存の final JSON authority 境界と合う。
+- リスク:
+  - process exit 0 を維持する場合、caller が final JSON を読まないと成功誤認する。skill guidance / tests で normalized status を必ず見る契約を強める必要がある。
+  - `permission_denied` のような新 status を導入するか、既存 `unknown` + limitation に留めるかは design で決める必要がある。
+- 具体シナリオ / edge case:
+  - `doctor` で check-runs read が失敗しても、diagnostic report 自体は生成できている。
+  - PR observation で check-runs read が失敗した場合、CI status を passed として返してはいけない。
+  - `gh` が存在しない / repo slug が解決できない / JSON が壊れる場合は capability limitation ではなく command/runtime error として扱う可能性がある。
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option C。
+- 理由:
+  - `doctor` は診断結果を返すこと自体が価値なので exit 0 + findings が自然。一方で PR observation は merge-prepared evidence には使えない non-success を JSON で明示する必要がある。process failure と semantic failure を分けると、エージェントが原因を読んで次の行動を選びやすい。
+- 未回答時の影響:
+  - command return code、final JSON status、human gate / recommended action の要件が曖昧になり、実装とテストがぶれる。
+
+## ユーザー回答 (回答後に必須)
+- answer capture:
+  - チャットで `オプションCを採用します。` と回答。
+- 回答:
+  - Option C を採用する。
+  - `doctor` は diagnosis command として exit 0 + findings を返す。
+  - PR observation は stdout final JSON を返すため process は原則 exit 0 を維持するが、normalized status は `unknown` / `human_gate` / `permission_denied` 相当の non-success とし、merge-prepared evidence には使えない。
+  - Malformed input / script misuse / JSON construction failure は non-zero とする。
+- 回答日時:
+  - 2026-06-11T14:00:00Z
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - no
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - なし。現時点の blocking scope questions は解消済み。
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- adoption target:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md` Evidence Adoption Ledger
+- 採用 / 棄却 / deferred の理由:
+  - `doctor` は診断結果を返すこと自体が価値であり、capability finding があるだけで command failure にしない。
+  - PR observation は final JSON を authority とする既存境界を保ちつつ、permission limitation を merge-prepared evidence に使えない semantic non-success として明示する必要がある。
+  - process failure と semantic failure を分けることで、caller が JSON の limitation / recommended action を読んで修正または human gate へ進める。
+- `report.md` Evidence Adoption Ledger への反映要否:
+  - yes
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - MUST に `doctor` は capability findings を診断結果として返すことを入れる。
+  - MUST に PR observation は permission limitation を final JSON の semantic non-success として返し、merge-prepared evidence に使えないことを入れる。
+  - MUST に malformed input / script misuse / JSON construction failure は command/runtime error として扱うことを入れる。
+- `design.md`:
+  - process exit code と semantic status を分離する。
+  - `doctor` は findings list / warning message に capability result を追加する。
+  - PR observation は normalized status、limitations、recommended next action に permission limitation を反映する。
+  - `permission_denied` を新 status として導入するか、既存 `unknown` / `human_gate` + limitation に留めるかは design phase で具体化する。
+- `plan.md`:
+  - `doctor` tests は exit 0 + findings を期待する。
+  - PR observation tests は process exit 0 + final JSON semantic non-success を期待する。
+  - malformed input / script misuse / invalid JSON などは non-zero case として別に検証する。
+- `ADR`:
+  - 現時点では不要。failure semantics は issue-level decision として `report.md` に記録する。
+- reflected_to 更新方針:
+  - requirement / design / plan 作成時にこの interview を採用 evidence として参照し、`report.md` Evidence Adoption Ledger に採用済みとして記録する。
+- adoption reflection:
+  - `iss-00180` は capability failure を一律 fatal にせず、surface ごとに process success と semantic non-success を分ける。
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t161800z-disc-pr-repair-batch.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t161800z-disc-pr-repair-batch.md
@@ -84,7 +84,7 @@ head_sha: "2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b"
 ## Repair Queue
 | unit_id | covered_items | owner | status | validation |
 |---|---|---|---|---|
-| U001 | I001-I007 | dev-coder | implemented | focused tests, full `tests/unit/infra/test_init_update.py`, runtime doctor suite, mirror diffs, `validate`, `git diff --check` |
+| U001 | I001-I007 | dev-coder | reobserved-pass | focused tests, full `tests/unit/infra/test_init_update.py`, runtime doctor suite, mirror diffs, `validate`, `git diff --check`, PR re-observation |
 
 ## Unit Discussion Plan
 - A separate repair unit is not necessary because the five items are a single bounded PR repair pass and all changes are within iss-00180's existing surfaces:
@@ -106,7 +106,7 @@ head_sha: "2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b"
   - Any remaining limitation is explicitly classified and not hidden.
 
 ## Implementation Result
-- U001 status: implemented, commit pending.
+- U001 status: implemented, committed, pushed, reobserved.
 - I001: fixed by adding `iss-00180` checked-in dogfooding `.meta.json` path and `depends_on=[]` expectation.
 - I002: fixed by updating the wait-contract test to expect typed `github_rate_limited` / `rate_limited` / `wait_or_retry_later`.
 - I003: fixed by classifying `Resource not accessible by integration` as permission denied in runtime doctor and PR observation checks helper.
@@ -129,7 +129,16 @@ head_sha: "2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b"
 - `git diff --check` -> pass
 
 ## Re-observation Plan
-- Commit U001.
-- Push branch.
-- Re-run `wait_pr_observation.sh` against PR #181 latest head SHA.
-- Treat previous Codex P2 threads as resolved only if they become stale on the new head or the new observation has no blocking unresolved findings.
+- Completed.
+- U001 commit: `cdb4a39c0818d10ee3d151c8cac8fd1b5002fd13`.
+- Re-observation command:
+  - `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 181 --head-sha cdb4a39c0818d10ee3d151c8cac8fd1b5002fd13 --timeout-seconds 1200 --poll-interval-seconds 30 --quiet-seconds 90 --same-fingerprint-count 2 --zero-check-grace-polls 2 --body-mode trigger-window-truncated --out /private/tmp/iss-00180-pr181-observation-2`
+- Re-observation result:
+  - CI: passed, 4/4 checks success.
+  - Latest Codex review signal: fallback issue comment with no major issues.
+  - PR state: open, ready, `MERGEABLE`.
+  - Final JSON: `overall_status=human_gate` because one old review thread remained unresolved outside the latest trigger boundary.
+- Residual risk:
+  - The remaining unresolved thread is an old-thread state limitation rather than a latest-head blocker. The repair commit addressed the finding, two prior threads became outdated, latest Codex review did not re-raise major issues, and all checks passed.
+- Merge-prepared decision:
+  - `merge-prepared=yes` for human merge decision; merge remains a human action.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t161800z-disc-pr-repair-batch.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/discussions/20260611t161800z-disc-pr-repair-batch.md
@@ -1,0 +1,135 @@
+---
+種別: discussion
+ID: "20260611t161800z-disc-pr-repair-batch"
+タイトル: "PR #181 repair batch"
+作成者: "codex"
+作成日: "2026-06-11"
+関連PR: "https://github.com/chemitaro/spec-dock/pull/181"
+head_sha: "2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b"
+---
+
+# PR #181 Repair Batch
+
+## Context
+- PR: https://github.com/chemitaro/spec-dock/pull/181
+- Base: `main`
+- Head branch: `iss-00180-github-token-capability-preflight`
+- Observed head SHA: `2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b`
+- Observation command:
+  - `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 181 --head-sha 2fa6da0d2f55a07eb6c60bbd01d1f7a67234c75b --timeout-seconds 1200 --poll-interval-seconds 30 --quiet-seconds 90 --same-fingerprint-count 2 --zero-check-grace-polls 2 --body-mode trigger-window-truncated --out /private/tmp/iss-00180-pr181-observation`
+- Observation result:
+  - `normalized_status=failed`
+  - `overall_status=failed`
+  - CI: one `provider-tests` failure, one `provider-tests` run still in progress at observation terminal point.
+  - Review: Codex review completed with 3 unresolved P2 comments.
+
+## Concern Catalog
+| concern_id | label | summary | root cause hypothesis |
+|---|---|---|---|
+| C001 | check_failure:provider-tests | Full provider suite fails on stale checked-in dogfooding metadata snapshot | `iss-00180` import added `.meta.json`; snapshot constant was not updated in final focused selector |
+| C002 | check_failure:provider-tests | Full provider suite fails on old wait-contract expectation | PR metadata rate-limit failures are now classified as `github_rate_limited`, but legacy test expects generic `pr_metadata_collection_failed` |
+| C003 | review_feedback:github-capability-classifier | Runtime doctor classifier misses `Resource not accessible by integration` | S99 follow-up fixed PR metadata classifier, but not runtime doctor classifier or checks snapshot helper |
+| C004 | review_feedback:token-source | Runtime doctor reports `gh_saved_auth` when only `GITHUB_TOKEN` is set | `_token_source()` only checks `GH_TOKEN` |
+| C005 | review_feedback:missing-gh | Runtime doctor raises `FileNotFoundError` when `gh` is absent | `_run_fixed_gh()` does not convert missing binary into a diagnostic process-like result |
+| C006 | review_feedback:pr-observation-token-source | PR metadata / trigger write limitations report `gh_saved_auth` when only `GITHUB_TOKEN` is set | PR observation script token-source helpers only checked `GH_TOKEN`; trigger permission matching also missed integration wording |
+
+## Inventory
+| item_id | source | source_link | failure_class | concern_id | validity | risk_class | need_to_fix | disposition | status |
+|---|---|---|---|---|---|---|---|---|---|
+| I001 | GitHub Actions `provider-tests` | `tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` | `check_failure:provider-tests` | C001 | valid | blocking | yes | fix-now | triaged |
+| I002 | GitHub Actions `provider-tests` | `tests/unit/infra/test_init_update.py::TestInitUpdate::test_issue_75_pr_observation_wait_stdout_stderr_progress_and_out_contract` | `check_failure:provider-tests` | C002 | valid | blocking | yes | fix-now | triaged |
+| I003 | Codex review P2 | `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py` line 155 | `review_feedback:github-capability-classifier` | C003 | valid | material-follow-up | yes | fix-now | triaged |
+| I004 | Codex review P2 | `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py` line 141 | `review_feedback:token-source` | C004 | valid | material-follow-up | yes | fix-now | triaged |
+| I005 | Codex review P2 | `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py` line 106 | `review_feedback:missing-gh` | C005 | valid | material-follow-up | yes | fix-now | triaged |
+| I006 | local code-review P2 | `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh` token_source | `review_feedback:pr-observation-token-source` | C006 | valid | material-follow-up | yes | fix-now | triaged |
+| I007 | local code-review P2 | `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh` token_source | `review_feedback:pr-observation-token-source` | C006 | valid | material-follow-up | yes | fix-now | triaged |
+
+## Per-Concern Analysis
+### C001
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: dogfooding `.meta.json` snapshot constant did not include imported issue `iss-00180`.
+- Recommended design: update only the checked-in snapshot constant / expectation, preserving the contract that the dogfooding tree has no legacy `deps.json`.
+
+### C002
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: classifier improvement changed a metadata collection failure from generic to typed rate-limit limitation.
+- Recommended design: update the legacy wait-contract test to expect `github_rate_limited` plus rate-limit fields, if that is now the intentional contract.
+
+### C003
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: runtime doctor and checks collector classifier still miss integration permission wording.
+- Recommended design: add `resource not accessible by integration` to permission-denied classifiers and cover with focused tests.
+
+### C004
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: token source logic handles `GH_TOKEN` but not `GITHUB_TOKEN`.
+- Recommended design: return `GITHUB_TOKEN` when only that env var is present, preserving `GH_TOKEN` precedence.
+
+### C005
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: missing `gh` binary escapes as `FileNotFoundError`.
+- Recommended design: convert missing binary to a diagnostic with `auth_missing` or equivalent prerequisite-unavailable status, without treating it as structural doctor failure.
+
+### C006
+- Validity: valid.
+- Need-to-fix: yes.
+- Root cause: runtime doctor and checks helper were fixed for `GITHUB_TOKEN`, but PR metadata and trigger write helpers still used the old `GH_TOKEN`-only source logic.
+- Recommended design: use the same `GH_TOKEN` -> `GITHUB_TOKEN` -> `gh_saved_auth` precedence in all PR observation token-source helpers.
+
+## Repair Queue
+| unit_id | covered_items | owner | status | validation |
+|---|---|---|---|---|
+| U001 | I001-I007 | dev-coder | implemented | focused tests, full `tests/unit/infra/test_init_update.py`, runtime doctor suite, mirror diffs, `validate`, `git diff --check` |
+
+## Unit Discussion Plan
+- A separate repair unit is not necessary because the five items are a single bounded PR repair pass and all changes are within iss-00180's existing surfaces:
+  - runtime doctor GitHub capability adapter and tests
+  - PR observation checks/snapshot scripts and tests
+  - checked-in dogfooding metadata snapshot
+  - provider/dogfooding mirrors
+
+## Stop Conditions
+- Stop for human decision if fixing requires broad GitHub API scanning, credential repair, live GitHub tests, changing workflow permissions, resolving review threads, or PR merge.
+
+## Merge-Prepared Gate
+- Required before merge-prepared:
+  - U001 implemented and committed.
+  - Branch pushed.
+  - PR observation rerun on latest head SHA.
+  - No required check failure remains.
+  - Codex review findings are stale/resolved by newer commit or no blocking unresolved findings remain.
+  - Any remaining limitation is explicitly classified and not hidden.
+
+## Implementation Result
+- U001 status: implemented, commit pending.
+- I001: fixed by adding `iss-00180` checked-in dogfooding `.meta.json` path and `depends_on=[]` expectation.
+- I002: fixed by updating the wait-contract test to expect typed `github_rate_limited` / `rate_limited` / `wait_or_retry_later`.
+- I003: fixed by classifying `Resource not accessible by integration` as permission denied in runtime doctor and PR observation checks helper.
+- I004: fixed by adding `GITHUB_TOKEN` token source with `GH_TOKEN` precedence.
+- I005: fixed by converting missing `gh` binary into `auth_missing` diagnostic instead of letting `FileNotFoundError` escape.
+- I006: fixed by adding `GITHUB_TOKEN` token source handling to PR metadata limitation output with `GH_TOKEN` precedence.
+- I007: fixed by adding `GITHUB_TOKEN` token source handling to trigger write limitation output with `GH_TOKEN` precedence and classifying trigger write `Resource not accessible by integration` as permission denied.
+
+## Validation Result
+- `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 41 passed
+- `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_issue_75_pr_observation_wait_stdout_stderr_progress_and_out_contract -q` -> 1 passed
+- `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json -q` -> 1 passed
+- `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_issue_180_s02_checks_collector_maps_integration_permission_denied -q` -> 1 passed
+- `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and (pr_metadata or trigger)'` -> 7 passed, 331 deselected
+- `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and trigger'` -> 4 passed, 334 deselected
+- `uv run pytest tests/unit/infra/test_init_update.py -q` -> 338 passed
+- `diff -qr -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime` -> clean
+- `diff -qr -x __pycache__ src/spec_dock/assets/install_root/.agents/skills/github-pr-observation .agents/skills/github-pr-observation` -> clean
+- `./spec-dock/scripts/spec-dock validate` -> ok nodes=92
+- `git diff --check` -> pass
+
+## Re-observation Plan
+- Commit U001.
+- Push branch.
+- Re-run `wait_pr_observation.sh` against PR #181 latest head SHA.
+- Treat previous Codex P2 threads as resolved only if they become stale on the new head or the new observation has no blocking unresolved findings.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/plan.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/plan.md
@@ -3,267 +3,302 @@
 ID: "iss-00180"
 タイトル: "Github Token Capability Preflight"
 関連GitHub: ["#180"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-11"
 依存: ["requirement.md", "design.md"]
 親: ["epic-00067", "init-local-00003"]
 ---
 
-# iss-00180 Github Token Capability Preflight — 実装計画（実行契約 / Execution Contract）
-
-> このテンプレートは executable scaffold です。`plan.md` は計画済み契約（planned contract）と、実装者が step を上から順に実行できる command queue を書く場所です。実行結果、逸脱、発見された tests、reviewer verdict、commit/no-op evidence は `report.md` の観測証跡台帳（observed evidence ledger）に記録する。workflow authority は skills / `workflow_issue.md` が持ち、Issue 計画の field semantics と詳しい書き方は `phase_plan_issue.md` と `docs/authoring/issue-plan.md` を detail-reference として参照する。
+# iss-00180 Github Token Capability Preflight — 実装計画（実行契約）
 
 ## この計画で満たす要件ID
 - AC:
-  - ...
+  - AC-001: `doctor` が明示 target 付きで core capability findings を表示する。
+  - AC-001b: `doctor` が target なしでは PR core probe を失敗扱いしない。
+  - AC-002: PR observation が permission limitation を final JSON に返す。
+  - AC-003: trigger write failure が core read failure と分離される。
+  - AC-004: capability probe が secret を出力しない。
+  - AC-005: capability probe が fixed endpoint set に閉じる。
+  - AC-006: malformed input と capability limitation が分離される。
+  - AC-007: `doctor` が optional extended checks を core と分離して表示する。
 - EC:
-  - ...
+  - EC-001: `GH_TOKEN` missing。
+  - EC-002: auth missing。
+  - EC-003: rate limit / transient failure。
+  - EC-004: partial capability。
+  - EC-005: optional extended check unavailable。
 - 制約:
-  - ...
+  - Provider-side source を先に変更し、必要な dogfooding mirror parity を確認する。
+  - Runtime Python と installed agent scripts の間に import dependency を作らない。
+  - `doctor` standalone probe で write operation を実行しない。
+  - PR observation の stdout final JSON を authority とし、permission limitation を merge-prepared evidence にしない。
+  - Token value / hosts.yml secret / private payload を出力しない。
 
 ## 依存関係から導く実装順序
-- 依存関係の参照元:
-  - `design.md` の依存関係、図、ファイル変更計画
+- 参照元:
+  - `requirement.md`
+  - `design.md`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/`
 - 順序ルール:
-  - prerequisite / lower-dependency slice から先に閉じる
-  - downstream slice は前提が固定されてから置く
+  - 共通語彙と runtime contract を先に固定する。
+  - PR observation scripts は runtime contract に import せず、同じ capability code / status names を再現する。
+  - Provider-side 実装後、dogfooding mirror と docs / skill guidance の差分を確認する。
 - step 依存サマリー:
-  - S01:
-    - 依存:
-    - unblock:
-    - 対象ファイル:
+  - S01: Runtime doctor capability diagnostics。S02/S03 の vocabulary 前提を固定する。
+  - S02: PR observation limitation classification。S01 の語彙と design の status mapping を使う。
+  - S03: Installed asset guidance と dogfooding parity。S01/S02 の provider-side 差分を反映・確認する。
+  - S99: Issue-wide validation / QA / review / handoff。
 
 ## ステップ一覧
 - S01:
-  - 観測可能な振る舞い:
-  - 依存:
-  - unblock:
-  - 対象ファイル:
-  - 閉じる要件:
-  - レビューゲート:
+  - 観測可能な振る舞い: `spec-dock doctor` が fixed GitHub capability diagnostics を structural findings と分離して返す。
+  - 依存: requirement / design の core / optional capability model。
+  - unblock: PR observation 側と共通に使う capability code / status vocabulary。
+  - 対象ファイル: runtime application / ports / infra / command / presentation / doctor tests。
+  - 閉じる要件: AC-001, AC-001b, AC-004, AC-005, AC-007, EC-001, EC-002, EC-003, EC-004, EC-005。
+  - レビューゲート: code-reviewer pass。
 - S02:
-  - ...
+  - 観測可能な振る舞い: `github-pr-observation` が read permission failure と trigger write failure を final JSON limitation として分類する。
+  - 依存: S01 の語彙、design の status mapping。
+  - unblock: merge-preparer が permission issue を semantic non-success として扱う証跡。
+  - 対象ファイル: provider-side `github-pr-observation` scripts / script tests。
+  - 閉じる要件: AC-002, AC-003, AC-004, AC-005, AC-006, EC-002, EC-003, EC-004。
+  - レビューゲート: code-reviewer pass。
+- S03:
+  - 観測可能な振る舞い: shipped asset guidance と dogfooding mirror が provider-side 実装と矛盾しない。
+  - 依存: S01, S02。
+  - unblock: installed workspace / dogfooding workspace での利用可能性。
+  - 対象ファイル: `SKILL.md`、dogfooding mirrors、parity tests / inspection。
+  - 閉じる要件: AC-004, AC-005, AC-006, provider / mirror parity 制約。
+  - レビューゲート: spec-reviewer または code-reviewer pass。
+- S99:
+  - 観測可能な振る舞い: issue 全体が requirement / design / plan / implementation / tests / docs の整合を満たす。
+  - 依存: S01-S03。
+  - unblock: PR 作成・merge-preparer へ進める状態。
+  - 対象ファイル: issue-wide diff。
+  - 閉じる要件: 全 AC/EC、final gate。
+  - レビューゲート: qa-reviewer pass、code-reviewer pass、spec-reviewer pass。
 
 ## 要件 ↔ ステップ対応
 - AC-001 -> S01
-- EC-001 -> S02
+- AC-001b -> S01
+- AC-002 -> S02
+- AC-003 -> S02
+- AC-004 -> S01, S02, S03
+- AC-005 -> S01, S02, S03
+- AC-006 -> S02, S03
+- AC-007 -> S01
+- EC-001 -> S01
+- EC-002 -> S01, S02
+- EC-003 -> S01, S02
+- EC-004 -> S01, S02
+- EC-005 -> S01
 
-## 仕様固定クロージャ索引（Spec-Locked Closure Index）
-
-> これは Issue 全体のテスト一覧ではなく、仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の step-local obligation と concrete seeds は各 implementation step の `具体テストケース一覧` に置く。
-
-| 識別子（ID） | ステップ（step） | スライス（slice） | 種別（type） | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル（evidence level） | クロージャ証跡（closure evidence） |
+## 仕様固定クロージャ索引
+| ID | step | slice | type | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | evidence level | closure evidence |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | 受け入れ（acceptance） | AC-001 | ... | ... | 仕様 drift（spec drift） | yes | red-required | ステップ完了証跡（report step closure） |
-| tc-002 | S01 | <behavior> | 否定系（negative） | EC-001 | ... | ... | 沈黙失敗（silent failure） | yes | inspect-only | ステップ完了証跡（report step closure） |
-
-- 証跡レベル（evidence level）:
-  - red-required: 実装前に失敗する新規 test / characterization を固定する。
-  - covered-existing: 既存 test が対象 behavior を検出できる根拠を固定する。
-  - inspect-only: docs / template / config などを inspection、structural assertion、review evidence で閉じる。
-  - manual-required: 自動化できない確認手順、期待結果、記録先を固定する。
-- 詳細化方針:
-  - 件数ではなく、AC、changed contract、failure mode、regression risk、invariant、manual / integration risk から必要な obligation を決める。
-  - private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+| tc-001 | S01 | doctor-targeted-core | acceptance | AC-001, AC-004 | Target 付き doctor が `check_runs_read` permission denied を secret なしで診断する | `GH_TOKEN` source、repo/pr/head SHA、fake gateway permission denied | opaque unknown / secret leak | yes | red-required | S01 report closure |
+| tc-002 | S01 | doctor-no-target | acceptance | AC-001b | Target なし doctor は PR core probe を `target_unavailable` / `skipped` とし exit 0 structural success を維持する | 通常 `spec-dock doctor` | false permission failure | yes | red-required | S01 report closure |
+| tc-003 | S01 | doctor-optional-extended | acceptance | AC-007, EC-005 | `actions_read` / `issue_comments_read` は optional group に分離され、core pass/fail を汚さない | fake gateway partial optional failure | core/optional conflation | yes | red-required | S01 report closure |
+| tc-004 | S01 | fixed-runtime-surface | negative | AC-005 | doctor は raw endpoint / method / jq / header / raw gh args を受け付けない | CLI parser / command args inspection | arbitrary API checker 化 | yes | inspect-only | S01 report closure |
+| tc-005 | S01 | doctor-auth-source | edge | EC-001, EC-002 | `GH_TOKEN` missing は `gh_saved_auth` または `unknown` source として表示し、auth missing は `auth_missing` として permission denied と区別する | fake gateway saved-auth fallback / auth-missing | auth state misdiagnosis | yes | red-required | S01 report closure |
+| tc-006 | S01 | doctor-transient-classification | edge | EC-003 | rate limit / transient / schema unavailable を `rate_limited` / `transient_unknown` / `schema_unavailable` として permission denied と区別する | fake gateway classified failures | retryable or schema issue misdiagnosed as token permission | yes | red-required | S01 report closure |
+| tc-007 | S02 | checks-permission-limitation | acceptance | AC-002, EC-004 | checks/status/rollup permission denied は `exit_code=0` で final JSON に `github_token_permission_denied`、`normalized_status=unknown`、`overall_status=unknown`、`recommended_next_action=fix_github_token_permissions` を返す | stubbed `gh api` / `gh pr view` permission denied | merge-prepared false positive / downstream process failure | yes | red-required | S02 report closure |
+| tc-008 | S02 | trigger-write-limitation | acceptance | AC-003 | trigger comment permission denied は `exit_code=0` で `trigger_comment_write` limitation と `human_gate` を返す | stubbed trigger script failure | blind retry / read failure conflation / downstream process failure | yes | red-required | S02 report closure |
+| tc-009 | S02 | script-auth-transient-classification | edge | EC-002, EC-003 | PR observation scripts classify auth missing, rate limit, transient, and schema unavailable separately from permission denied | stubbed `gh` auth/rate/transient/schema failures | all GitHub failures collapsed into permission issue | yes | red-required | S02 report closure |
+| tc-010 | S02 | script-error-semantics | negative | AC-006 | malformed input / JSON construction failure は non-zero process error で、capability limitation と混同しない | invalid repo/pr/head or malformed fixture | misuse hidden as permission issue | yes | red-required | S02 report closure |
+| tc-011 | S02 | script-secret-redaction | negative | AC-004 | stdout/stderr JSON に token value / raw secret-bearing stderr を出さない | stub stderr containing token-like marker | credential leak | yes | red-required | S02 report closure |
+| tc-012 | S03 | guidance-and-parity | inspect | AC-005, provider parity | SKILL guidance / provider asset / dogfooding mirror が fixed contract と一致する | provider vs mirror diff / installed asset tests | shipped behavior drift | yes | inspect-only | S03 report closure |
+| tc-013 | S99 | issue-wide-quality | final gate | 全 AC/EC | focused tests、validation、reviewer gates が pass する | issue-wide diff | incomplete handoff | yes | manual-required | S99 report closure |
 
 ## レビュー / QA ゲート方針
-- RG1 step review:
-  - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only）
-  - pass 条件: review_status: pass
-- QG1 final QA:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage、missing high-value tests、manual / integration test 要否
-- SG1 final spec review:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / docs 整合
+- 各 implementation step:
+  - dev-coder に bounded task として委任する。
+  - step-local 実装後、fresh code-reviewer を pass まで回す。
+- S03 が docs / skill guidance only で閉じる場合:
+  - doc-writer または dev-coder に委任し、fresh spec-reviewer または code-reviewer を pass まで回す。
+- S99:
+  - qa-reviewer で obligation coverage を確認する。
+  - code-reviewer で issue-wide integrated diff を確認する。
+  - spec-reviewer で requirement / design / plan / report / implementation evidence の整合を確認する。
 
 ## 実行ルール（全ステップ共通）
-- 各 implementation step は原則として 1 behavior slice / 1 review scope / 1 commit boundary とする。
-- `plan.md` には planned requirements、evidence destination、closure 条件だけを書く。observed result は `report.md` に書く。
-- docs-only / inspect-only / manual-required step は code test 前提にせず、代替 evidence path と rationale を implementation 前に固定する。
-- implementation 中に新しい仕様、bug class、外部 contract risk、未計画の closure が見つかった場合は、report 記録だけで足りるか、plan amendment と re-review が必要かを判断する。
+- `report.md` に実行結果、reviewer verdict、test evidence、closure delta を記録する。
+- 実装は provider-side source of truth を優先し、dogfooding mirror は parity 確認または必要な refresh として扱う。
+- Capability probe の fixed endpoint set を広げる発見があれば、実装を止めて plan / design amendment と再レビューに戻す。
+- Token source label は出してよいが、token value、hosts.yml secret、private payload は出してはならない。
+- Live GitHub API に依存する自動テストは禁止。`gh` stub / fake gateway / fixture で閉じる。
 
-## 実装ステップ
-
-### 実装ステップ S01 — <観測可能な振る舞い>
-- 振る舞いの目標（behavior goal）:
-  - ...
+## 実装ステップ S01 — Runtime doctor capability diagnostics
+- 振る舞いの目標:
+  - `doctor` に GitHub capability diagnostics channel を追加し、structural `DoctorFinding` / `DoctorResult.ok` と分離する。
 - design 参照:
-  - ...
+  - `Capability Result Model`
+  - `インターフェース契約`
+  - `ディレクトリ / ファイル変更計画`
 - 依存:
-  - ...
+  - なし。最初に実施する。
 - unblock:
-  - ...
+  - S02/S03 が使う common vocabulary。
 - 対象ファイル:
-  - ...
-- 計画済み契約（planned contract）:
-  - scope:
-    - 実装・文書化する範囲:
-  - テスト義務（test obligation）:
-    - closure id:
-      - tc-001
-    - coverage rationale:
-      - AC / changed contract / failure mode / regression risk / invariant / manual risk から必要性を書く:
-  - Red / 代替証跡の要件:
-    - red-required / covered-existing:
-      - 実装前に確認する failing test、characterization、または既存 test sensitivity:
-    - docs-only / inspect-only / manual-required:
-      - code test を置かない理由:
-      - 代替 evidence path:
-      - manual 手順と期待結果:
-  - 実装範囲（implementation scope）:
-    - allowed paths:
-      - ...
-    - forbidden changes:
-      - ...
-  - Green 検証:
-    - command / inspection / manual evidence:
-      - ...
-  - Refactor / cleanup ガードレール:
-    - 目的:
-    - 禁止する広がり:
-  - closure 証跡要件:
-    - Step Contract Closure:
-    - Test Contract Closure:
-    - Closure Coverage:
-  - report 証跡の記録先:
-    - `report.md` の対象 section / ledger:
-  - amendment trigger（plan amendment が必要になる契機）:
-    - plan amendment と re-review が必要になる発見:
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py`
+  - `tests/cli_runtime/test_runtime_doctor_s04.py`
+- planned contract:
+  - Add dataclasses / Literals for GitHub capability diagnostics with fixed codes and statuses from `design.md`.
+  - Add `GitHubCapabilityGateway` Protocol and `Ports.github_capability_gateway`.
+  - Add optional fixed `doctor` args for repo / PR / head SHA and optional extended group; do not add raw API args.
+  - No-target doctor emits skipped / target_unavailable diagnostic without structural failure.
+  - Fake gateway tests must prove permission denied, optional extended separation, source label, and no secret output.
+- implementation scope:
+  - allowed paths: listed S01 target files only.
+  - forbidden changes: PR observation scripts, unrelated doctor findings, arbitrary GitHub scanner, live network tests.
+- concrete tests:
+  - `tc-001`: fake gateway returns `check_runs_read` permission denied with `token_source=GH_TOKEN`; CLI/app output includes capability/status/api/source and excludes token value.
+  - `tc-002`: no target returns skipped / target_unavailable diagnostic and keeps structural exit semantics.
+  - `tc-003`: optional `actions_read` / `issue_comments_read` are rendered separately and do not change core result.
+  - `tc-004`: parser / command assertions reject absence of raw endpoint/method/jq/header surface by inspection or negative invocation.
+  - `tc-005`: `GH_TOKEN` missing renders `gh_saved_auth` or `unknown` source without secret; unauthenticated `gh` path renders `auth_missing`, not `permission_denied`.
+  - `tc-006`: rate limit / transient / schema-unavailable gateway results render distinct statuses and remediation hints.
+- green verification:
+  - `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`
+  - focused `rg` inspection for forbidden raw API argument names in doctor command surface.
+- delegation contract:
+  - delegated role: dev-coder.
+  - input docs: `requirement.md`, `design.md`, `plan.md`.
+  - required output: changed files, tests run, closure evidence for `tc-001`-`tc-006`, unresolved risks.
+  - stop conditions: target fields cannot be modeled without broad command redesign; capability probe needs endpoint outside fixed set; secret redaction cannot be asserted.
+- step gate:
+  - reviewer: code-reviewer.
+  - pass condition: `review_status: pass`.
 
-#### 委任契約（delegation contract）
-- 委任ロール（delegated role）:
-  - dev-coder / doc-writer / other named worker / N/A
-- 入力 docs:
-  - `requirement.md`
-  - `design.md`
-  - `plan.md`
-  - workflow / authoring docs:
-  - current target files:
-- 許可 paths:
-  - ...
-- 禁止 changes:
-  - ...
-- 受け入れ条件:
-  - closure id / step close condition:
-- 必須 tests または docs-only verification:
-  - targeted command / inspection / docs diff / manual evidence:
-- reviewer focus:
-  - code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only docs/spec alignment）
-- 必須出力（output required）:
-  - changed files:
-  - verification result:
-  - report evidence to update:
-  - unresolved risks:
-- 停止条件（stop conditions）:
-  - input docs conflict / path outside allowed scope / verification cannot run / acceptance cannot be met:
+## 実装ステップ S02 — PR observation permission limitation classification
+- 振る舞いの目標:
+  - `github-pr-observation` scripts が token permission failure を final JSON limitation として分類し、process success と semantic non-success を分離する。
+- design 参照:
+  - `Status policy`
+  - `PR observation final JSON`
+  - `シーケンス差分`
+- 依存:
+  - S01 の vocabulary。
+- unblock:
+  - merge-preparer / orchestrator が permission issue を machine-readable に判断できる。
+- 対象ファイル:
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh`
+  - `tests/unit/infra/test_init_update.py`
+- planned contract:
+  - Permission denied from checks/status/rollup read produces `github_token_permission_denied` limitation with capability, API, token source, `secret_redacted=true`, `stderr_sha256`, `recommended_next_action=fix_github_token_permissions`.
+  - Read permission failure maps to `normalized_status=unknown`, `overall_status=unknown`, `observation_complete=false`.
+  - Trigger comment write permission failure maps to `capability=trigger_comment_write`, `normalized_status=human_gate`, `overall_status=human_gate`.
+  - Malformed input / script misuse / JSON construction failure remains non-zero and is not encoded as permission limitation.
+- implementation scope:
+  - allowed paths: listed S02 target files only.
+  - forbidden changes: raw endpoint/method args, extra write probes, retired `pr-monitor`, live GitHub tests.
+- concrete tests:
+  - `tc-007`: stubbed `gh api check-runs` or `gh pr view statusCheckRollup` permission denied exits 0 when final JSON is built, and yields final JSON limitation plus `unknown` semantic status.
+  - `tc-008`: stubbed trigger comment permission denied exits 0 when final JSON is built, and yields `trigger_comment_write` limitation plus `human_gate`.
+  - `tc-009`: stubbed auth missing, rate limit, transient, and schema-unavailable cases are not misclassified as permission denied.
+  - `tc-010`: invalid inputs / malformed JSON remain non-zero process errors and do not claim token limitation.
+  - `tc-011`: token-like stderr fixture is redacted or hashed; final JSON never includes the raw token marker.
+- green verification:
+  - `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or codex_review or checks_snapshot'`
+  - targeted shell fixture tests already housed in `test_init_update.py`.
+- delegation contract:
+  - delegated role: dev-coder.
+  - input docs: `requirement.md`, `design.md`, `plan.md`, `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`.
+  - required output: changed files, tests run, final JSON examples, unresolved risks.
+  - stop conditions: status enum conflict, JSON compatibility break, needing arbitrary API surface.
+- step gate:
+  - reviewer: code-reviewer.
+  - pass condition: `review_status: pass`.
 
-#### 具体テストケース一覧
+## 実装ステップ S03 — Guidance, shipped asset, and dogfooding parity
+- 振る舞いの目標:
+  - Shipped guidance and dogfooding mirror expose the same fixed contract as provider-side implementation.
+- design 参照:
+  - `ディレクトリ / ファイル変更計画`
+  - `テスト戦略`
+- 依存:
+  - S01, S02。
+- unblock:
+  - Consumer repos and this dogfooding repo can run the installed skill/runtime consistently.
+- 対象ファイル:
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - `.agents/skills/github-pr-observation/`
+  - `spec-dock/scripts/spec_dock_runtime/`
+  - installer / parity tests in `tests/unit/infra/test_init_update.py` if needed.
+- planned contract:
+  - SKILL guidance explains permission limitation semantics without turning the scripts into arbitrary permission scanners.
+  - Dogfooding mirror either matches provider-side changed assets or the report records why sync is intentionally deferred.
+  - Parity / install tests cover changed shipped files where practical.
+- implementation scope:
+  - allowed paths: listed S03 target files and focused parity assertions.
+  - forbidden changes: unrelated workflow text, broad docs rewrite, credential instructions that imply token storage or secret disclosure.
+- concrete tests:
+  - `tc-012`: inspect provider vs dogfooding mirror and run parity / install test path that covers installed `github-pr-observation` assets.
+- green verification:
+  - `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'`
+  - `git diff -- src/spec_dock/assets/install_root/.agents/skills/github-pr-observation .agents/skills/github-pr-observation`
+- delegation contract:
+  - delegated role: dev-coder if code/test parity changes are needed; doc-writer only if guidance-only update is needed.
+  - input docs: `requirement.md`, `design.md`, `plan.md`.
+  - required output: changed files, parity evidence, tests/inspection run, unresolved risks.
+  - stop conditions: mirror sync would overwrite unrelated user changes; guidance needs new scope not in requirement.
+- step gate:
+  - reviewer: code-reviewer for code/test/scaffold changes; spec-reviewer for guidance-only changes.
+  - pass condition: `review_status: pass`.
 
-> この欄は full test inventory ではありません。step-local obligation と concrete red / characterization / inspect / manual seeds を、実装前に固定するための欄です。
-
-- `tc-s01-001` acceptance: <短い説明>
-  - 前提: ...
-  - 操作: ...
-  - 期待結果: ...
-  - 失敗検出: ...
-  - 検証方法: ...
-  - 関連 closure id: tc-001
-
-- `tc-s01-002` inspect-only / manual-required: <短い説明>
-  - テスト不要理由: <自動テスト不要の理由>
-  - 代替検証方法: <確認手順>
-  - 期待結果: <期待される状態>
-  - 記録先: <証跡の保存先>
-  - 関連 closure id: tc-002
-
-#### ステップ完了契約（step closure contract）
-- closure id:
-  - tc-001
-- close 条件:
-  - ...
-- 検証 evidence:
-  - targeted command / inspection / manual evidence:
-- report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-  - Closure Delta:
-- 残リスク:
-  - ...
-
-#### ステップゲート（step gate）
-- step reviewer gate:
-  - reviewer:
-  - review 範囲:
-  - pass 条件: review_status: pass
-  - re-review rule: 指摘を修正し pass まで再実行
-- commit / no-op gate:
-  - closure 状態: committed / approved-no-op
-  - commit 範囲:
-  - no-op の場合の確認対象、差分なし確認コマンド、read-only evidence:
-
-### 実装ステップ Sxx — <次に観測可能な振る舞い>
-- S01 の subsections を複製して記入する。
-- `planned contract`、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`step gate` がない implementation step は implementation-ready ではない。
-
-### ドキュメント影響の解消ステップ S90（docs impact resolution / docs refresh）
+## 最終品質ゲートステップ S99
+- 振る舞いの目標:
+  - Issue-wide diff is implementation-ready / PR-ready with complete evidence.
+- 依存:
+  - S01-S03 closed.
 - 対象:
-  - docs / templates / README / workflow / skill / migration notes / none
-- 対応:
-  - ...
-- doc update owner:
-  - doc-writer when updates are required
-- spec/doc review:
-  - reviewer: spec-reviewer
-  - pass 条件: docs が requirement / design / plan と整合し、未解決の必須 docs 影響が残っていない
-
-### 最終品質ゲートステップ S99（final quality gate）
-- branch diff 範囲:
-  - ...
-- 必須 validation:
-  - ...
+  - All files changed for `iss-00180`.
+- required validation:
+  - `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`
+  - `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or codex_review or checks_snapshot or checked_in_dogfooding_runtime'`
+  - `./spec-dock/scripts/spec-dock validate`
+  - `git diff --check`
 - final QA gate:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage と integration test 要否
-  - pass 条件: reviewer pass
-- final code review ゲート:
-  - reviewer: code-reviewer
-  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性
-  - pass 条件: review_status: pass
-- final spec review ゲート:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合
-  - pass 条件: reviewer pass
-- final commit gate:
-  - commit 範囲:
-  - final report ledger:
-  - post-commit external evidence destination:
+  - reviewer: qa-reviewer.
+  - scope: AC/EC coverage, missing high-value tests, integration risk.
+  - pass condition: `review_status: pass`.
+- final code review gate:
+  - reviewer: code-reviewer.
+  - scope: issue-wide integrated diff, runtime/script boundaries, secret handling, compatibility.
+  - pass condition: `review_status: pass`.
+- final spec review gate:
+  - reviewer: spec-reviewer.
+  - scope: requirement / design / plan / report / implementation evidence.
+  - pass condition: `review_status: pass`.
+- report evidence:
+  - Record command outputs, reviewer statuses, closure coverage, closure delta, and remaining risk in `report.md`.
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 推奨案:
-  - 影響範囲:
+- なし:
+  - Scope、probe profile、failure semantics、runtime port / adapter、PR observation status mapping は requirement / design review で確定済み。
 
 ## 最終完了条件
 - AC/EC 達成:
-  - ...
+  - All closure IDs `tc-001` through `tc-013` are closed or explicitly amended with reviewer-approved rationale.
 - docs 影響解決:
-  - ...
+  - S03 parity / guidance evidence is recorded.
 - 全 implementation step 完了:
-  - committed / approved-no-op:
+  - S01-S03 are committed or approved-no-op with report evidence.
 - final quality gate pass:
-  - qa-reviewer:
-  - issue-wide code-reviewer:
-  - spec-reviewer:
-- final commit 完了:
-  - ...
-- 必須 closure id 完了:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-- final clean state:
-  - no unintended staged / unstaged changes:
+  - qa-reviewer: pass.
+  - issue-wide code-reviewer: pass.
+  - final spec-reviewer: pass.
+- handoff:
+  - `report.md` contains implementation delegation contracts, reviewer verdicts, validation commands, and PR-ready remaining risks.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -90,7 +90,7 @@ ID: "iss-00180"
 | step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | observed result |
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | S01 | delegated | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; forbidden raw API surface inspection; `git diff --check` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pass: dev-coder implemented S01, follow-up fixed schema classification, code-reviewer pass |
-| S02 | planned delegation | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pending |
+| S02 | delegated | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection; nearby regression selector; `git diff --check` | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pass: dev-coder implemented S02, focused/nearby tests pass, code-reviewer pass after follow-ups |
 | S03 | planned delegation | shipped asset guidance / dogfooding parity | dev-coder or doc-writer | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | parity inspection and focused tests | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pending |
 | S99 | planned review gates | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer | final quality gates | `plan.md` S99 | issue-wide diff | unreviewed completion | required validation commands and reviewer pass | missing closure evidence | gate verdicts / final risk | pending |
 
@@ -101,7 +101,13 @@ ID: "iss-00180"
   - `doctor` command surface は fixed target fields と optional extended flag に限定した。
   - `GitHubCapabilityGateway` port と fixed `gh` CLI adapter を追加した。
   - `tc-001`-`tc-006` を focused runtime tests で閉じた。
-- 次回実行時は `plan.md` S02 から開始する。
+- S02 complete:
+  - PR observation scripts が GitHub token permission denied を machine-readable limitation として返すようにした。
+  - Checks / statuses / statusCheckRollup の read permission failure は `unknown` semantic non-success として扱う。
+  - Fixed trigger comment write permission failure は `trigger_comment_write` limitation と `human_gate` として扱う。
+  - auth missing / rate limit / transient / schema unavailable / invalid input を permission denied と分離した。
+  - `tc-007`-`tc-011` を focused script tests で閉じた。
+- 次回実行時は `plan.md` S03 から開始する。
 
 ## 実行コマンド / 結果
 ```bash
@@ -116,6 +122,19 @@ rg -n -- '--(endpoint|method|jq|header|raw|api|graphql)|raw gh|GraphQL|headers' 
 
 git diff --check
 # pass
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'
+# 6 passed
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or codex_review or checks_snapshot'
+# 6 passed
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 or issue_75_pr_observation_checks_collector or issue_170_pr_observation_checks_collector or issue_176_s01_trigger_helper or issue_176_s04_wait'
+# 41 passed
+
+uv run pytest tests/unit/infra/test_init_update.py
+# 326 passed / 4 failed
+# failures are outside S02 allowed scope: dogfooding mirror/S03 parity and existing dogfooding snapshot mismatch
 ```
 
 ## テスト駆動開発証跡
@@ -124,11 +143,17 @@ git diff --check
 | S01 | Red / characterization | tc-001-tc-006 red-required / inspect-only | S01 closure tests failed before capability contract / port implementation | dev-coder focused test run | fail as expected | `GitHubCapabilityDiagnostic` / `Ports.github_capability_gateway` missing caused failures |
 | S01 | Green | tc-001-tc-006 pass | Runtime doctor focused suite passed | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | 34 passed |
 | S01 | Refactor / guardrail | forbidden raw API surface absent | Implementation files have no forbidden raw API args | `rg -n -- ... commands/doctor.py application/doctor.py infra/github_capability_cli.py` | pass | Test forbidden-list strings exist only in tests |
+| S02 | Red / characterization | tc-007-tc-011 red-required | Focused `issue_180_s02` tests failed before implementation | dev-coder focused test run | fail as expected | 4 failed / 1 passed for planned permission/secret/status semantics gaps |
+| S02 | Green | tc-007-tc-011 pass | Focused and nearby PR observation suites passed | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'`; nearby selector | pass | 6 passed; 41 passed nearby |
+| S02 | Reviewer follow-up | code-reviewer P2 generic permission denied | Generic `permission denied` fixture failed before follow-up and passed after classifier broadening | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | `tc-007` strengthened for S01/S02 classifier parity |
+| S02 | Reviewer follow-up | code-reviewer P2 trigger generic permission denied | Generic `permission denied while posting issue comment` fixture failed before follow-up and passed after trigger classifier broadening | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | `tc-008` strengthened for read/trigger classifier parity |
+| S02 | Refactor / guardrail | fixed contract retained | Diff stayed within S02 allowed paths; no raw endpoint/method args added | diff inspection; `git diff --check` | pass | Dogfooding mirror intentionally left for S03 |
 
 ## ステップ契約の完了証跡
 | step | closure ids | close condition from plan | observed evidence | result | notes |
 |---|---|---|---|---|---|
 | S01 | tc-001-tc-006 | Runtime doctor capability diagnostics implemented, verified, and reviewed | Tests `34 passed`; forbidden surface inspection pass; code-reviewer pass | pass | S01 scope complete |
+| S02 | tc-007-tc-011 | PR observation permission limitation classification implemented, verified, and reviewed | Focused tests 6 passed; nearby regression 41 passed; code-reviewer pass after generic permission follow-ups | pass | S02 provider-side scope complete; S03 parity pending |
 
 ## テスト契約の完了証跡
 | closure id / test id | step | required | evidence level | pre-implementation evidence | verification command or path | observed result | notes |
@@ -139,6 +164,11 @@ git diff --check
 | tc-004 | S01 | yes | inspect-only | Parser surface lacked explicit fixed GitHub args before S01 | parser negative test; implementation `rg` inspection | pass | No raw endpoint / method / jq / header / raw surface in implementation |
 | tc-005 | S01 | yes | red-required | Added test failed before implementation due missing auth diagnostics | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `auth_missing` remains distinct from `permission_denied` and token source is non-secret |
 | tc-006 | S01 | yes | red-required | Initial implementation classified `Unknown JSON field` as `transient_unknown`; follow-up red evidence reproduced it | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | rate limit / transient / schema unavailable render distinctly; `Unknown JSON field` maps to `schema_unavailable` |
+| tc-007 | S02 | yes | red-required | Focused S02 test failed before implementation because checks permission denied stayed generic | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | check-runs permission denied exits 0 and yields `github_token_permission_denied`, `unknown`, and `fix_github_token_permissions` |
+| tc-008 | S02 | yes | red-required | Focused S02 test failed before implementation because trigger permission denied leaked raw marker and did not map to human gate | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | trigger comment permission denied exits 0 and yields `trigger_comment_write` / `human_gate` |
+| tc-009 | S02 | yes | red-required | Focused S02 test failed before implementation because non-permission failures collapsed into generic failure | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | auth/rate/transient/schema are distinct and not `github_token_permission_denied` |
+| tc-010 | S02 | yes | red-required | Existing usage contract characterized invalid input as exit 64 | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | invalid `--head-sha` remains usage error and emits no token limitation |
+| tc-011 | S02 | yes | red-required | Focused S02 tests failed before implementation because token marker could leak in trigger helper JSON | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | raw token-like stderr marker absent; limitation includes `stderr_sha256` and `secret_redacted=true` |
 
 ## クロージャ網羅
 | closure id | step | verification evidence | result | notes |
@@ -149,21 +179,31 @@ git diff --check
 | tc-004 | S01 | `test_doctor_command_surface_rejects_raw_github_api_arguments`; implementation `rg` | pass | Fixed command surface only |
 | tc-005 | S01 | `test_doctor_distinguishes_auth_missing_from_permission_denied_without_gh_token` | pass | Auth missing and token source handled without secret |
 | tc-006 | S01 | `test_doctor_renders_rate_transient_and_schema_statuses_distinctly`; `test_github_capability_cli_classifies_unknown_json_field_as_schema_unavailable` | pass | EC-003 classification covered |
+| tc-007 | S02 | `test_issue_180_s02_snapshot_maps_check_runs_permission_denied_to_unknown_limitation` | pass | Read permission failure semantic non-success covered |
+| tc-008 | S02 | `test_issue_180_s02_wait_maps_trigger_comment_permission_denied_to_human_gate` | pass | Trigger write failure semantic non-success covered |
+| tc-009 | S02 | `test_issue_180_s02_checks_collector_keeps_non_permission_failures_distinct` | pass | Auth/rate/transient/schema classification covered |
+| tc-010 | S02 | `test_issue_180_s02_checks_collector_invalid_input_remains_usage_error` | pass | Usage error remains non-zero |
+| tc-011 | S02 | `test_issue_180_s02_trigger_helper_classifies_comment_permission_denied_without_secret`; snapshot permission test | pass | Secret marker excluded from final JSON |
 
 ## クロージャ差分
 | change | closure id | test id alias | resolved closure id | reason | plan amendment required | re-review required |
 |---|---|---|---|---|---|---|
 | none | tc-001-tc-006 | S01 runtime doctor focused tests | tc-001-tc-006 | Planned closure ids closed as written | no | no |
+| changed | tc-007 | generic permission denied fixture | tc-007 | code-reviewer P2 requested parity with S01 runtime classifier | no | yes, S02 code-reviewer re-review |
+| changed | tc-008 | generic trigger permission denied fixture | tc-008 | code-reviewer P2 requested parity with read-side classifier | no | yes, S02 code-reviewer re-review |
+| none | tc-009-tc-011 | S02 PR observation focused tests | tc-009-tc-011 | Planned closure ids closed as written | no | no |
 
 ## 委任 worker 証跡
 | step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
 |---|---|---|---|---|---|---|---|
 | S01 | dev-coder | Added runtime GitHub capability diagnostics, fixed CLI probe port/adapter, added focused tests; follow-up fixed `Unknown JSON field` schema classification | `application/contracts.py`; `application/ports.py`; `application/doctor.py`; `commands/doctor.py`; `cli/bootstrap.py`; `infra/github_capability_cli.py`; `presentation/cli_text.py`; `tests/cli_runtime/test_runtime_doctor_s04.py` | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 34 passed; `git diff --check` -> pass | code-reviewer pass after follow-up | Live GitHub API behavior intentionally not tested per plan; S02 remains pending | accepted |
+| S02 | dev-coder | Added PR observation permission limitation classification for checks/status/rollup and trigger comment write, with focused script tests; follow-ups broadened generic `permission denied` matching for read and trigger paths | `fetch_pr_checks_snapshot.sh`; `fetch_pr_observation_snapshot.sh`; `trigger_codex_review.sh`; `wait_pr_observation.sh`; `tests/unit/infra/test_init_update.py` | `issue_180_s02` -> 6 passed; nearby PR observation selector -> 41 passed; `git diff --check` -> pass | code-reviewer pass after follow-ups | Full `test_init_update.py` has 4 failures in S03 parity / existing dogfooding snapshot scope | accepted |
 
 ## ステップ commit ゲート
 | step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
 |---|---|---|---|---|---|---|---|---|
 | S01 | ready_to_commit | Runtime doctor capability diagnostics and S01 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
+| S02 | ready_to_commit | Provider-side PR observation permission limitation classification and S02 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
 
 ## 最終品質ゲート
 | gate | scope | result | evidence | next action |
@@ -171,4 +211,4 @@ git diff --check
 | authoring requirement gate | `requirement.md` | pass | fresh spec-reviewer pass | complete |
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
-| issue execution gate | S01-S99 | in progress | S01 complete; S02 pending | start S02 |
+| issue execution gate | S01-S99 | in progress | S01 complete; S02 complete; S03 pending | start S03 |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -89,19 +89,81 @@ ID: "iss-00180"
 ## 実装委任ゲート
 | step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | observed result |
 |---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | planned delegation | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pending |
+| S01 | delegated | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; forbidden raw API surface inspection; `git diff --check` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pass: dev-coder implemented S01, follow-up fixed schema classification, code-reviewer pass |
 | S02 | planned delegation | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pending |
 | S03 | planned delegation | shipped asset guidance / dogfooding parity | dev-coder or doc-writer | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | parity inspection and focused tests | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pending |
 | S99 | planned review gates | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer | final quality gates | `plan.md` S99 | issue-wide diff | unreviewed completion | required validation commands and reviewer pass | missing closure evidence | gate verdicts / final risk | pending |
 
 ## 実装記録
-- 実装未着手。
-- 次回実行時は `plan.md` S01 から開始する。
+- S01 complete:
+  - Runtime doctor capability diagnostics を追加した。
+  - `DoctorResult.ok` / structural `DoctorFinding` と GitHub capability diagnostics を分離した。
+  - `doctor` command surface は fixed target fields と optional extended flag に限定した。
+  - `GitHubCapabilityGateway` port と fixed `gh` CLI adapter を追加した。
+  - `tc-001`-`tc-006` を focused runtime tests で閉じた。
+- 次回実行時は `plan.md` S02 から開始する。
 
 ## 実行コマンド / 結果
 ```bash
-# authoring validation commands are recorded after this report update.
+uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py
+# 34 passed
+
+rg -n -- '--(endpoint|method|jq|header|raw|api|graphql)|raw gh|GraphQL|headers' \
+  src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py \
+  src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py \
+  src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
+# no matches
+
+git diff --check
+# pass
 ```
+
+## テスト駆動開発証跡
+| step | phase | planned evidence | observed evidence | method | result | notes |
+|---|---|---|---|---|---|---|
+| S01 | Red / characterization | tc-001-tc-006 red-required / inspect-only | S01 closure tests failed before capability contract / port implementation | dev-coder focused test run | fail as expected | `GitHubCapabilityDiagnostic` / `Ports.github_capability_gateway` missing caused failures |
+| S01 | Green | tc-001-tc-006 pass | Runtime doctor focused suite passed | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | 34 passed |
+| S01 | Refactor / guardrail | forbidden raw API surface absent | Implementation files have no forbidden raw API args | `rg -n -- ... commands/doctor.py application/doctor.py infra/github_capability_cli.py` | pass | Test forbidden-list strings exist only in tests |
+
+## ステップ契約の完了証跡
+| step | closure ids | close condition from plan | observed evidence | result | notes |
+|---|---|---|---|---|---|
+| S01 | tc-001-tc-006 | Runtime doctor capability diagnostics implemented, verified, and reviewed | Tests `34 passed`; forbidden surface inspection pass; code-reviewer pass | pass | S01 scope complete |
+
+## テスト契約の完了証跡
+| closure id / test id | step | required | evidence level | pre-implementation evidence | verification command or path | observed result | notes |
+|---|---|---|---|---|---|---|---|
+| tc-001 | S01 | yes | red-required | Added test failed before implementation due missing capability contract / port | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `check_runs_read` permission denied renders status/api/source/action without token value |
+| tc-002 | S01 | yes | red-required | Added test failed before implementation due missing no-target diagnostic | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | No target returns `target_unavailable`, gateway not called, structural success retained |
+| tc-003 | S01 | yes | red-required | Added test failed before implementation due missing extended diagnostics | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `actions_read` / `issue_comments_read` render as `[github:extended]` |
+| tc-004 | S01 | yes | inspect-only | Parser surface lacked explicit fixed GitHub args before S01 | parser negative test; implementation `rg` inspection | pass | No raw endpoint / method / jq / header / raw surface in implementation |
+| tc-005 | S01 | yes | red-required | Added test failed before implementation due missing auth diagnostics | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `auth_missing` remains distinct from `permission_denied` and token source is non-secret |
+| tc-006 | S01 | yes | red-required | Initial implementation classified `Unknown JSON field` as `transient_unknown`; follow-up red evidence reproduced it | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | rate limit / transient / schema unavailable render distinctly; `Unknown JSON field` maps to `schema_unavailable` |
+
+## クロージャ網羅
+| closure id | step | verification evidence | result | notes |
+|---|---|---|---|---|
+| tc-001 | S01 | `test_doctor_renders_targeted_github_permission_diagnostic_without_secret` | pass | Secret token marker excluded from rendered output |
+| tc-002 | S01 | `test_doctor_without_github_target_skips_capability_probe_without_structural_failure` | pass | No false permission failure |
+| tc-003 | S01 | `test_doctor_renders_optional_extended_diagnostics_separately` | pass | Core and extended groups separated |
+| tc-004 | S01 | `test_doctor_command_surface_rejects_raw_github_api_arguments`; implementation `rg` | pass | Fixed command surface only |
+| tc-005 | S01 | `test_doctor_distinguishes_auth_missing_from_permission_denied_without_gh_token` | pass | Auth missing and token source handled without secret |
+| tc-006 | S01 | `test_doctor_renders_rate_transient_and_schema_statuses_distinctly`; `test_github_capability_cli_classifies_unknown_json_field_as_schema_unavailable` | pass | EC-003 classification covered |
+
+## クロージャ差分
+| change | closure id | test id alias | resolved closure id | reason | plan amendment required | re-review required |
+|---|---|---|---|---|---|---|
+| none | tc-001-tc-006 | S01 runtime doctor focused tests | tc-001-tc-006 | Planned closure ids closed as written | no | no |
+
+## 委任 worker 証跡
+| step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
+|---|---|---|---|---|---|---|---|
+| S01 | dev-coder | Added runtime GitHub capability diagnostics, fixed CLI probe port/adapter, added focused tests; follow-up fixed `Unknown JSON field` schema classification | `application/contracts.py`; `application/ports.py`; `application/doctor.py`; `commands/doctor.py`; `cli/bootstrap.py`; `infra/github_capability_cli.py`; `presentation/cli_text.py`; `tests/cli_runtime/test_runtime_doctor_s04.py` | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 34 passed; `git diff --check` -> pass | code-reviewer pass after follow-up | Live GitHub API behavior intentionally not tested per plan; S02 remains pending | accepted |
+
+## ステップ commit ゲート
+| step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
+|---|---|---|---|---|---|---|---|---|
+| S01 | ready_to_commit | Runtime doctor capability diagnostics and S01 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
 
 ## 最終品質ゲート
 | gate | scope | result | evidence | next action |
@@ -109,4 +171,4 @@ ID: "iss-00180"
 | authoring requirement gate | `requirement.md` | pass | fresh spec-reviewer pass | complete |
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
-| issue execution gate | S01-S99 | pending | implementation not started | start S01 |
+| issue execution gate | S01-S99 | in progress | S01 complete; S02 pending | start S02 |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -3,277 +3,110 @@
 ID: "iss-00180"
 タイトル: "Github Token Capability Preflight"
 関連GitHub: ["#180"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-11"
 依存: ["requirement.md", "design.md", "plan.md"]
 親: ["epic-00067", "init-local-00003"]
 ---
 
-# iss-00180 Github Token Capability Preflight — 実装報告（観測証跡台帳 / Observed Evidence Ledger）
+# iss-00180 Github Token Capability Preflight — 実装報告（観測証跡台帳）
 
-> `report.md` は観測証跡台帳（observed evidence ledger）の scaffold です。planned requirements、evidence destination、closure 条件は `plan.md` が持ち、この文書は実際の Red / Green / Refactor evidence、発見された tests、closure delta、reviewer status、commit/no-op evidence を記録する evidence slot です。workflow / compliance authority は skills、docs、accepted ADRs、reviewer gates に置きます。
+## 現在の状態
+- 仕様 authoring:
+  - `requirement.md`: 作成済み、fresh spec-reviewer pass。
+  - `design.md`: 作成済み、fresh spec-reviewer pass。
+  - `plan.md`: 作成済み、fresh spec-reviewer pass。
+- 実装:
+  - 未着手。次工程は `plan.md` S01 からの dev-coder 委任。
+- handoff readiness:
+  - ready for issue execution。
+  - 実行者は `plan.md` の S01 -> S02 -> S03 -> S99 の順に進める。
 
-## 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger / 必須）
-
-`report.md` は実装中・文書更新中に発生した material な仕様解釈、判断、plan 逸脱、tradeoff、open question、promotion / follow-up を記録する audit trail でもある。worker の raw note や作業 transcript を貼る場所ではなく、orchestrator が source docs、diff、tests、reviewer output と照合して issue-level の canonical entry に統合する。
-
-Material な判断がない場合もこの section は残し、次を明示する。
-
-- No material interpretation changes.
-- No decision entries.
-
-Ledger entry は次の契約値を使う。
-
-- `Status`: `open` / `resolved` / `superseded`
-- `Type`: `interpretation` / `scope` / `implementation` / `compatibility` / `test-strategy` / `operation` / `deviation` / `follow-up`
-- `Disposition`: `applied` / `rejected` / `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` / `converted_to_followup` / `deferred` / `no_action` / `superseded`
-
-完了時の意味論（completion semantics）:
-- issue completion 前に `Status=open` の entry を残してはならない。
-- `Status=resolved` は `Disposition`、evidence、必要な follow-up を持つ。
-- `Status=superseded` または `Disposition=superseded` は置換先 entry ID を持つ。
-- `Disposition=promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` は昇格先 artifact と evidence を持つ。
-- `Disposition=converted_to_followup` は follow-up issue / discussion / ADR candidate の参照を持つ。
-- `Disposition=deferred` は scope 外である理由、blocking でない根拠、revisit 条件を持つ。
-- `Disposition=no_action` は issue-local な判断で追加対応不要である理由を持つ。将来も効く durable decision を `report.md` だけに閉じ込めてはならない。
-
-Disposition ごとの必須証跡:
-- `applied`: 変更した artifact / 実装証跡と、issue-local 適用で十分な理由。
-- `rejected`: 却下した選択肢、理由、blocking impact が残らない根拠。
-- `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan`: 昇格先 artifact 参照と証跡。
-- `converted_to_followup`: follow-up issue / discussion / ADR candidate 参照と blocking / non-blocking の分類。
-- `deferred`: scope-out 理由、non-blocking の根拠、revisit 条件。
-- `no_action`: 判断が issue-local で durable ではない理由。
-- `superseded`: 置換先 entry ID と置換理由。
-
-| 識別子（ID） | 状態（Status） | 種別（Type） | 起票元（Raised By） | 契機 / 差分（Gap） | 検討した選択肢 | 判断 / 解釈 | 根拠（Rationale） | 処置（Disposition） | 証跡（Evidence） | フォローアップ（Follow-up） |
+## 仕様解釈・判断台帳
+| ID | Status | Type | Raised By | Gap | 検討した選択肢 | 判断 / 解釈 | Rationale | Disposition | Evidence | Follow-up |
 |---|---|---|---|---|---|---|---|---|---|---|
-| D-001 | 未解決 / 解決済み / 置換済み（open / resolved / superseded） | 解釈 / 範囲 / 実装 / 互換性 / テスト戦略 / 運用 / 逸脱 / フォローアップ（interpretation / scope / implementation / compatibility / test-strategy / operation / deviation / follow-up） | 起票元（orchestrator / reviewer / worker source） | 計画の曖昧さ / 実装制約 / レビュー指摘 / 発見リスク（plan ambiguity / implementation constraint / reviewer finding / discovered risk） | 選択肢 A; 選択肢 B; 対応なし（option A; option B; no action） | ... | ... | 採用 / 却下 / design 昇格 / ADR 昇格 / plan 昇格 / follow-up 化 / 延期 / 対応なし / 置換済み（applied / rejected / promoted_to_design / promoted_to_adr / promoted_to_plan / converted_to_followup / deferred / no_action / superseded） | `path` / コマンド / reviewer 指摘 / discussion（path / command / reviewer finding / discussion） | 対象 artifact / issue / discussion / 置換先 entry / 理由付き対応なし（target artifact / issue / discussion / replacement entry / none with reason） |
+| D-001 | resolved | scope | clarification | `doctor` だけか PR observation も含めるか | A: doctor only; B: PR observation only; C: both | Option C を採用し、`doctor` と PR observation の両方を scope に含める | ユーザーが Option C を採用。権限不足は手動診断と runtime observation の両面で露出する必要がある | promoted_to_requirement | `discussions/20260611t135317z-interview-github-token-capability-scope.md`; `requirement.md` | none |
+| D-002 | resolved | scope | clarification | probe profile を固定するか拡張可能にするか | A: minimal; B: broad; C: fixed core + optional extensions | Option C を採用。Core は metadata / PR read / check-runs / statuses / statusCheckRollup、doctor optional は actions / issue comments に限定 | ユーザーが Option C を採用。arbitrary API checker 化を避けつつ実用診断を確保する | promoted_to_requirement | `discussions/20260611t135608z-interview-github-capability-probe-profile.md`; `requirement.md` | none |
+| D-003 | resolved | compatibility | clarification | capability failure を process error にするか semantic non-success にするか | A: fail fast; B: warning only; C: final JSON semantic non-success | Option C を採用。`doctor` は exit 0 + findings、PR observation は final JSON semantic non-success、malformed/runtime error は non-zero | ユーザーが Option C を採用。下流 workflow が stdout final JSON を authority として判断できる | promoted_to_requirement | `discussions/20260611t135901z-interview-github-capability-failure-semantics.md`; `requirement.md`; `design.md` | none |
+| D-004 | resolved | implementation | design reviewer | Runtime GitHub probe の port / adapter / wiring が曖昧 | A: existing ports に暗黙追加; B: explicit Protocol / infra adapter | `GitHubCapabilityGateway` Protocol、`infra/github_capability_cli.py`、`cli/bootstrap.py` injection を design に明記 | 実装者が source-of-truth layer を迷わず変更できるようにする | applied | spec-reviewer finding; `design.md` | none |
+| D-005 | resolved | compatibility | design reviewer | PR observation permission failure 時の status mapping が曖昧 | A: new top-level `permission_denied`; B: existing enum + limitation | top-level status は増やさず、read failure は `unknown`、trigger write failure は `human_gate`、next action は `fix_github_token_permissions` に固定 | Existing callers の enum compatibility を維持しつつ machine-readable limitation を足す | applied | spec-reviewer finding; `design.md` | none |
+| D-006 | resolved | test-strategy | plan reviewer | EC-001/EC-002/EC-003 と exit-code semantics の closure が不足 | A: implementation 中に補う; B: plan closure に固定 | `tc-005` / `tc-006` / `tc-009` と `tc-007` / `tc-008` の `exit_code=0` 義務を追加 | 実装者が edge cases と process/semantic 分離を省略できないようにする | promoted_to_plan | spec-reviewer finding; `plan.md` | none |
 
-## 証跡採用台帳（Evidence Adoption Ledger / 必須）
-
-Delegated draft、worker note、research、reviewer finding、discussion、command output を canonical artifact や実装判断へ取り込む場合、この台帳に採用判断を記録する。raw transcript ではなく、orchestrator が検証した採否・理由・証跡・次アクションだけを記録する。
-
-- `adoption_status`: `adopted` / `partially_adopted` / `rejected` / `deferred` / `stale` / `blocked`
-- `blocked` または `stale` の unresolved entry は promotion / implementation start / issue ready / issue finish / phase completion を止める。
-- `deferred` は blocking でない根拠と revisit 条件を持つ場合だけ完了時に残せる。
-- Evidence Adoption Ledger なしで delegated evidence の採用を主張してはならない。
-- Evidence Adoption Ledger fields: ID, adoption_status, source, source_role, claim, target_artifact, target_section, rationale, evidence_strength, evidence_path, adopter, reviewer, blocking, next_action.
-
-| 識別子（ID） | 採用状態（adoption_status） | 出所（source） | 対象（target） | 判断理由（rationale） | 証跡（evidence） | 次アクション（next_action） |
+## 証跡採用台帳
+| ID | adoption_status | source | target | rationale | evidence | next_action |
 |---|---|---|---|---|---|---|
-| EAL-001 | 採用（`adopted`） / 部分採用（`partially_adopted`） / 棄却（`rejected`） / 延期（`deferred`） / stale（`stale`） / blocked（`blocked`） | サブエージェント（`sub-agent`） / レビュアー（`reviewer`） / 議論（`discussion`） / コマンド（`command`） / 調査（`research`） | 成果物（`artifact`） / Issue（`issue`） / フォローアップ（`follow-up`） | ... | `path` / コマンド / レビュアー指摘 | なし / フォローアップ（`follow-up`） / 再レビュー（`re-review`） / 再訪条件（`revisit condition`） |
+| EAL-001 | adopted | discussion | `requirement.md` scope / AC | User-adopted Option C。`doctor` と PR observation の両 surface を scope に固定した | `discussions/20260611t135317z-interview-github-token-capability-scope.md` | none |
+| EAL-002 | adopted | discussion | `requirement.md` scope / EC | User-adopted Option C。fixed core + limited optional extensions を採用した | `discussions/20260611t135608z-interview-github-capability-probe-profile.md` | none |
+| EAL-003 | adopted | discussion | `requirement.md` / `design.md` failure semantics | User-adopted Option C。process exit と semantic status の分離を採用した | `discussions/20260611t135901z-interview-github-capability-failure-semantics.md` | none |
+| EAL-004 | adopted | reviewer | `requirement.md` | Reviewer findings を反映し、target handling、optional extended set、trigger write surface を確定した | spec-reviewer rounds: fail -> fail -> fail -> pass | none |
+| EAL-005 | adopted | reviewer | `design.md` | Reviewer findings を反映し、port / adapter / status mapping / capability code を確定した | spec-reviewer rounds: fail -> pass | none |
+| EAL-006 | adopted | reviewer | `plan.md` | Reviewer findings を反映し、EC closure と exit-code obligation を追加した | spec-reviewer rounds: fail -> pass | none |
 
-## 目的整合台帳（Objective Alignment Ledger / 必須）
-
-主要目的と副次要件の主従が逆転していないことを記録する。特に clarification / authoring / handoff の変更では、primary objective evidence、secondary requirement evidence、inversion risk、reviewer verdict を残す。
-
-| 対象 | 主要目的の証跡（primary objective evidence） | 副次要件の証跡（secondary requirement evidence） | 逆転リスク（inversion risk） | レビュアー判定（reviewer verdict） |
+## 目的整合台帳
+| 対象 | primary objective evidence | secondary requirement evidence | inversion risk | reviewer verdict |
 |---|---|---|---|---|
-| OAL-001 | ... | ... | なし / 低 / 中 / 高（none / low / medium / high） | 合格 / 不合格 / blocked（pass / fail / blocked） |
+| OAL-001 | `requirement.md` は GitHub token capability の事前診断と PR observation semantic non-success を主目的として固定 | fixed endpoint、secret redaction、provider/mirror parity を制約として固定 | low | requirement / design / plan spec-reviewer pass |
 
-## 仕様 authoring ゲート（Spec Authoring Gate / 必須）
-
-Requirement / design / plan の phase promotion ごとに、調査、未確定事項、回答、採用判断、reviewer verdict、blocking / non-blocking、次アクションを記録する。
-
-| フェーズ（phase） | 調査証跡（investigated facts） | 未確定事項 / 回答（open questions / answers） | 採用判断（adoption decision） | レビュアー判定（reviewer verdict） | ブロック有無（blocking） | 昇格 / 次アクション（promotion / next_action） |
+## 仕様 authoring ゲート
+| phase | investigated facts | open questions / answers | adoption decision | reviewer verdict | blocking | promotion / next_action |
 |---|---|---|---|---|---|---|
-| 要件 / 設計 / 計画（requirement / design / plan） | 文書 / コード / discussions / 外部証跡（docs / code / discussions / external evidence） | なし / `discussions/...`（none / `discussions/...`） | 採用 / 部分採用 / 棄却 / 延期 / なし（adopted / partially_adopted / rejected / deferred / none） | 合格 / 不合格 / 利用不可 / 拒否 / waiver / provisional（passed / failed / unavailable / denied / waived / provisional） | はい / いいえ（yes / no） | 昇格 / clarification へ戻す / 再レビュー / フォローアップ（promote / return to clarification / re-review / follow-up） |
+| requirement | GitHub issue #180、active issue docs、clarification discussions、existing `doctor` runtime、PR observation scripts | Option C x3 採用済み。未確定なし | adopted | pass | no | promoted to design |
+| design | `application/contracts.py`、`application/doctor.py`、`commands/doctor.py`、`application/ports.py`、`cli/bootstrap.py`、`infra/github_cli.py`、PR observation scripts | reviewer 指摘により port / adapter / status mapping / capability code を修正済み | adopted | pass | no | promoted to plan |
+| plan | requirement / design、existing doctor tests、PR observation tests in `tests/unit/infra/test_init_update.py` | reviewer 指摘により EC closure と exit-code obligation を修正済み | adopted | pass | no | ready for issue execution |
 
-## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
+## 委任ドラフト証跡
 - 委任 authoring の使用:
-  - used / not used
-- 未使用の場合:
-  - manual authoring path / 委任ドラフトを昇格証跡として使っていない理由。
-- lifecycle state（契約値）:
-  - `requested`, `produced`, `integrated`, `partially_integrated`, `rejected`, `superseded`, `blocked`, `stale`
-- 昇格不可 state:
-  - `stale`, `rejected`, `superseded`, `blocked`
-- 標準出力先:
-  - 対象 scope の `discussions/` direct child にある flat Markdown
-  - filename: `<ts>-<kind>-<slug>.md` または same-second collision 用 `<ts>-<nn>-<kind>-<slug>.md`
-- 軽量 provenance:
-  - `created_by_role`, `scope_id`, `source_paths`, `intended_targets`, `adoption_status: unreviewed`, `reflected_to: []`, `diff_guard_result`, fallback decision, report evidence destination, adoption ledger note
-  - 互換 label: source artifacts, draft artifact path, status, integration result, rejected portions, blockers, reviewer result, promotion decision
-- 禁止 self-claim:
-  - `authority: accepted`, `adoption_status: adopted`, non-empty `reflected_to`, reviewer pass, phase completion, implementation readiness
-- 禁止 wildcard token:
-  - `*`, `grants.*`, `all`
-- 標準必須にしない field:
-  - task manifest hash, Permission Profile hash, session invocation hash, probe run id, session hash
-- historical note:
-  - 既存 `iss-00126` などの manifest/Profile/probe/session artifacts は grandfathered evidence として残し、削除・rename・validation failure 化しない。
+  - not used for system-architect / implementation-planner draft artifacts。
+- 未使用理由:
+  - `spec-dock-issue-planning` の delegated direct-write authoring は scope-local discussion direct-write consent と clean target discussions を前提にする。
+  - この issue では clarification interview artifacts が target `discussions/` に未追跡状態で存在し、scope-local direct-write authoring consent も明示されていないため、delegated draft adoption eligibility を満たさない。
+  - そのため design / plan は main orchestrator が canonical docs を直接 authoring し、fresh `spec-reviewer` gates で品質を担保した。
 
-| ロール（created_by_role） | 範囲（scope_id） | ドラフトパス（discussion draft path） | 参照元（source_paths） | 予定反映先（intended_targets） | 採用状態（adoption_status） | 反映先（reflected_to） | 差分ガード結果（diff_guard_result） | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果（reviewer result） | 昇格判断（promotion decision） |
+| created_by_role | scope_id | discussion draft path | source_paths | intended_targets | adoption_status | reflected_to | diff_guard_result | integration result | rejected portions | blockers | reviewer result | promotion decision |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| 該当なし | 該当なし | 該当なし | 該当なし | 該当なし | 未使用（not used） | なし（[]） | 未実行（not_run） | 手動 authoring | 該当なし | なし（none） | 該当なし | 委任ドラフト昇格なし |
+| system-architect | iss-00180 | N/A | N/A | `design.md` | not used | [] | not_run | manual authoring fallback | N/A | direct-write precondition not met | design spec-reviewer pass | no delegated draft promotion |
+| implementation-planner | iss-00180 | N/A | N/A | `plan.md` | not used | [] | not_run | manual authoring fallback | N/A | direct-write precondition not met | plan spec-reviewer pass | no delegated draft promotion |
 
-### 委任ドラフトの失敗モード（Delegated Draft Failure Modes）
-| 失敗モード | 期待される判定 | 許可される次アクション | レポート証跡の記録先（report evidence destination） | 昇格可否 |
-|---|---|---|---|---|
-| 同意なし（missing consent） | blocked / incomplete | 範囲付き同意を取得する、または手動 authoring に戻す | この section | ineligible |
-| 前段 reviewer pass 不足 / stale（missing/stale previous reviewer pass） | blocked / incomplete | レビューゲートを再実行する（rerun reviewer gate） | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
-| 設計中の要件 gap（requirement gap during design） | blocked / incomplete | requirement phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| 計画中の設計 gap（design gap during plan） | blocked / incomplete | design phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| ロール利用不可（role unavailable） | blocked / manual path | 利用不可を記録し、妥当なら手動で続行する | この section | ineligible |
-| 禁止行為の試行（forbidden action attempt） | rejected | ドラフトを破棄し incident を記録する | この section / decision ledger | ineligible |
-| 古いドラフト（stale draft） | stale | 再生成または差分調整する | この section | ineligible |
-| 置換済みドラフト（superseded draft） | superseded | 置換先ドラフトを参照する | この section | ineligible |
-| 委任使用主張に対する証跡不足（missing draft evidence when delegated use is claimed） | incomplete | 証跡を追加する、または委任使用 claim を外す | この section | ineligible |
-| reviewer 利用不可 / 拒否 / waiver / provisional（reviewer unavailable/denied/waived/provisional） | blocked / incomplete | fresh な passed reviewer を取得する、または昇格なしの risk acceptance を記録する | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
+## ワークフロー委任同意の証跡
+| consent source | repo/worktree | active issue | session | named roles | boundary | expires / invalidation condition | denied / unavailable reason | next action |
+|---|---|---|---|---|---|---|---|---|
+| user instruction `$spec-dock-issue-planning` | `/Users/iwasawayuuta/.codex/worktrees/0799/spec-dock` | iss-00180 | current session | spec-reviewer | read-only review gates for requirement / design / plan | issue complete / session end / scope change / user revocation | none | proceed |
+| none for delegated direct-write authoring | `/Users/iwasawayuuta/.codex/worktrees/0799/spec-dock` | iss-00180 | current session | system-architect / implementation-planner | discussion draft direct-write not granted | until explicit scope-local consent and clean target discussions | direct-write precondition not met | manual authoring fallback |
 
-## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+## レビューゲート状態
+| step / phase | gate name | reviewer role | freshness | state | risk acceptance | promotion / completion decision | notes |
+|---|---|---|---|---|---|---|---|
+| requirement | authoring gate round 1 | spec-reviewer | stale | failed | no | re-review | P1 target resolution ambiguity; P2 optional extended positive AC missing |
+| requirement | authoring gate round 2 | spec-reviewer | stale | failed | no | re-review | Optional extended set was still open-ended |
+| requirement | authoring gate round 3 | spec-reviewer | stale | failed | no | re-review | Doctor trigger write display contradiction |
+| requirement | authoring gate round 4 | spec-reviewer | fresh at promotion | passed | N/A | promoted to design | No blockers |
+| design | authoring gate round 1 | spec-reviewer | stale | failed | no | re-review | Missing explicit port / adapter; PR observation status mapping ambiguous; capability code mismatch |
+| design | authoring gate round 2 | spec-reviewer | fresh at promotion | passed | N/A | promoted to plan | No blockers |
+| plan | authoring gate round 1 | spec-reviewer | stale | failed | no | re-review | Missing EC closure rows; missing `exit_code=0` obligations |
+| plan | authoring gate round 2 | spec-reviewer | fresh | passed | N/A | ready for issue execution | No blockers |
 
-## 実装記録（セッションログ） (必須)
+## 実装委任ゲート
+| step | decision | required reason | delegated role | delegated scope | source of truth | allowed changes | forbidden changes | required verification | stop conditions | output required | observed result |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S01 | planned delegation | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pending |
+| S02 | planned delegation | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pending |
+| S03 | planned delegation | shipped asset guidance / dogfooding parity | dev-coder or doc-writer | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | parity inspection and focused tests | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pending |
+| S99 | planned review gates | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer | final quality gates | `plan.md` S99 | issue-wide diff | unreviewed completion | required validation commands and reviewer pass | missing closure evidence | gate verdicts / final risk | pending |
 
-### セッションログ（2026-06-11 HH:MM - HH:MM）
+## 実装記録
+- 実装未着手。
+- 次回実行時は `plan.md` S01 から開始する。
 
-#### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
-- 計画上の出典（Planned source）:
-  - `plan.md` section:
-  - closure ids:
-
-#### 実施内容
-- ...
-
-#### 実行コマンド / 結果
+## 実行コマンド / 結果
 ```bash
-<command>
-
-<result>
+# authoring validation commands are recorded after this report update.
 ```
 
-#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
-| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
-|---|---|---|---|---|---|---|
-| S01 | 赤フェーズ / 代替証跡（Red / alternative） | red-required / covered-existing / inspect-only / manual-required | ... | `command` / 文書点検（docs inspection） / 手動記録（manual record） | pass / approved-no-op / fail / blocked | ... |
-| S01 | 緑フェーズ（Green） | ... | ... | `command` / 点検（inspection） / 手動記録（manual record） | pass / fail / blocked | ... |
-| S01 | リファクタリング（Refactor） | guardrail satisfied / no refactor needed | ... | 差分点検（diff inspection） / command | pass / approved-no-op / fail / blocked | ... |
-
-#### 発見されたテスト / リスク（Discovered Tests）
-| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
-|---|---|---|---|---|---|---|
-| S01 | none / ... | implementation / review / QA / user report | recorded / added test / deferred / amended plan | tc-001 / new | yes / no | ... |
-
-#### ステップ契約の完了証跡（Step Contract Closure）
-| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
-|---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved-no-op / fail / blocked | ... |
-
-#### テスト契約の完了証跡（Test Contract Closure）
-| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
-|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required / covered-existing / inspect-only / manual-required | ... | ... | pass / approved-no-op / fail / blocked | ... |
-
-- `closure id / test id` は Spec-Locked Closure Index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
-
-#### クロージャ網羅（Closure Coverage）
-| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
+## 最終品質ゲート
+| gate | scope | result | evidence | next action |
 |---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved-no-op / fail / blocked | ... |
-
-#### クロージャ差分（Closure Delta）
-| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
-|---|---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no | yes / no |
-
-#### ワークフロー委任同意の証跡（Workflow Delegation Consent）
-`workflow_issue.md` is the policy source for workflow-scoped delegation consent. This report records observed consent, boundary, expiry, and denied / unavailable handling only.
-
-| 同意元（consent source） | リポジトリ / worktree（repo/worktree） | 対象課題（active issue） | セッション（session） | 指名ロール（named roles） | 境界（boundary） | 期限 / 無効化条件（expires / invalidation condition） | 拒否 / 利用不可理由（denied / unavailable reason） | 次アクション（next action） |
-|---|---|---|---|---|---|---|---|---|
-| user instruction / explicit approval / none | ... | iss-00180 | current session / ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | same repo, active issue, session, named role; no destructive action / publishing / credentialed access / scope expansion / write-capable delegation / private external system use | issue complete / session end / scope change / host policy conflict / user revocation | none / denied / unavailable / host conflict | proceed / ask user / block gate / record waiver request |
-
-#### 実装委任ゲート（Implementation Delegation Gate）
-`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records observed evidence only.
-
-| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
-
-#### 委任 worker 証跡（Delegated Worker Evidence）
-| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
-|---|---|---|---|---|---|---|---|
-| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
-
-#### 親実装例外（Parent Implementation Exception）
-| ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
-
-#### レビューゲート状態（Reviewer Gate Status）
-| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
-|---|---|---|---|---|---|---|---|
-| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
-
-#### ステップ commit ゲート（Step Commit Gate）
-| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | committed / approved-no-op | ... | <hash or final ledger reference> | `git status --short` -> clean | ... | ... | ... | ... |
-
-#### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
-
-#### コミット
-- <hash> <message>
-
-#### メモ
-- ...
-
----
-
-### セッションログ（2026-06-11 HH:MM - HH:MM）
-
-#### 対象
-- Step: ...
-- AC/EC: ...
-
-#### 実施内容
-- ...
-
----
-
-## 最終品質ゲート（Final Quality Gate / 必須）
-
-### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
-| 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
-|---|---|---|---|---|
-| docs / templates / README / workflow / skill / migration notes | yes / no | doc-writer / N/A | ... | pass / fail / blocked |
-
-### 最終 QA ゲート（Final QA Gate）
-| レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
-|---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | added / already sufficient / not applicable | ... | pass / fail / blocked |
-
-### 最終コードレビューゲート（Final Code Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
-|---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | ... | 0 | pass / fail / blocked |
-
-### 最終 spec review ゲート（Final Spec Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
-|---|---|---|---|---|
-| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | ... | 0 | pass / fail / blocked |
-
-### 最終 commit（Final Commit）
-| 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
-|---|---|---|---|
-| ... | ... | final response / PR / issue comment / other external delivery evidence | ready / blocked |
-
-## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
-
-## 学んだこと (任意)
-- ...
-
-## 今後の推奨事項 (任意)
-- ...
-
-## 省略/例外メモ (必須)
-- 該当なし
+| authoring requirement gate | `requirement.md` | pass | fresh spec-reviewer pass | complete |
+| authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
+| authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
+| issue execution gate | S01-S99 | pending | implementation not started | start S01 |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -18,10 +18,13 @@ ID: "iss-00180"
   - `design.md`: 作成済み、fresh spec-reviewer pass。
   - `plan.md`: 作成済み、fresh spec-reviewer pass。
 - 実装:
-  - 未着手。次工程は `plan.md` S01 からの dev-coder 委任。
+  - S01 Runtime doctor capability diagnostics: 実装済み、focused tests pass、code-reviewer pass、commit 済み。
+  - S02 PR observation permission limitation classification: 実装済み、focused / nearby tests pass、code-reviewer pass、commit 済み。
+  - S03 Guidance / dogfooding parity: 実装済み、provider/mirror parity pass、code-reviewer pass、commit 済み。
+  - S99 final gate: 初回 final reviewers の P1/P2 指摘を反映済み。`doctor` malformed target rejection、PR metadata / commit status / statusCheckRollup permission coverage、`Resource not accessible by integration` 分類を追補実装済み。fresh final QA / code / spec reviewer pass。
 - handoff readiness:
-  - ready for issue execution。
-  - 実行者は `plan.md` の S01 -> S02 -> S03 -> S99 の順に進める。
+  - ready for final commit and PR creation。
+  - final commit、PR 作成・観測が残作業。
 
 ## 仕様解釈・判断台帳
 | ID | Status | Type | Raised By | Gap | 検討した選択肢 | 判断 / 解釈 | Rationale | Disposition | Evidence | Follow-up |
@@ -91,8 +94,8 @@ ID: "iss-00180"
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | S01 | delegated | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; forbidden raw API surface inspection; `git diff --check` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pass: dev-coder implemented S01, follow-up fixed schema classification, code-reviewer pass |
 | S02 | delegated | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection; nearby regression selector; `git diff --check` | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pass: dev-coder implemented S02, focused/nearby tests pass, code-reviewer pass after follow-ups |
-| S03 | delegated | shipped asset guidance / dogfooding parity | dev-coder | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | provider/mirror diff inspection; focused install/parity tests; `validate`; `git diff --check` | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pass: provider guidance updated and dogfooding mirrors synced; code-reviewer pending after report evidence update |
-| S99 | planned review gates | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer | final quality gates | `plan.md` S99 | issue-wide diff | unreviewed completion | required validation commands and reviewer pass | missing closure evidence | gate verdicts / final risk | pending |
+| S03 | delegated | shipped asset guidance / dogfooding parity | dev-coder | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | provider/mirror diff inspection; focused install/parity tests; `validate`; `git diff --check` | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pass: provider guidance updated and dogfooding mirrors synced; code-reviewer pass |
+| S99 | delegated / passed | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer / dev-coder | final quality gates and reviewer follow-ups | `plan.md` S99 | issue-wide diff; bounded follow-up paths | unreviewed completion, live GitHub tests, arbitrary API expansion | required validation commands and reviewer pass | missing closure evidence, implementation reviewer finding | gate verdicts / final risk | pass: first final reviewers failed on stale report and P2 coverage gaps; follow-up implementation verified; final QA/code/spec reviewers passed |
 
 ## 実装記録
 - S01 complete:
@@ -112,7 +115,12 @@ ID: "iss-00180"
   - Provider-side PR observation skill assets を dogfooding `.agents/skills/github-pr-observation/` に反映した。
   - Provider-side runtime S01 changes を dogfooding `spec-dock/scripts/spec_dock_runtime/` に反映した。
   - `tc-012` を parity inspection と focused install/parity tests で閉じた。
-- 次回実行時は `plan.md` S99 から開始する。
+- S99 in progress:
+  - 初回 final QA / code / spec reviewer で stale report evidence と追補 coverage gaps を確認した。
+  - `doctor --github-repo/--github-pr/--github-head-sha` の malformed target を CLI misuse として reject する追補を実装した。
+  - PR observation read permission coverage を PR metadata `pull_request_read`、commit status `/status`、`statusCheckRollup` に拡張した。
+  - PR metadata permission denied でも raw stderr / token marker を出さず、`stderr_sha256` と `secret_redacted=true` を返す。
+  - code-reviewer P2 により、GitHub App / `GITHUB_TOKEN` 系の `Resource not accessible by integration` を permission denied として扱う追補が必要と判定されたため、dev-coder に委任し、provider / dogfooding mirror とテストを更新した。
 
 ## 実行コマンド / 結果
 ```bash
@@ -149,6 +157,27 @@ diff -qr -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime
 
 uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'
 # 40 passed
+
+uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py
+# 37 passed
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 or github_pr_observation or codex_review or checks_snapshot or checked_in_dogfooding_runtime'
+# 56 passed, 279 deselected
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'
+# 2 passed, 333 deselected
+
+diff -qr -x __pycache__ src/spec_dock/assets/install_root/.agents/skills/github-pr-observation .agents/skills/github-pr-observation
+# clean
+
+diff -qr -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime
+# clean
+
+./spec-dock/scripts/spec-dock validate
+# spec-dock: ok (validate) nodes=92
+
+git diff --check
+# pass
 ```
 
 ## テスト駆動開発証跡
@@ -165,13 +194,18 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or 
 | S03 | Red / alternative | tc-012 inspect-only | Provider/mirror diff failed before sync; focused parity test failed 1/40 before dogfooding runtime sync | `diff -qr ...`; focused pytest selector | fail as expected | S01/S02 provider changes had not yet been mirrored |
 | S03 | Green | tc-012 pass | Provider/mirror diffs clean and focused parity tests pass | `diff -qr ...`; `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'` | pass | 40 passed |
 | S03 | Refactor / guardrail | guidance/mirror only | Diff limited to SKILL guidance and dogfooding mirrors | diff inspection; `git diff --check` | pass | No broad docs rewrite or credential storage guidance |
+| S99 | Red / reviewer follow-up | final reviewer P2 coverage gaps | Malformed doctor target test failed before follow-up; PR metadata permission denied mapped to generic path before follow-up | dev-coder focused red runs | fail as expected | `malformed_github_targets`: 3 failed before fix; `pr_metadata` permission path: 1 failed / 2 passed before fix |
+| S99 | Green / follow-up | tc-004 / tc-007 / tc-011 strengthened | Runtime doctor suite and PR observation issue-wide selector passed | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; PR observation selector | pass | 37 passed; 56 passed / 279 deselected |
+| S99 | Red / reviewer follow-up | code-reviewer P2 integration permission wording | `Resource not accessible by integration` PR metadata classification gap found | code-reviewer review; dev-coder red test | fail as expected | `recommended_next_action` fell to `human_gate` before fix |
+| S99 | Green / reviewer follow-up | code-reviewer P2 integration permission wording | Integration-denied PR metadata fixture passes and maps to token permission limitation | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'`; broader PR observation selector | pass | 2 passed; 56 passed / 279 deselected |
 
 ## ステップ契約の完了証跡
 | step | closure ids | close condition from plan | observed evidence | result | notes |
 |---|---|---|---|---|---|
 | S01 | tc-001-tc-006 | Runtime doctor capability diagnostics implemented, verified, and reviewed | Tests `34 passed`; forbidden surface inspection pass; code-reviewer pass | pass | S01 scope complete |
 | S02 | tc-007-tc-011 | PR observation permission limitation classification implemented, verified, and reviewed | Focused tests 6 passed; nearby regression 41 passed; code-reviewer pass after generic permission follow-ups | pass | S02 provider-side scope complete; S03 parity pending |
-| S03 | tc-012 | Guidance and dogfooding parity implemented, verified, and reviewed | Provider/mirror diffs clean; focused parity tests 40 passed; code-reviewer pending after report evidence update | pass | S03 scope complete |
+| S03 | tc-012 | Guidance and dogfooding parity implemented, verified, and reviewed | Provider/mirror diffs clean; focused parity tests 40 passed; code-reviewer pass | pass | S03 scope complete |
+| S99 | tc-013 | Issue-wide validation / QA / code / spec review / handoff gates pass | Focused runtime tests 37 passed; PR observation selector 56 passed; `issue_180_s02 and pr_metadata` 2 passed; provider/mirror diffs clean; validate ok; `git diff --check` pass; final QA pass; final code-reviewer pass; final spec-reviewer pass | pass | S99 scope complete before final commit / PR delivery |
 
 ## テスト契約の完了証跡
 | closure id / test id | step | required | evidence level | pre-implementation evidence | verification command or path | observed result | notes |
@@ -179,15 +213,16 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or 
 | tc-001 | S01 | yes | red-required | Added test failed before implementation due missing capability contract / port | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `check_runs_read` permission denied renders status/api/source/action without token value |
 | tc-002 | S01 | yes | red-required | Added test failed before implementation due missing no-target diagnostic | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | No target returns `target_unavailable`, gateway not called, structural success retained |
 | tc-003 | S01 | yes | red-required | Added test failed before implementation due missing extended diagnostics | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `actions_read` / `issue_comments_read` render as `[github:extended]` |
-| tc-004 | S01 | yes | inspect-only | Parser surface lacked explicit fixed GitHub args before S01 | parser negative test; implementation `rg` inspection | pass | No raw endpoint / method / jq / header / raw surface in implementation |
+| tc-004 | S01 | yes | inspect-only | Parser surface lacked explicit fixed GitHub args before S01; malformed target arguments were accepted before S99 follow-up | parser negative test; implementation `rg` inspection; malformed target parser test | pass | No raw endpoint / method / jq / header / raw surface in implementation; malformed `--github-repo`, non-positive `--github-pr`, and non-hex `--github-head-sha` reject at parse time |
 | tc-005 | S01 | yes | red-required | Added test failed before implementation due missing auth diagnostics | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | `auth_missing` remains distinct from `permission_denied` and token source is non-secret |
 | tc-006 | S01 | yes | red-required | Initial implementation classified `Unknown JSON field` as `transient_unknown`; follow-up red evidence reproduced it | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` | pass | rate limit / transient / schema unavailable render distinctly; `Unknown JSON field` maps to `schema_unavailable` |
-| tc-007 | S02 | yes | red-required | Focused S02 test failed before implementation because checks permission denied stayed generic | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | check-runs permission denied exits 0 and yields `github_token_permission_denied`, `unknown`, and `fix_github_token_permissions` |
+| tc-007 | S02 | yes | red-required | Focused S02 test failed before implementation because checks permission denied stayed generic; PR metadata permission denied mapped to generic path before S99 follow-up; integration wording mapped to `human_gate` before final follow-up | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'`; S99 PR observation selector | pass | check-runs, commit status `/status`, statusCheckRollup, PR metadata PAT wording, and PR metadata integration wording permission denied paths are covered |
 | tc-008 | S02 | yes | red-required | Focused S02 test failed before implementation because trigger permission denied leaked raw marker and did not map to human gate | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | trigger comment permission denied exits 0 and yields `trigger_comment_write` / `human_gate` |
 | tc-009 | S02 | yes | red-required | Focused S02 test failed before implementation because non-permission failures collapsed into generic failure | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | auth/rate/transient/schema are distinct and not `github_token_permission_denied` |
 | tc-010 | S02 | yes | red-required | Existing usage contract characterized invalid input as exit 64 | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | invalid `--head-sha` remains usage error and emits no token limitation |
 | tc-011 | S02 | yes | red-required | Focused S02 tests failed before implementation because token marker could leak in trigger helper JSON | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | raw token-like stderr marker absent; limitation includes `stderr_sha256` and `secret_redacted=true` |
 | tc-012 | S03 | yes | inspect-only | Provider/mirror diffs and focused dogfooding parity test failed before sync | provider/mirror `diff -qr`; `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'` | pass | PR observation skill mirror and dogfooding runtime mirror match provider-side sources excluding `__pycache__` |
+| tc-013 | S99 | yes | manual-required | First final reviewer pass failed on stale report and P2 coverage gaps | final QA / code / spec reviewer gates; final validation commands | pass | Final QA pass with P2 ledger update request; final code-reviewer pass; final spec-reviewer pass |
 
 ## クロージャ網羅
 | closure id | step | verification evidence | result | notes |
@@ -204,6 +239,7 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or 
 | tc-010 | S02 | `test_issue_180_s02_checks_collector_invalid_input_remains_usage_error` | pass | Usage error remains non-zero |
 | tc-011 | S02 | `test_issue_180_s02_trigger_helper_classifies_comment_permission_denied_without_secret`; snapshot permission test | pass | Secret marker excluded from final JSON |
 | tc-012 | S03 | provider/mirror diff inspections; checked-in dogfooding parity tests | pass | Shipped guidance and dogfooding mirrors align |
+| tc-013 | S99 | focused tests, parity diff, `validate`, `git diff --check`, final reviewer gates | pass | S99 final gate closed |
 
 ## クロージャ差分
 | change | closure id | test id alias | resolved closure id | reason | plan amendment required | re-review required |
@@ -213,20 +249,28 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or 
 | changed | tc-008 | generic trigger permission denied fixture | tc-008 | code-reviewer P2 requested parity with read-side classifier | no | yes, S02 code-reviewer re-review |
 | none | tc-009-tc-011 | S02 PR observation focused tests | tc-009-tc-011 | Planned closure ids closed as written | no | no |
 | none | tc-012 | S03 parity inspection and focused tests | tc-012 | Planned closure id closed as written | no | yes, S03 code-reviewer re-review |
+| changed | tc-004 | malformed GitHub target parser test | tc-004 | final code-reviewer requested malformed local target rejection instead of accepting invalid target values | no | yes, S99 code-reviewer re-review |
+| changed | tc-007 | PR metadata / commit status / statusCheckRollup permission fixtures | tc-007 | final QA/code reviewers requested branch coverage for all PR observation read permission paths | no | yes, S99 code-reviewer re-review |
+| changed | tc-007 | PR metadata integration permission fixture | tc-007 | code-reviewer P2 identified `Resource not accessible by integration` as unclassified permission wording | no | yes, S99 code-reviewer re-review |
+| changed | tc-011 | PR metadata secret redaction fixture | tc-011 | final reviewers requested secret redaction evidence for PR metadata permission failure path | no | yes, S99 code-reviewer re-review |
+| changed | tc-013 | final reviewer gates | tc-013 | Final QA/code/spec reviewers passed after S99 follow-up implementation and report evidence update | no | no |
 
 ## 委任 worker 証跡
 | step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
 |---|---|---|---|---|---|---|---|
 | S01 | dev-coder | Added runtime GitHub capability diagnostics, fixed CLI probe port/adapter, added focused tests; follow-up fixed `Unknown JSON field` schema classification | `application/contracts.py`; `application/ports.py`; `application/doctor.py`; `commands/doctor.py`; `cli/bootstrap.py`; `infra/github_capability_cli.py`; `presentation/cli_text.py`; `tests/cli_runtime/test_runtime_doctor_s04.py` | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 34 passed; `git diff --check` -> pass | code-reviewer pass after follow-up | Live GitHub API behavior intentionally not tested per plan; S02 remains pending | accepted |
 | S02 | dev-coder | Added PR observation permission limitation classification for checks/status/rollup and trigger comment write, with focused script tests; follow-ups broadened generic `permission denied` matching for read and trigger paths | `fetch_pr_checks_snapshot.sh`; `fetch_pr_observation_snapshot.sh`; `trigger_codex_review.sh`; `wait_pr_observation.sh`; `tests/unit/infra/test_init_update.py` | `issue_180_s02` -> 6 passed; nearby PR observation selector -> 41 passed; `git diff --check` -> pass | code-reviewer pass after follow-ups | Full `test_init_update.py` has 4 failures in S03 parity / existing dogfooding snapshot scope | accepted |
-| S03 | dev-coder | Updated provider skill guidance and mirrored PR observation assets plus runtime dogfooding files | provider `github-pr-observation/SKILL.md`; `.agents/skills/github-pr-observation/**`; `spec-dock/scripts/spec_dock_runtime/**` | provider/mirror diffs clean; focused parity tests -> 40 passed; `validate` -> ok; `git diff --check` -> pass | code-reviewer pending after report evidence update | Live GitHub API not exercised per plan | accepted |
+| S03 | dev-coder | Updated provider skill guidance and mirrored PR observation assets plus runtime dogfooding files | provider `github-pr-observation/SKILL.md`; `.agents/skills/github-pr-observation/**`; `spec-dock/scripts/spec_dock_runtime/**` | provider/mirror diffs clean; focused parity tests -> 40 passed; `validate` -> ok; `git diff --check` -> pass | code-reviewer pass | Live GitHub API not exercised per plan | accepted |
+| S99 follow-up 1 | dev-coder | Added malformed doctor target rejection and expanded read permission coverage for PR metadata, commit status, and statusCheckRollup | `commands/doctor.py`; `fetch_pr_observation_snapshot.sh`; dogfooding mirrors; `tests/cli_runtime/test_runtime_doctor_s04.py`; `tests/unit/infra/test_init_update.py` | runtime doctor suite -> 37 passed; PR observation selector -> 55 passed; provider/mirror diffs clean; `validate` -> ok; `git diff --check` -> pass | code-reviewer fail | live GitHub API intentionally not exercised; integration wording gap found | accepted with follow-up |
+| S99 follow-up 2 | dev-coder | GitHub App / `GITHUB_TOKEN` integration permission wording classification | `fetch_pr_observation_snapshot.sh`; dogfooding mirror; `tests/unit/infra/test_init_update.py` | `issue_180_s02 and pr_metadata` -> 2 passed; PR observation selector -> 56 passed; provider/mirror diff clean; `git diff --check` -> pass | final code-reviewer pass | live GitHub API intentionally not exercised | accepted |
 
 ## ステップ commit ゲート
 | step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
 |---|---|---|---|---|---|---|---|---|
-| S01 | ready_to_commit | Runtime doctor capability diagnostics and S01 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
-| S02 | ready_to_commit | Provider-side PR observation permission limitation classification and S02 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
-| S03 | ready_to_commit | Guidance and dogfooding mirror parity plus S03 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
+| S01 | committed | Runtime doctor capability diagnostics and S01 report evidence | `a8d128d5` | clean after commit | N/A | N/A | N/A | N/A |
+| S02 | committed | Provider-side PR observation permission limitation classification and S02 report evidence | `0bfe1049` | clean after commit | N/A | N/A | N/A | N/A |
+| S03 | committed | Guidance and dogfooding mirror parity plus S03 report evidence | `8499971d` | clean after commit | N/A | N/A | N/A | N/A |
+| S99 follow-up | ready_to_commit | Final reviewer implementation follow-ups and final report evidence | pending final commit | pending | N/A | N/A | N/A | N/A |
 
 ## 最終品質ゲート
 | gate | scope | result | evidence | next action |
@@ -234,4 +278,4 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or 
 | authoring requirement gate | `requirement.md` | pass | fresh spec-reviewer pass | complete |
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
-| issue execution gate | S01-S99 | in progress | S01 complete; S02 complete; S03 complete; S99 pending | start S99 |
+| issue execution gate | S01-S99 | pass | S01 complete; S02 complete; S03 complete; S99 final QA/code/spec reviewers passed | commit final follow-up and create PR |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -23,8 +23,8 @@ ID: "iss-00180"
   - S03 Guidance / dogfooding parity: 実装済み、provider/mirror parity pass、code-reviewer pass、commit 済み。
   - S99 final gate: 初回 final reviewers の P1/P2 指摘を反映済み。`doctor` malformed target rejection、PR metadata / commit status / statusCheckRollup permission coverage、`Resource not accessible by integration` 分類を追補実装済み。fresh final QA / code / spec reviewer pass。
 - handoff readiness:
-  - ready for final commit and PR creation。
-  - final commit、PR 作成・観測が残作業。
+  - PR #181 created and repair loop in progress。
+  - 初回 PR observation で provider-tests failure と Codex P2 comments を検出し、repair batch `discussions/20260611t161800z-disc-pr-repair-batch.md` の U001 を実装・検証済み。local code-review P2 で PR metadata / trigger write の `GITHUB_TOKEN` source coverage と trigger integration wording も追補済み。final repair commit、push、再観測が残作業。
 
 ## 仕様解釈・判断台帳
 | ID | Status | Type | Raised By | Gap | 検討した選択肢 | 判断 / 解釈 | Rationale | Disposition | Evidence | Follow-up |
@@ -198,6 +198,8 @@ git diff --check
 | S99 | Green / follow-up | tc-004 / tc-007 / tc-011 strengthened | Runtime doctor suite and PR observation issue-wide selector passed | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; PR observation selector | pass | 37 passed; 56 passed / 279 deselected |
 | S99 | Red / reviewer follow-up | code-reviewer P2 integration permission wording | `Resource not accessible by integration` PR metadata classification gap found | code-reviewer review; dev-coder red test | fail as expected | `recommended_next_action` fell to `human_gate` before fix |
 | S99 | Green / reviewer follow-up | code-reviewer P2 integration permission wording | Integration-denied PR metadata fixture passes and maps to token permission limitation | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'`; broader PR observation selector | pass | 2 passed; 56 passed / 279 deselected |
+| PR repair U001 | Red / observation | PR #181 initial observation | Provider CI failed; Codex review returned 3 unresolved P2 comments | `wait_pr_observation.sh` on PR #181 head `2fa6da0d...`; `gh run view`; local focused reproduction | fail as expected | failure classes: `check_failure:provider-tests`, `review_feedback:github-capability-classifier`, `review_feedback:token-source`, `review_feedback:missing-gh` |
+| PR repair U001 | Green | I001-I007 repair | Full provider unit lane and focused repair tests passed | focused pytest commands; full `tests/unit/infra/test_init_update.py`; mirror diffs; validate; diff check | pass | 41 runtime doctor tests passed; focused trigger selector 4 passed; 338 `test_init_update.py` tests passed |
 
 ## ステップ契約の完了証跡
 | step | closure ids | close condition from plan | observed evidence | result | notes |
@@ -263,6 +265,7 @@ git diff --check
 | S03 | dev-coder | Updated provider skill guidance and mirrored PR observation assets plus runtime dogfooding files | provider `github-pr-observation/SKILL.md`; `.agents/skills/github-pr-observation/**`; `spec-dock/scripts/spec_dock_runtime/**` | provider/mirror diffs clean; focused parity tests -> 40 passed; `validate` -> ok; `git diff --check` -> pass | code-reviewer pass | Live GitHub API not exercised per plan | accepted |
 | S99 follow-up 1 | dev-coder | Added malformed doctor target rejection and expanded read permission coverage for PR metadata, commit status, and statusCheckRollup | `commands/doctor.py`; `fetch_pr_observation_snapshot.sh`; dogfooding mirrors; `tests/cli_runtime/test_runtime_doctor_s04.py`; `tests/unit/infra/test_init_update.py` | runtime doctor suite -> 37 passed; PR observation selector -> 55 passed; provider/mirror diffs clean; `validate` -> ok; `git diff --check` -> pass | code-reviewer fail | live GitHub API intentionally not exercised; integration wording gap found | accepted with follow-up |
 | S99 follow-up 2 | dev-coder | GitHub App / `GITHUB_TOKEN` integration permission wording classification | `fetch_pr_observation_snapshot.sh`; dogfooding mirror; `tests/unit/infra/test_init_update.py` | `issue_180_s02 and pr_metadata` -> 2 passed; PR observation selector -> 56 passed; provider/mirror diff clean; `git diff --check` -> pass | final code-reviewer pass | live GitHub API intentionally not exercised | accepted |
+| PR repair U001 | dev-coder | Closed PR #181 provider-tests failures and Codex P2 review comments by updating dogfooding snapshot, rate-limit expectation, integration wording classifiers, `GITHUB_TOKEN` token source, and missing `gh` diagnostic handling | runtime doctor adapter/contracts; PR observation scripts; dogfooding mirrors; runtime doctor tests; `test_init_update.py`; repair batch discussion | runtime doctor -> 41 passed; focused trigger selector -> 4 passed; full `test_init_update.py` -> 338 passed; mirror diffs clean; `validate` -> ok; `git diff --check` -> pass | code-reviewer pass with P2 follow-up applied; PR re-observation pending | live GitHub API limited to PR observation; previous review threads unresolved until new head is pushed and reobserved | accepted |
 
 ## ステップ commit ゲート
 | step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
@@ -279,3 +282,4 @@ git diff --check
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
 | issue execution gate | S01-S99 | pass | S01 complete; S02 complete; S03 complete; S99 final QA/code/spec reviewers passed | commit final follow-up and create PR |
+| PR delivery gate | PR #181 | in progress | PR created against `main`; initial observation failed; repair batch U001 implemented and verified locally | run code-reviewer on repair diff, commit, push, reobserve PR |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -23,8 +23,9 @@ ID: "iss-00180"
   - S03 Guidance / dogfooding parity: 実装済み、provider/mirror parity pass、code-reviewer pass、commit 済み。
   - S99 final gate: 初回 final reviewers の P1/P2 指摘を反映済み。`doctor` malformed target rejection、PR metadata / commit status / statusCheckRollup permission coverage、`Resource not accessible by integration` 分類を追補実装済み。fresh final QA / code / spec reviewer pass。
 - handoff readiness:
-  - PR #181 created and repair loop in progress。
-  - 初回 PR observation で provider-tests failure と Codex P2 comments を検出し、repair batch `discussions/20260611t161800z-disc-pr-repair-batch.md` の U001 を実装・検証済み。local code-review P2 で PR metadata / trigger write の `GITHUB_TOKEN` source coverage と trigger integration wording も追補済み。final repair commit、push、再観測が残作業。
+  - PR #181 created and merge-prepared。
+  - 初回 PR observation で provider-tests failure と Codex P2 comments を検出し、repair batch `discussions/20260611t161800z-disc-pr-repair-batch.md` の U001 を実装・検証済み。local code-review P2 で PR metadata / trigger write の `GITHUB_TOKEN` source coverage と trigger integration wording も追補済み。
+  - repair commit `cdb4a39c0818d10ee3d151c8cac8fd1b5002fd13` を push 後、PR #181 を再観測し、CI は全 pass、最新 Codex review は major issues なし、PR は `MERGEABLE`。
 
 ## 仕様解釈・判断台帳
 | ID | Status | Type | Raised By | Gap | 検討した選択肢 | 判断 / 解釈 | Rationale | Disposition | Evidence | Follow-up |
@@ -200,6 +201,7 @@ git diff --check
 | S99 | Green / reviewer follow-up | code-reviewer P2 integration permission wording | Integration-denied PR metadata fixture passes and maps to token permission limitation | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'`; broader PR observation selector | pass | 2 passed; 56 passed / 279 deselected |
 | PR repair U001 | Red / observation | PR #181 initial observation | Provider CI failed; Codex review returned 3 unresolved P2 comments | `wait_pr_observation.sh` on PR #181 head `2fa6da0d...`; `gh run view`; local focused reproduction | fail as expected | failure classes: `check_failure:provider-tests`, `review_feedback:github-capability-classifier`, `review_feedback:token-source`, `review_feedback:missing-gh` |
 | PR repair U001 | Green | I001-I007 repair | Full provider unit lane and focused repair tests passed | focused pytest commands; full `tests/unit/infra/test_init_update.py`; mirror diffs; validate; diff check | pass | 41 runtime doctor tests passed; focused trigger selector 4 passed; 338 `test_init_update.py` tests passed |
+| PR re-observation | Green / human-gate triage | PR #181 latest head after U001 | CI passed; latest Codex review fallback comment reported no major issues; previous review threads were outside current trigger boundary, with two outdated and one residual unresolved old thread | `wait_pr_observation.sh` on head `cdb4a39c0818d10ee3d151c8cac8fd1b5002fd13`; `gh pr checks 181`; `gh pr view 181` | pass with residual disclosed | final JSON `overall_status=human_gate` due legacy unresolved thread state, but no latest-head blocking feedback remained; PR `mergeable=MERGEABLE` and all checks pass |
 
 ## ステップ契約の完了証跡
 | step | closure ids | close condition from plan | observed evidence | result | notes |
@@ -282,4 +284,17 @@ git diff --check
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
 | issue execution gate | S01-S99 | pass | S01 complete; S02 complete; S03 complete; S99 final QA/code/spec reviewers passed | commit final follow-up and create PR |
-| PR delivery gate | PR #181 | in progress | PR created against `main`; initial observation failed; repair batch U001 implemented and verified locally | run code-reviewer on repair diff, commit, push, reobserve PR |
+| PR delivery gate | PR #181 | pass | PR created against `main`; initial observation failed; repair batch U001 implemented, committed, pushed, and reobserved; latest checks pass; latest Codex review found no major issues; PR is `MERGEABLE` | human merge decision |
+
+## PR delivery / merge-prepared evidence
+| item | evidence |
+|---|---|
+| PR | https://github.com/chemitaro/spec-dock/pull/181 |
+| Base / head | `main` <- `iss-00180-github-token-capability-preflight` |
+| Latest observed repair head | `cdb4a39c0818d10ee3d151c8cac8fd1b5002fd13` |
+| PR state | `OPEN`, ready, `MERGEABLE` |
+| Checks | `validate` x2 pass; `provider-tests` x2 pass |
+| Latest Codex review signal | fallback issue comment: no major issues |
+| Observation result | `overall_status=human_gate` because one old review thread remained unresolved outside the latest trigger boundary |
+| Triage decision | old unresolved thread is non-blocking residual risk: latest repair addressed the finding, newer Codex review did not re-raise it, and checks passed |
+| Merge-prepared | yes, for human merge decision |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/report.md
@@ -91,7 +91,7 @@ ID: "iss-00180"
 |---|---|---|---|---|---|---|---|---|---|---|---|
 | S01 | delegated | runtime contract / tests / infra adapter | dev-coder | Runtime doctor capability diagnostics | `plan.md` S01 | S01 allowed paths | raw API checker, live GitHub tests, unrelated doctor findings | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py`; forbidden raw API surface inspection; `git diff --check` | broad command redesign, endpoint scope expansion, secret redaction cannot be asserted | changed files / tests / closure evidence / risks | pass: dev-coder implemented S01, follow-up fixed schema classification, code-reviewer pass |
 | S02 | delegated | shipped script behavior / final JSON compatibility | dev-coder | PR observation permission limitation classification | `plan.md` S02 | S02 allowed paths | arbitrary API args, extra write probes, retired wrapper | focused `tests/unit/infra/test_init_update.py` selection; nearby regression selector; `git diff --check` | status enum conflict, JSON compatibility break | changed files / tests / final JSON examples / risks | pass: dev-coder implemented S02, focused/nearby tests pass, code-reviewer pass after follow-ups |
-| S03 | planned delegation | shipped asset guidance / dogfooding parity | dev-coder or doc-writer | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | parity inspection and focused tests | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pending |
+| S03 | delegated | shipped asset guidance / dogfooding parity | dev-coder | Guidance and parity | `plan.md` S03 | S03 allowed paths | broad docs rewrite, credential storage guidance | provider/mirror diff inspection; focused install/parity tests; `validate`; `git diff --check` | mirror overwrite risk, scope expansion | changed files / parity evidence / risks | pass: provider guidance updated and dogfooding mirrors synced; code-reviewer pending after report evidence update |
 | S99 | planned review gates | issue-wide closure | qa-reviewer / code-reviewer / spec-reviewer | final quality gates | `plan.md` S99 | issue-wide diff | unreviewed completion | required validation commands and reviewer pass | missing closure evidence | gate verdicts / final risk | pending |
 
 ## 実装記録
@@ -107,7 +107,12 @@ ID: "iss-00180"
   - Fixed trigger comment write permission failure は `trigger_comment_write` limitation と `human_gate` として扱う。
   - auth missing / rate limit / transient / schema unavailable / invalid input を permission denied と分離した。
   - `tc-007`-`tc-011` を focused script tests で閉じた。
-- 次回実行時は `plan.md` S03 から開始する。
+- S03 complete:
+  - Provider `github-pr-observation/SKILL.md` に permission limitation semantics を追記した。
+  - Provider-side PR observation skill assets を dogfooding `.agents/skills/github-pr-observation/` に反映した。
+  - Provider-side runtime S01 changes を dogfooding `spec-dock/scripts/spec_dock_runtime/` に反映した。
+  - `tc-012` を parity inspection と focused install/parity tests で閉じた。
+- 次回実行時は `plan.md` S99 から開始する。
 
 ## 実行コマンド / 結果
 ```bash
@@ -135,6 +140,15 @@ uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 or issue_75
 uv run pytest tests/unit/infra/test_init_update.py
 # 326 passed / 4 failed
 # failures are outside S02 allowed scope: dogfooding mirror/S03 parity and existing dogfooding snapshot mismatch
+
+diff -qr src/spec_dock/assets/install_root/.agents/skills/github-pr-observation .agents/skills/github-pr-observation
+# clean
+
+diff -qr -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime
+# clean
+
+uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'
+# 40 passed
 ```
 
 ## テスト駆動開発証跡
@@ -148,12 +162,16 @@ uv run pytest tests/unit/infra/test_init_update.py
 | S02 | Reviewer follow-up | code-reviewer P2 generic permission denied | Generic `permission denied` fixture failed before follow-up and passed after classifier broadening | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | `tc-007` strengthened for S01/S02 classifier parity |
 | S02 | Reviewer follow-up | code-reviewer P2 trigger generic permission denied | Generic `permission denied while posting issue comment` fixture failed before follow-up and passed after trigger classifier broadening | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | `tc-008` strengthened for read/trigger classifier parity |
 | S02 | Refactor / guardrail | fixed contract retained | Diff stayed within S02 allowed paths; no raw endpoint/method args added | diff inspection; `git diff --check` | pass | Dogfooding mirror intentionally left for S03 |
+| S03 | Red / alternative | tc-012 inspect-only | Provider/mirror diff failed before sync; focused parity test failed 1/40 before dogfooding runtime sync | `diff -qr ...`; focused pytest selector | fail as expected | S01/S02 provider changes had not yet been mirrored |
+| S03 | Green | tc-012 pass | Provider/mirror diffs clean and focused parity tests pass | `diff -qr ...`; `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'` | pass | 40 passed |
+| S03 | Refactor / guardrail | guidance/mirror only | Diff limited to SKILL guidance and dogfooding mirrors | diff inspection; `git diff --check` | pass | No broad docs rewrite or credential storage guidance |
 
 ## ステップ契約の完了証跡
 | step | closure ids | close condition from plan | observed evidence | result | notes |
 |---|---|---|---|---|---|
 | S01 | tc-001-tc-006 | Runtime doctor capability diagnostics implemented, verified, and reviewed | Tests `34 passed`; forbidden surface inspection pass; code-reviewer pass | pass | S01 scope complete |
 | S02 | tc-007-tc-011 | PR observation permission limitation classification implemented, verified, and reviewed | Focused tests 6 passed; nearby regression 41 passed; code-reviewer pass after generic permission follow-ups | pass | S02 provider-side scope complete; S03 parity pending |
+| S03 | tc-012 | Guidance and dogfooding parity implemented, verified, and reviewed | Provider/mirror diffs clean; focused parity tests 40 passed; code-reviewer pending after report evidence update | pass | S03 scope complete |
 
 ## テスト契約の完了証跡
 | closure id / test id | step | required | evidence level | pre-implementation evidence | verification command or path | observed result | notes |
@@ -169,6 +187,7 @@ uv run pytest tests/unit/infra/test_init_update.py
 | tc-009 | S02 | yes | red-required | Focused S02 test failed before implementation because non-permission failures collapsed into generic failure | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | auth/rate/transient/schema are distinct and not `github_token_permission_denied` |
 | tc-010 | S02 | yes | red-required | Existing usage contract characterized invalid input as exit 64 | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | invalid `--head-sha` remains usage error and emits no token limitation |
 | tc-011 | S02 | yes | red-required | Focused S02 tests failed before implementation because token marker could leak in trigger helper JSON | `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02'` | pass | raw token-like stderr marker absent; limitation includes `stderr_sha256` and `secret_redacted=true` |
+| tc-012 | S03 | yes | inspect-only | Provider/mirror diffs and focused dogfooding parity test failed before sync | provider/mirror `diff -qr`; `uv run pytest tests/unit/infra/test_init_update.py -k 'github_pr_observation or checked_in_dogfooding_runtime'` | pass | PR observation skill mirror and dogfooding runtime mirror match provider-side sources excluding `__pycache__` |
 
 ## クロージャ網羅
 | closure id | step | verification evidence | result | notes |
@@ -184,6 +203,7 @@ uv run pytest tests/unit/infra/test_init_update.py
 | tc-009 | S02 | `test_issue_180_s02_checks_collector_keeps_non_permission_failures_distinct` | pass | Auth/rate/transient/schema classification covered |
 | tc-010 | S02 | `test_issue_180_s02_checks_collector_invalid_input_remains_usage_error` | pass | Usage error remains non-zero |
 | tc-011 | S02 | `test_issue_180_s02_trigger_helper_classifies_comment_permission_denied_without_secret`; snapshot permission test | pass | Secret marker excluded from final JSON |
+| tc-012 | S03 | provider/mirror diff inspections; checked-in dogfooding parity tests | pass | Shipped guidance and dogfooding mirrors align |
 
 ## クロージャ差分
 | change | closure id | test id alias | resolved closure id | reason | plan amendment required | re-review required |
@@ -192,18 +212,21 @@ uv run pytest tests/unit/infra/test_init_update.py
 | changed | tc-007 | generic permission denied fixture | tc-007 | code-reviewer P2 requested parity with S01 runtime classifier | no | yes, S02 code-reviewer re-review |
 | changed | tc-008 | generic trigger permission denied fixture | tc-008 | code-reviewer P2 requested parity with read-side classifier | no | yes, S02 code-reviewer re-review |
 | none | tc-009-tc-011 | S02 PR observation focused tests | tc-009-tc-011 | Planned closure ids closed as written | no | no |
+| none | tc-012 | S03 parity inspection and focused tests | tc-012 | Planned closure id closed as written | no | yes, S03 code-reviewer re-review |
 
 ## 委任 worker 証跡
 | step | delegated role | delegated worker summary | changed files | tests run or docs-only verification | reviewer verdict | unresolved risks | parent integration decision |
 |---|---|---|---|---|---|---|---|
 | S01 | dev-coder | Added runtime GitHub capability diagnostics, fixed CLI probe port/adapter, added focused tests; follow-up fixed `Unknown JSON field` schema classification | `application/contracts.py`; `application/ports.py`; `application/doctor.py`; `commands/doctor.py`; `cli/bootstrap.py`; `infra/github_capability_cli.py`; `presentation/cli_text.py`; `tests/cli_runtime/test_runtime_doctor_s04.py` | `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 34 passed; `git diff --check` -> pass | code-reviewer pass after follow-up | Live GitHub API behavior intentionally not tested per plan; S02 remains pending | accepted |
 | S02 | dev-coder | Added PR observation permission limitation classification for checks/status/rollup and trigger comment write, with focused script tests; follow-ups broadened generic `permission denied` matching for read and trigger paths | `fetch_pr_checks_snapshot.sh`; `fetch_pr_observation_snapshot.sh`; `trigger_codex_review.sh`; `wait_pr_observation.sh`; `tests/unit/infra/test_init_update.py` | `issue_180_s02` -> 6 passed; nearby PR observation selector -> 41 passed; `git diff --check` -> pass | code-reviewer pass after follow-ups | Full `test_init_update.py` has 4 failures in S03 parity / existing dogfooding snapshot scope | accepted |
+| S03 | dev-coder | Updated provider skill guidance and mirrored PR observation assets plus runtime dogfooding files | provider `github-pr-observation/SKILL.md`; `.agents/skills/github-pr-observation/**`; `spec-dock/scripts/spec_dock_runtime/**` | provider/mirror diffs clean; focused parity tests -> 40 passed; `validate` -> ok; `git diff --check` -> pass | code-reviewer pending after report evidence update | Live GitHub API not exercised per plan | accepted |
 
 ## ステップ commit ゲート
 | step | closure state | commit scope | commit hash / final ledger | post-commit clean check | no-op rationale | no-op checked contracts / files | no-op diff-clean command | no-op read-only confirmation |
 |---|---|---|---|---|---|---|---|---|
 | S01 | ready_to_commit | Runtime doctor capability diagnostics and S01 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
 | S02 | ready_to_commit | Provider-side PR observation permission limitation classification and S02 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
+| S03 | ready_to_commit | Guidance and dogfooding mirror parity plus S03 report evidence | pending commit | pending | N/A | N/A | N/A | N/A |
 
 ## 最終品質ゲート
 | gate | scope | result | evidence | next action |
@@ -211,4 +234,4 @@ uv run pytest tests/unit/infra/test_init_update.py
 | authoring requirement gate | `requirement.md` | pass | fresh spec-reviewer pass | complete |
 | authoring design gate | `design.md` | pass | fresh spec-reviewer pass | complete |
 | authoring plan gate | `plan.md` | pass | fresh spec-reviewer pass | complete |
-| issue execution gate | S01-S99 | in progress | S01 complete; S02 complete; S03 pending | start S03 |
+| issue execution gate | S01-S99 | in progress | S01 complete; S02 complete; S03 complete; S99 pending | start S99 |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/requirement.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/requirement.md
@@ -3,7 +3,7 @@
 ID: "iss-00180"
 タイトル: "Github Token Capability Preflight"
 関連GitHub: ["#180"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-11"
 親: ["epic-00067", "init-local-00003"]
@@ -12,88 +12,322 @@ ID: "iss-00180"
 # iss-00180 Github Token Capability Preflight — 要件定義（何を、なぜ行うか）
 
 ## 目的
-- （1〜3行）...
+- GitHub token の権限不足により PR / CI 観測が `unknown` になる前に、実際に使われる token の capability 不足として診断できるようにする。
+- `spec-dock doctor` では手動診断として GitHub token capability findings を返し、`github-pr-observation` では PR observation の final JSON に machine-readable limitation と semantic non-success を返す。
+- `GH_TOKEN` が `gh` 保存済み token より優先される実行環境でも、利用者とエージェントが原因、失敗 API、次アクションを切り分けられる状態にする。
 
 ## 背景・現状
 - 現状の挙動:
-  - ...
+  - PR observation / merge-preparer 系 workflow は `check-runs`、commit statuses、`statusCheckRollup`、PR review / comment signals を GitHub CLI / API で収集する。
+  - GitHub API 権限不足、schema failure、取得不能は observation の `unknown` や limitation として現れる。
+  - `spec-dock doctor` は spec tree / active pointer / create lock などの構造診断を持つが、GitHub token capability の診断 contract はない。
 - 現状の課題:
-  - ...
+  - `GH_TOKEN` に設定された fine-grained PAT の権限が不足していると、`gh` 保存済み token では読める API でも `Resource not accessible by personal access token` になる。
+  - 現在の利用者体験では、PR / CI が本当に不明なのか、実行 token の権限不足なのか、どの API / permission が不足しているのかを切り分けにくい。
+  - PR observation の final JSON を merge-prepared evidence として使う workflow では、権限不足を `passed` 相当として扱ってはならない。
 - 再現手順:
-  1. ...
-  2. ...
+  1. `GH_TOKEN` に checks / actions / statuses 系 read 権限が不足した token を設定する。
+  2. PR observation または GitHub checks 取得を実行する。
+  3. `gh api repos/<owner>/<repo>/commits/<sha>/check-runs --paginate`、`gh pr view <pr> --json statusCheckRollup`、`gh pr checks <pr>` が `Resource not accessible by personal access token` を返す。
+  4. `GH_TOKEN` を外して `gh` 保存済み token を使うと同じ repo / PR / commit で取得できる。
 - 観測点:
-  - UI:
-  - HTTP:
-  - DB:
-  - ログ:
+  - CLI:
+    - `spec-dock doctor`
+    - `github-pr-observation` scripts の stdout final JSON
+  - GitHub API:
+    - `check-runs`
+    - commit `status`
+    - `statusCheckRollup`
+    - PR metadata
+    - trigger comment write failure when `@codex review` posting is attempted
+  - ログ / 出力:
+    - stderr progress は authority ではない。PR observation の primary authority は stdout final JSON である。
 - 情報源:
-  - ...
+  - GitHub issue `#180`
+  - `discussions/20260611t135317z-interview-github-token-capability-scope.md`
+  - `discussions/20260611t135608z-interview-github-capability-probe-profile.md`
+  - `discussions/20260611t135901z-interview-github-capability-failure-semantics.md`
+  - `spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00170-harden-pr-monitor-stable-observation/requirement.md`
+  - `spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00176-github-pr-observation-codex-review-trigger-and-completion/requirement.md`
+  - `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh`
 
-## 対象ユーザー / 利用シナリオ（必要時）
+## 対象ユーザー / 利用シナリオ
 - 主な利用者:
-  - ...
+  - PR 作成後または push 後に GitHub checks / reviews を待つ main orchestrator。
+  - `github-pr-merge-preparer` / `github-pr-observation` を使い、merge-prepared evidence を作る agent。
+  - GitHub token / PAT 設定を調整する maintainer。
 - 代表シナリオ:
-  - ...
+  - maintainer が `spec-dock doctor` を実行し、現在の実行環境で `GH_TOKEN` が優先されていることと、core GitHub capability の不足を確認する。
+  - PR observation が `check-runs` または `statusCheckRollup` を読めない場合、stdout final JSON に permission limitation と recommended next action を含め、merge-prepared と誤判定しない。
+  - `@codex review` trigger comment の投稿権限が不足した場合、trigger write failure を PR observation の limitation として返し、blind retry や arbitrary write に広げない。
 
 ## スコープ
 - 必須:
-  - ...
+  - `doctor` と PR observation workflow の両方を scope に含める。
+  - 共通 core capability probe を fixed API set として定義する。
+  - core capability probe は repository metadata / PR read / commit check-runs read / commit statuses read / `statusCheckRollup` read を対象にする。
+  - `doctor` では core capability と optional extended checks を分けて表示する。
+  - `doctor` の PR / commit 固有 core probe は、対象 repo / PR / head SHA が明示された場合だけ実行する。
+  - `doctor` に PR / commit probe target が無い場合は、通常の structural diagnosis を維持し、GitHub PR core probe を `skipped` / `target_unavailable` diagnostic として表示できる。これは capability failure ではない。
+  - optional extended checks は `doctor` の診断表示用に限定し、次の fixed capability set だけを扱う。
+    - `actions_read`: repository Actions runs metadata read。
+    - `issue_comments_read`: PR conversation issue comments read。
+  - `doctor` standalone probe は write operation を実行しない。PR observation の固定 `@codex review` trigger write failure / success は `doctor` 表示対象ではなく、PR observation final JSON の limitation / trigger result surface で扱う。
+  - Optional extended checks は core result と分けて扱う。上記以外の GitHub capability / endpoint はこの issue の optional extended scope に含めない。
+  - `GH_TOKEN` が設定されている場合、実行時に優先される token source として明示する。ただし token value は表示しない。
+  - `Resource not accessible by personal access token` を GitHub token permission issue として分類できる。
+  - permission denied / auth missing / rate limited / transient unknown / malformed response を区別できる machine-readable result を持つ。
+  - `doctor` は capability findings を診断結果として返し、capability finding だけで structural doctor failure と混同しない。
+  - PR observation は core capability failure と trigger write failure を stdout final JSON の limitation / recommended next action / semantic non-success として返す。
+  - PR observation の permission limitation は merge-prepared evidence に使えない。
+  - malformed input、script misuse、final JSON construction failure などは command/runtime error として扱い、capability limitation と混同しない。
+  - provider-side source と dogfooding mirror の parity を維持する。
+  - token permission guidance は必要 permission の目安を示し、fine-grained PAT / classic PAT / GitHub App token の違いを断定しすぎない。
 - 禁止:
-  - ...
+  - arbitrary GitHub API checker を作らない。
+  - caller-provided endpoint / method / raw `gh` args / GraphQL / jq / headers を capability probe に受け入れない。
+  - token value、hosts.yml の secret、private payload を出力しない。
+  - capability probe のために不要な GitHub write operation を実行しない。
+  - Issue comment write capability を検査するために任意 body を投稿しない。
+  - PR observation が permission limitation を `passed` / merge-ready / merge-prepared 相当として返さない。
+  - stderr progress を final decision authority にしない。
+  - `pr-monitor` や retired wrapper を復活させない。
 - 対象外:
-  - ...
+  - GitHub token の自動発行、保存、更新。
+  - GitHub fine-grained PAT permission UI の自動操作。
+  - GitHub App / organization policy の管理。
+  - repository-specific required checks policy の全面設定機構。
+  - PR merge、auto-merge、branch cleanup、issue finish。
+  - `gh` の認証状態そのものを修復する command。
 
 ## 境界
 - 常に行う:
-  - ...
+  - fixed core probe と optional extended checks を分ける。
+  - `GH_TOKEN` 優先状態は source label として表示し、secret は表示しない。
+  - permission denied は API / capability / token source / remediation hint を machine-readable に残す。
+  - PR observation final JSON の semantic status / limitation / recommended next action を caller が読める形にする。
 - 判断が必要:
-  - ...
+  - Design phase で `permission_denied` を新しい normalized status として導入するか、既存 `unknown` / `human_gate` + limitation に留めるかを決める。
+  - Design phase で `doctor` の明示 target surface を CLI option にするか、既存 observation artifact / environment 由来にするかを決める。ただし no-target path は skipped diagnostic とする。
+  - なし。PR observation の fixed trigger write failure / success は `doctor` 表示対象から外し、PR observation final JSON のみで扱う。
+  - `doctor` の structural findings と capability findings を同じ `DoctorFinding` に入れるか、別の diagnostic channel に分けるかを決める。
 - 行わない:
-  - ...
+  - GitHub API 全般の permission scanner にしない。
+  - GitHub CLI の credential store を読み取って secret を表示しない。
+  - PR observation の read-only / fixed trigger write 境界を広げない。
 
 ## 非交渉制約
-- ...
+- Capability probe は fixed endpoint set に閉じる。
+- Core probe は PR checks / statuses 観測に必要な最小 capability に固定する。
+- PR / commit 固有 probe は target context なしに推測実行しない。
+- Target context がない `doctor` 実行は capability failure ではなく target unavailable / skipped diagnostic とする。
+- Optional extended checks は `doctor` 表示用であり、PR observation の必須 success 条件に混ぜない。
+- Optional extended checks は `actions_read`、`issue_comments_read` に限定し、不要な write operation を発生させない。
+- `doctor` は capability findings を返せるが、capability finding だけを spec tree structural failure として扱わない。
+- PR observation は permission limitation を semantic non-success として扱い、merge-prepared evidence に使わない。
+- stdout final JSON が PR observation の primary authority である。
+- Token value / secret / private payload は絶対に出力しない。
 
 ## 前提
-- ...
+- 実行環境には GitHub CLI `gh` がある。
+- 対象 repo / PR / commit が probe の入力として解決できる。
+- `doctor` の PR / commit 固有 probe は対象 repo / PR / head SHA の target context を必要とし、target context が無い通常 `doctor` 実行では probe skipped とする。
+- `GH_TOKEN` が設定されている場合、GitHub CLI はそれを保存済み token より優先する。
+- `github-pr-observation` の provider-side source of truth は `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/` である。
+- Dogfooding mirror `.agents/skills/github-pr-observation/` は provider-side source と parity を保つ。
+- `doctor` runtime の provider-side source of truth は `src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/` である。
 
 ## 受け入れ条件
-- AC-001:
+- AC-001: `doctor` が明示 target 付きで core capability findings を表示する
   - アクター:
+    - maintainer
   - 前提:
+    - `GH_TOKEN` が優先されている。
+    - maintainer が対象 repo / PR / head SHA を明示して GitHub PR core probe を有効にしている。
+    - core capability のうち `check-runs` または `statusCheckRollup` read が permission denied になる。
   - 操作:
+    - maintainer が `spec-dock doctor` の GitHub PR core probe path を実行する。
   - 期待結果:
+    - `doctor` は token source と failing capability を secret なしで表示する。
+    - `Resource not accessible by personal access token` は token permission issue として説明される。
+    - structural spec tree failure と capability finding は混同されない。
   - 観測点:
-- AC-002:
-  - ...
+    - CLI runtime test
+    - doctor rendering assertion
+
+- AC-001b: `doctor` が target なしでは PR core probe を失敗扱いしない
+  - アクター:
+    - maintainer
+  - 前提:
+    - repo 内で通常の `spec-dock doctor` を実行する。
+    - PR number / head SHA などの PR core probe target は明示されていない。
+  - 操作:
+    - maintainer が `spec-dock doctor` を実行する。
+  - 期待結果:
+    - structural diagnosis は従来どおり実行される。
+    - GitHub PR core probe は `skipped` / `target_unavailable` diagnostic として表現され、permission denied や structural failure として扱われない。
+    - token value は表示されない。
+  - 観測点:
+    - CLI runtime test
+    - doctor rendering assertion
+
+- AC-002: PR observation が permission limitation を final JSON に返す
+  - アクター:
+    - main orchestrator / `github-pr-merge-preparer`
+  - 前提:
+    - `check-runs`、commit statuses、または `statusCheckRollup` が token permission で取得できない。
+  - 操作:
+    - `github-pr-observation` の snapshot または wait script を実行する。
+  - 期待結果:
+    - stdout final JSON に permission limitation、failing capability、recommended next action が含まれる。
+    - normalized status は merge-prepared に使えない non-success になる。
+    - process exit code は final JSON が構築できる限り原則 0 を維持する。
+  - 観測点:
+    - script stub test
+    - final JSON assertion
+
+- AC-003: trigger write failure が core read failure と分離される
+  - アクター:
+    - main orchestrator
+  - 前提:
+    - core read capability は足りているが、`@codex review` trigger comment の投稿が permission denied になる。
+  - 操作:
+    - `wait_pr_observation.sh` を trigger posting path で実行する。
+  - 期待結果:
+    - trigger write failure は core read failure とは別の limitation として返る。
+    - blind retry や arbitrary write に広がらない。
+    - final JSON は human gate / permission remediation を促す。
+  - 観測点:
+    - trigger script / wait script stub test
+    - limitation code assertion
+
+- AC-004: capability probe が secret を出力しない
+  - アクター:
+    - maintainer / reviewer
+  - 前提:
+    - `GH_TOKEN` または `gh` credential store が存在する。
+  - 操作:
+    - `doctor` と PR observation failure path を実行する。
+  - 期待結果:
+    - 出力には token source label と capability result だけが含まれ、token value、hosts.yml secret、private payload は含まれない。
+  - 観測点:
+    - output assertion
+    - forbidden token assertion
+
+- AC-005: capability probe が fixed endpoint set に閉じる
+  - アクター:
+    - implementer / reviewer
+  - 前提:
+    - capability probe を実装する。
+  - 操作:
+    - API invocation surface と script arguments を確認する。
+  - 期待結果:
+    - caller-provided endpoint / method / raw `gh` args / GraphQL / jq / headers は受け付けない。
+    - probe は requirement で固定した core / extended capability に限定される。
+  - 観測点:
+    - unit test
+    - script usage validation
+    - code review
+
+- AC-006: malformed input と capability limitation が分離される
+  - アクター:
+    - implementer / maintainer
+  - 前提:
+    - repo slug missing、PR number missing、invalid JSON など command/runtime error が起きる。
+  - 操作:
+    - `doctor` または PR observation を不正入力 / malformed response path で実行する。
+  - 期待結果:
+    - script misuse / malformed input / JSON construction failure は command/runtime error として扱われる。
+    - GitHub token permission limitation と誤分類されない。
+  - 観測点:
+    - negative test
+
+- AC-007: `doctor` が optional extended checks を core と分離して表示する
+  - アクター:
+    - maintainer / reviewer
+  - 前提:
+    - `doctor` の GitHub capability diagnosis が有効である。
+    - core probe target は明示されている、または core probe は target unavailable として skipped されている。
+  - 操作:
+    - maintainer が `spec-dock doctor` を実行する。
+  - 期待結果:
+    - optional extended checks は core capability result と別の group / field / label で表示される。
+    - `actions_read`、`issue_comments_read` は optional extended check として扱われ、core pass / fail を汚さない。
+    - 上記以外の GitHub capability は skipped / out-of-scope として扱われる。
+    - optional extended checks のために不要な GitHub write operation は実行されない。
+  - 観測点:
+    - CLI runtime test
+    - no-write assertion
+    - doctor rendering assertion
 
 ## 例外・エッジケース
-- EC-001:
+- EC-001: `GH_TOKEN` missing
   - 条件:
+    - `GH_TOKEN` が未設定で、`gh` 保存済み token が使われる。
   - 期待:
+    - token source は saved `gh` auth 相当として表示される。secret は表示しない。
   - 観測点:
-- EC-002:
-  - ...
+    - doctor rendering assertion
 
-## 入力→出力例（必要時）
-- EX-001:
+- EC-002: auth missing
+  - 条件:
+    - GitHub CLI が認証されていない。
+  - 期待:
+    - auth missing と permission denied を区別し、`gh auth login` または token 設定確認を促す。
+  - 観測点:
+    - CLI / script stub test
+
+- EC-003: rate limit / transient failure
+  - 条件:
+    - GitHub API が rate limit、network、temporary unavailable、schema mismatch を返す。
+  - 期待:
+    - permission denied と区別し、transient / unknown limitation として扱う。
+  - 観測点:
+    - script stub test
+
+- EC-004: partial capability
+  - 条件:
+    - PR metadata は読めるが check-runs が読めない、または check-runs は読めるが `statusCheckRollup` が読めない。
+  - 期待:
+    - capability ごとの result を返し、失敗した API だけを remediation 対象として示す。
+  - 観測点:
+    - unit / script test
+
+- EC-005: optional extended check unavailable
+  - 条件:
+    - `doctor` の optional extended checks が一部確認できない。
+  - 期待:
+    - core capability result と分けて表示し、PR observation の core success / failure 判定を汚さない。
+  - 観測点:
+    - doctor rendering assertion
+
+## 入力→出力例
+- EX-001: `doctor` の capability finding
   - 入力:
+    - `GH_TOKEN` が優先され、`check-runs` read が `Resource not accessible by personal access token` を返す。
   - 出力:
+    - `github_token_capability` finding / diagnostic に `token_source=GH_TOKEN`, `capability=check_runs_read`, `status=permission_denied`, `api=check-runs`, `secret_redacted=true` が含まれる。
+
+- EX-002: PR observation final JSON
+  - 入力:
+    - `fetch_pr_observation_snapshot.sh` が checks collector で permission denied を受け取る。
+  - 出力:
+    - `normalized_status` は merge-prepared に使えない non-success。
+    - `limitations[]` に permission limitation object が含まれる。
+    - `recommended_next_action` は token permission remediation / human gate を示す。
 
 ## 用語（ドメイン語彙）
-- TERM-001:
-  - ...
+- TERM-001: core capability probe
+  - PR checks / statuses 観測に必要な fixed endpoint set の read-only probe。repository metadata、PR read、check-runs、commit statuses、`statusCheckRollup` を対象にする。
+- TERM-002: optional extended checks
+  - `doctor` 表示用の追加診断。`actions_read`、`issue_comments_read` だけを扱う。上記以外の GitHub capability / endpoint はこの issue の optional extended checks に含めない。
+- TERM-003: token source
+  - 実行時に GitHub CLI が使う token の由来を示す label。`GH_TOKEN`、saved gh auth、unknown など。secret value ではない。
+- TERM-004: semantic non-success
+  - process が final JSON を返せても、workflow evidence として成功ではない状態。PR observation では merge-prepared evidence に使えない。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+- なし:
+  - Scope、probe profile、failure semantics は adopted interview 3件で確定済み。

--- a/spec-dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/contracts.py
@@ -83,7 +83,7 @@ GitHubCapabilityStatus = Literal[
     "schema_unavailable",
     "skipped",
 ]
-GitHubCapabilityTokenSource = Literal["GH_TOKEN", "gh_saved_auth", "unknown"]
+GitHubCapabilityTokenSource = Literal["GH_TOKEN", "GITHUB_TOKEN", "gh_saved_auth", "unknown"]
 GitHubCapabilitySeverity = Literal["info", "warning", "blocking"]
 GitHubCapabilityGroup = Literal["core", "extended"]
 GitHubCapabilityDiagnosticCode = Literal[

--- a/spec-dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/contracts.py
@@ -57,7 +57,68 @@ class ValidationResult:
 
 @dataclass(frozen=True)
 class DoctorRequest:
-    pass
+    github_repo: str | None = None
+    github_pr: int | None = None
+    github_head_sha: str | None = None
+    github_extended: bool = False
+
+
+GitHubCapability = Literal[
+    "repo_metadata_read",
+    "pull_request_read",
+    "check_runs_read",
+    "commit_statuses_read",
+    "status_check_rollup_read",
+    "actions_read",
+    "issue_comments_read",
+    "trigger_comment_write",
+]
+GitHubCapabilityStatus = Literal[
+    "ok",
+    "permission_denied",
+    "auth_missing",
+    "rate_limited",
+    "target_unavailable",
+    "transient_unknown",
+    "schema_unavailable",
+    "skipped",
+]
+GitHubCapabilityTokenSource = Literal["GH_TOKEN", "gh_saved_auth", "unknown"]
+GitHubCapabilitySeverity = Literal["info", "warning", "blocking"]
+GitHubCapabilityGroup = Literal["core", "extended"]
+GitHubCapabilityDiagnosticCode = Literal[
+    "github_capability_ok",
+    "github_token_permission_denied",
+    "github_auth_missing",
+    "github_rate_limited",
+    "github_target_unavailable",
+    "github_transient_unknown",
+    "github_schema_unavailable",
+    "github_capability_skipped",
+]
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityProbeRequest:
+    github_repo: str
+    github_pr: int
+    github_head_sha: str
+    include_extended: bool = False
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityDiagnostic:
+    code: GitHubCapabilityDiagnosticCode
+    capability: GitHubCapability
+    status: GitHubCapabilityStatus
+    token_source: GitHubCapabilityTokenSource
+    api: str
+    severity: GitHubCapabilitySeverity
+    message: str
+    recommended_next_action: str
+    secret_redacted: bool
+    stderr_sha256: str | None
+    group: GitHubCapabilityGroup
 
 
 @dataclass(frozen=True)
@@ -81,6 +142,7 @@ class DoctorResult:
     ok: bool
     findings: list[DoctorFinding]
     warnings: list[str]
+    github_capability_diagnostics: list[GitHubCapabilityDiagnostic] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -678,7 +740,7 @@ class UseCases:
         RuntimeError("issue_finish is not configured")
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
-        lambda _req: DoctorResult(ok=True, findings=[], warnings=[])
+        lambda _req: DoctorResult(ok=True, findings=[], warnings=[], github_capability_diagnostics=[])
     )
     worktree_create: Callable[[WorktreeCreateRequest], WorktreeCreateResult] = lambda _req: (_ for _ in ()).throw(
         RuntimeError("worktree_create is not configured")

--- a/spec-dock/scripts/spec_dock_runtime/application/doctor.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/doctor.py
@@ -10,6 +10,7 @@ from ..infra.contracts import ActiveManifestEntry, StoredMetaRecord
 from . import create_node as app_create_node
 from .artifact_preflight import validate_required_artifacts_for_graph
 from .contracts import DoctorFinding, DoctorRequest, DoctorResult
+from .contracts import GitHubCapabilityDiagnostic, GitHubCapabilityProbeRequest
 from .ports import Ports
 from .repo_context import resolve_current_repo_slug
 
@@ -322,8 +323,53 @@ def _stale_create_lock_finding(specdock_dir: Path) -> DoctorFinding | None:
     )
 
 
+def _github_target_unavailable_diagnostic() -> GitHubCapabilityDiagnostic:
+    return GitHubCapabilityDiagnostic(
+        code="github_target_unavailable",
+        capability="check_runs_read",
+        status="target_unavailable",
+        token_source="unknown",
+        api="github_pr_core_probe",
+        severity="info",
+        message="GitHub PR capability probe skipped because repo, PR, or head SHA was not provided.",
+        recommended_next_action="provide_github_repo_pr_and_head_sha_for_capability_probe",
+        secret_redacted=True,
+        stderr_sha256=None,
+        group="core",
+    )
+
+
+def _github_gateway_unavailable_diagnostic() -> GitHubCapabilityDiagnostic:
+    return GitHubCapabilityDiagnostic(
+        code="github_capability_skipped",
+        capability="check_runs_read",
+        status="skipped",
+        token_source="unknown",
+        api="github_pr_core_probe",
+        severity="info",
+        message="GitHub capability gateway is unavailable.",
+        recommended_next_action="run_in_installed_runtime_with_github_capability_gateway",
+        secret_redacted=True,
+        stderr_sha256=None,
+        group="core",
+    )
+
+
+def _github_capability_diagnostics(req: DoctorRequest, ports: Ports) -> list[GitHubCapabilityDiagnostic]:
+    if not (req.github_repo and req.github_pr is not None and req.github_head_sha):
+        return [_github_target_unavailable_diagnostic()]
+    if ports.github_capability_gateway is None:
+        return [_github_gateway_unavailable_diagnostic()]
+    probe_request = GitHubCapabilityProbeRequest(
+        github_repo=req.github_repo,
+        github_pr=req.github_pr,
+        github_head_sha=req.github_head_sha,
+        include_extended=req.github_extended,
+    )
+    return ports.github_capability_gateway.probe(probe_request)
+
+
 def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
-    del req
     warnings: list[str] = []
     findings: list[DoctorFinding] = []
     graph: SpecGraph | None = None
@@ -335,7 +381,12 @@ def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
 
     if has_legacy_workspace and not has_current_workspace:
         findings.append(_legacy_only_workspace_finding(legacy_dir=legacy_dir))
-        return DoctorResult(ok=False, findings=findings, warnings=warnings)
+        return DoctorResult(
+            ok=False,
+            findings=findings,
+            warnings=warnings,
+            github_capability_diagnostics=_github_capability_diagnostics(req, ports),
+        )
 
     try:
         records = ports.node_reader.load_node_records()
@@ -380,4 +431,9 @@ def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
     if has_current_workspace and has_legacy_workspace and not findings:
         _append_unique(warnings, "legacy_cleanup_pending")
 
-    return DoctorResult(ok=(len(findings) == 0), findings=findings, warnings=warnings)
+    return DoctorResult(
+        ok=(len(findings) == 0),
+        findings=findings,
+        warnings=warnings,
+        github_capability_diagnostics=_github_capability_diagnostics(req, ports),
+    )

--- a/spec-dock/scripts/spec_dock_runtime/application/ports.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/ports.py
@@ -7,6 +7,8 @@ from typing import Protocol
 
 from .contracts import ArtifactWriteResult
 from .contracts import BootstrapResult
+from .contracts import GitHubCapabilityDiagnostic
+from .contracts import GitHubCapabilityProbeRequest
 from .contracts import GitWorktreeRecord
 from .contracts import SyncCommandResult
 from .contracts import SyncRequest
@@ -167,6 +169,11 @@ class GitGateway(Protocol):
         ...
 
 
+class GitHubCapabilityGateway(Protocol):
+    def probe(self, request: GitHubCapabilityProbeRequest) -> list[GitHubCapabilityDiagnostic]:
+        ...
+
+
 class BootstrapGateway(Protocol):
     def run_make_init_if_available(self, worktree_path: Path) -> BootstrapResult:
         ...
@@ -228,6 +235,7 @@ class Ports:
     active_state_store: ActiveStateStore | None = None
     deps_topology_reader: DepsTopologyReader | None = None
     git_gateway: GitGateway | None = None
+    github_capability_gateway: GitHubCapabilityGateway | None = None
     json_store: JsonStore | None = None
     clock: Clock | None = None
     artifact_writer: ArtifactWriter | None = None

--- a/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/spec-dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -37,6 +37,7 @@ from ..infra import derived_state_reader as infra_derived_state_reader
 from ..infra import fs_cli as infra_fs_cli
 from ..infra import fs_repo as infra_fs_repo
 from ..infra import git_cli as infra_git_cli
+from ..infra import github_capability_cli as infra_github_capability_cli
 from ..infra import github_cli as infra_github_cli
 from ..infra import json_store as infra_json_store
 from ..infra import make_cli as infra_make_cli
@@ -205,6 +206,12 @@ class _GitGateway:
 
 
 @dataclass(frozen=True)
+class _GitHubCapabilityGateway:
+    def probe(self, request):
+        return infra_github_capability_cli.GitHubCapabilityCliGateway().probe(request)
+
+
+@dataclass(frozen=True)
 class _BootstrapGateway:
     def run_make_init_if_available(self, worktree_path: Path):
         return infra_make_cli.run_make_init_if_available(worktree_path)
@@ -264,6 +271,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         active_state_store=_ActiveStateStore(),
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
+        github_capability_gateway=_GitHubCapabilityGateway(),
         bootstrap_gateway=_BootstrapGateway(),
         environment_gateway=_EnvironmentGateway(),
         filesystem_gateway=_FilesystemGateway(),

--- a/spec-dock/scripts/spec_dock_runtime/commands/doctor.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from dataclasses import dataclass
 
 from ..application.contracts import DoctorRequest, UseCases
@@ -27,9 +28,21 @@ def command_specs() -> dict[str, CommandSpec]:
 
 
 def _add_doctor_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--github-repo", help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo")
-    parser.add_argument("--github-pr", type=int, help="GitHub pull request number for fixed capability diagnostics")
-    parser.add_argument("--github-head-sha", help="GitHub PR head SHA for fixed capability diagnostics")
+    parser.add_argument(
+        "--github-repo",
+        type=_github_repo_arg,
+        help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo",
+    )
+    parser.add_argument(
+        "--github-pr",
+        type=_github_pr_arg,
+        help="GitHub pull request number for fixed capability diagnostics",
+    )
+    parser.add_argument(
+        "--github-head-sha",
+        type=_github_head_sha_arg,
+        help="GitHub PR head SHA for fixed capability diagnostics",
+    )
     parser.add_argument(
         "--github-extended",
         action="store_true",
@@ -64,3 +77,25 @@ def _expect_doctor_args(args: CommandArgs) -> DoctorArgs:
     if not isinstance(args, DoctorArgs):
         raise RuntimeError("Invalid command args for doctor")
     return args
+
+
+def _github_repo_arg(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value or ""):
+        return value
+    raise argparse.ArgumentTypeError("--github-repo must be OWNER/REPO")
+
+
+def _github_pr_arg(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--github-pr must be a positive integer") from exc
+    if parsed > 0:
+        return parsed
+    raise argparse.ArgumentTypeError("--github-pr must be a positive integer")
+
+
+def _github_head_sha_arg(value: str) -> str:
+    if re.fullmatch(r"[0-9A-Fa-f]{7,64}", value or ""):
+        return value
+    raise argparse.ArgumentTypeError("--github-head-sha must be a 7-64 character hex SHA")

--- a/spec-dock/scripts/spec_dock_runtime/commands/doctor.py
+++ b/spec-dock/scripts/spec_dock_runtime/commands/doctor.py
@@ -10,7 +10,10 @@ from .contracts import CommandArgs, CommandOutcome, CommandSpec
 
 @dataclass(frozen=True)
 class DoctorArgs(CommandArgs):
-    pass
+    github_repo: str | None = None
+    github_pr: int | None = None
+    github_head_sha: str | None = None
+    github_extended: bool = False
 
 
 def command_specs() -> dict[str, CommandSpec]:
@@ -24,17 +27,35 @@ def command_specs() -> dict[str, CommandSpec]:
 
 
 def _add_doctor_arguments(parser: argparse.ArgumentParser) -> None:
-    del parser
+    parser.add_argument("--github-repo", help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo")
+    parser.add_argument("--github-pr", type=int, help="GitHub pull request number for fixed capability diagnostics")
+    parser.add_argument("--github-head-sha", help="GitHub PR head SHA for fixed capability diagnostics")
+    parser.add_argument(
+        "--github-extended",
+        action="store_true",
+        help="Include fixed optional GitHub capability diagnostics",
+    )
 
 
 def _doctor_args(ns: argparse.Namespace) -> CommandArgs:
-    del ns
-    return DoctorArgs()
+    return DoctorArgs(
+        github_repo=ns.github_repo,
+        github_pr=ns.github_pr,
+        github_head_sha=ns.github_head_sha,
+        github_extended=bool(ns.github_extended),
+    )
 
 
 def _run_doctor(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
-    _expect_doctor_args(args)
-    result = use_cases.doctor(DoctorRequest())
+    doctor_args = _expect_doctor_args(args)
+    result = use_cases.doctor(
+        DoctorRequest(
+            github_repo=doctor_args.github_repo,
+            github_pr=doctor_args.github_pr,
+            github_head_sha=doctor_args.github_head_sha,
+            github_extended=doctor_args.github_extended,
+        )
+    )
     text = render_doctor_text(result)
     return CommandOutcome(exit_code=(0 if result.ok else 1), text=text)
 

--- a/spec-dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
+++ b/spec-dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from dataclasses import dataclass
+
+from ..application.contracts import GitHubCapability
+from ..application.contracts import GitHubCapabilityDiagnostic
+from ..application.contracts import GitHubCapabilityDiagnosticCode
+from ..application.contracts import GitHubCapabilityGroup
+from ..application.contracts import GitHubCapabilityProbeRequest
+from ..application.contracts import GitHubCapabilitySeverity
+from ..application.contracts import GitHubCapabilityStatus
+from ..application.contracts import GitHubCapabilityTokenSource
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityCliGateway:
+    def probe(self, request: GitHubCapabilityProbeRequest) -> list[GitHubCapabilityDiagnostic]:
+        checks: list[tuple[GitHubCapability, GitHubCapabilityGroup, str, list[str]]] = [
+            (
+                "repo_metadata_read",
+                "core",
+                "gh repo view",
+                ["gh", "repo", "view", request.github_repo, "--json", "nameWithOwner"],
+            ),
+            (
+                "pull_request_read",
+                "core",
+                "gh pr view",
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(request.github_pr),
+                    "--repo",
+                    request.github_repo,
+                    "--json",
+                    "number,headRefOid",
+                ],
+            ),
+            (
+                "check_runs_read",
+                "core",
+                "GET /repos/{repo}/commits/{sha}/check-runs",
+                [
+                    "gh",
+                    "api",
+                    f"repos/{request.github_repo}/commits/{request.github_head_sha}/check-runs",
+                    "--paginate",
+                ],
+            ),
+            (
+                "commit_statuses_read",
+                "core",
+                "GET /repos/{repo}/commits/{sha}/status",
+                ["gh", "api", f"repos/{request.github_repo}/commits/{request.github_head_sha}/status"],
+            ),
+            (
+                "status_check_rollup_read",
+                "core",
+                "gh pr view --json statusCheckRollup",
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(request.github_pr),
+                    "--repo",
+                    request.github_repo,
+                    "--json",
+                    "statusCheckRollup",
+                ],
+            ),
+        ]
+        if request.include_extended:
+            checks.extend(
+                [
+                    (
+                        "actions_read",
+                        "extended",
+                        "GET /repos/{repo}/actions/runs",
+                        ["gh", "api", f"repos/{request.github_repo}/actions/runs"],
+                    ),
+                    (
+                        "issue_comments_read",
+                        "extended",
+                        "GET /repos/{repo}/issues/{pr}/comments",
+                        ["gh", "api", f"repos/{request.github_repo}/issues/{request.github_pr}/comments"],
+                    ),
+                ]
+            )
+        return [
+            _diagnostic_from_completed_process(
+                capability=capability,
+                group=group,
+                api=api,
+                completed=_run_fixed_gh(command),
+            )
+            for capability, group, api, command in checks
+        ]
+
+
+def _run_fixed_gh(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _diagnostic_from_completed_process(
+    *,
+    capability: GitHubCapability,
+    group: GitHubCapabilityGroup,
+    api: str,
+    completed: subprocess.CompletedProcess[str],
+) -> GitHubCapabilityDiagnostic:
+    status = _classify_status(completed)
+    code = _code_for_status(status)
+    return GitHubCapabilityDiagnostic(
+        code=code,
+        capability=capability,
+        status=status,
+        token_source=_token_source(),
+        api=api,
+        severity=_severity_for_status(status),
+        message=_message_for_status(status),
+        recommended_next_action=_action_for_status(status),
+        secret_redacted=True,
+        stderr_sha256=_stderr_sha256(completed.stderr),
+        group=group,
+    )
+
+
+def _token_source() -> GitHubCapabilityTokenSource:
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    return "gh_saved_auth"
+
+
+def _stderr_sha256(stderr: str) -> str | None:
+    if not stderr:
+        return None
+    return hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+
+
+def _classify_status(completed: subprocess.CompletedProcess[str]) -> GitHubCapabilityStatus:
+    if completed.returncode == 0:
+        return "ok"
+    stderr = completed.stderr.lower()
+    if "resource not accessible by personal access token" in stderr or "permission denied" in stderr:
+        return "permission_denied"
+    if "authentication" in stderr or "not logged into" in stderr or "could not resolve to a repository" in stderr:
+        return "auth_missing"
+    if "rate limit" in stderr or "api rate limit exceeded" in stderr:
+        return "rate_limited"
+    if "unknown json field" in stderr:
+        return "schema_unavailable"
+    if "field" in stderr and ("not found" in stderr or "doesn't exist" in stderr):
+        return "schema_unavailable"
+    if completed.returncode in (1, 2, 4):
+        return "transient_unknown"
+    return "transient_unknown"
+
+
+def _code_for_status(status: GitHubCapabilityStatus) -> GitHubCapabilityDiagnosticCode:
+    if status == "ok":
+        return "github_capability_ok"
+    if status == "permission_denied":
+        return "github_token_permission_denied"
+    if status == "auth_missing":
+        return "github_auth_missing"
+    if status == "rate_limited":
+        return "github_rate_limited"
+    if status == "schema_unavailable":
+        return "github_schema_unavailable"
+    if status == "skipped":
+        return "github_capability_skipped"
+    if status == "target_unavailable":
+        return "github_target_unavailable"
+    return "github_transient_unknown"
+
+
+def _severity_for_status(status: GitHubCapabilityStatus) -> GitHubCapabilitySeverity:
+    if status == "ok" or status == "skipped" or status == "target_unavailable":
+        return "info"
+    if status == "transient_unknown" or status == "rate_limited" or status == "schema_unavailable":
+        return "warning"
+    return "blocking"
+
+
+def _message_for_status(status: GitHubCapabilityStatus) -> str:
+    messages = {
+        "ok": "GitHub capability probe succeeded.",
+        "permission_denied": "GitHub token lacks permission for this fixed capability.",
+        "auth_missing": "GitHub authentication is missing or unavailable.",
+        "rate_limited": "GitHub API rate limit blocked this fixed capability probe.",
+        "target_unavailable": "GitHub target context is unavailable.",
+        "transient_unknown": "GitHub capability probe failed with an unclassified transient error.",
+        "schema_unavailable": "GitHub response schema is unavailable for this fixed capability.",
+        "skipped": "GitHub capability probe was skipped.",
+    }
+    return messages[status]
+
+
+def _action_for_status(status: GitHubCapabilityStatus) -> str:
+    actions = {
+        "ok": "none",
+        "permission_denied": "fix_github_token_permissions",
+        "auth_missing": "authenticate_gh_or_set_token",
+        "rate_limited": "retry_after_rate_limit_reset",
+        "target_unavailable": "provide_github_repo_pr_and_head_sha_for_capability_probe",
+        "transient_unknown": "retry_or_inspect_github",
+        "schema_unavailable": "inspect_gh_version_or_api_schema",
+        "skipped": "run_in_installed_runtime_with_github_capability_gateway",
+    }
+    return actions[status]

--- a/spec-dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
+++ b/spec-dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
@@ -102,13 +102,16 @@ class GitHubCapabilityCliGateway:
 
 
 def _run_fixed_gh(command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        command,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        return subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(command, 127, "", "gh executable not found")
 
 
 def _diagnostic_from_completed_process(
@@ -138,6 +141,8 @@ def _diagnostic_from_completed_process(
 def _token_source() -> GitHubCapabilityTokenSource:
     if os.environ.get("GH_TOKEN"):
         return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
     return "gh_saved_auth"
 
 
@@ -151,9 +156,18 @@ def _classify_status(completed: subprocess.CompletedProcess[str]) -> GitHubCapab
     if completed.returncode == 0:
         return "ok"
     stderr = completed.stderr.lower()
-    if "resource not accessible by personal access token" in stderr or "permission denied" in stderr:
+    if (
+        "resource not accessible by personal access token" in stderr
+        or "resource not accessible by integration" in stderr
+        or "permission denied" in stderr
+    ):
         return "permission_denied"
-    if "authentication" in stderr or "not logged into" in stderr or "could not resolve to a repository" in stderr:
+    if (
+        "authentication" in stderr
+        or "not logged into" in stderr
+        or "could not resolve to a repository" in stderr
+        or "gh executable not found" in stderr
+    ):
         return "auth_missing"
     if "rate limit" in stderr or "api rate limit exceeded" in stderr:
         return "rate_limited"

--- a/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/spec-dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -55,9 +55,13 @@ def render_validate_text(result: ValidationResult) -> CliText:
 
 def render_doctor_text(result: DoctorResult) -> CliText:
     warnings = [_doctor_warning_message(warning) for warning in result.warnings]
+    capability_lines = _render_github_capability_diagnostics(result)
     if result.ok:
         return CliText(
-            stdout_lines=["spec-dock: ok (doctor) findings=0"],
+            stdout_lines=[
+                "spec-dock: ok (doctor) findings=0",
+                *capability_lines,
+            ],
             stderr_lines=[],
             warnings=warnings,
         )
@@ -67,12 +71,35 @@ def render_doctor_text(result: DoctorResult) -> CliText:
         stderr_lines.append(f"- [{finding.code}] {finding.message}")
         for guidance in finding.guidance:
             stderr_lines.append(f"  -> {guidance}")
+    stderr_lines.extend(capability_lines)
 
     return CliText(
         stdout_lines=[],
         stderr_lines=stderr_lines,
         warnings=warnings,
     )
+
+
+def _render_github_capability_diagnostics(result: DoctorResult) -> list[str]:
+    diagnostics = list(result.github_capability_diagnostics)
+    if not diagnostics:
+        return []
+    lines = [f"spec-dock: github capability diagnostics={len(diagnostics)}"]
+    for diagnostic in diagnostics:
+        stderr_hash = f" stderr_sha256={diagnostic.stderr_sha256}" if diagnostic.stderr_sha256 else ""
+        lines.append(
+            f"- [github:{diagnostic.group}] "
+            f"code={diagnostic.code} "
+            f"capability={diagnostic.capability} "
+            f"status={diagnostic.status} "
+            f"api={diagnostic.api} "
+            f"token_source={diagnostic.token_source} "
+            f"severity={diagnostic.severity} "
+            f"recommended_next_action={diagnostic.recommended_next_action} "
+            f"secret_redacted={str(diagnostic.secret_redacted).lower()}"
+            f"{stderr_hash}"
+        )
+    return lines
 
 
 def _rel_path_for_output(path_text: str) -> str:

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md
@@ -44,6 +44,25 @@ Triage and judgment over collected evidence belong to
   machine-readable `limitations`.
 - `summary.md` is never generated.
 
+## Permission Limitations
+
+- The final JSON written to `stdout` is the authority for permission limitation
+  semantics; `stderr` progress is non-authoritative.
+- GitHub token permission failures are reported with
+  `limitations[].code="github_token_permission_denied"` and
+  `recommended_next_action="fix_github_token_permissions"`.
+- Read permission failures for checks, statuses, or status rollup keep process
+  exit success when final JSON can be built, but return semantic non-success:
+  `normalized_status="unknown"` and `overall_status="unknown"`.
+- The fixed `@codex review` trigger comment write failure is separate from read
+  collection failures. It returns `normalized_status="human_gate"`,
+  `overall_status="human_gate"`, and a
+  `limitations[].capability="trigger_comment_write"` permission limitation.
+- These scripts remain a fixed PR observation surface, not an arbitrary GitHub
+  permission scanner. Do not add caller-provided endpoints, methods, GraphQL,
+  headers, request bodies, `jq`, or raw `gh` arguments.
+- Token values, `hosts.yml` secrets, and private payloads must never be emitted.
+
 ## Entry Points
 
 ```bash

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -308,7 +308,11 @@ def has_permission_limitation():
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def classify_github_stderr(stderr):

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -307,6 +307,107 @@ def has_permission_limitation():
     )
 
 
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def classify_github_stderr(stderr):
+    lowered = (stderr or "").lower()
+    if (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    ):
+        return "permission_denied"
+    if (
+        "requires authentication" in lowered
+        or "authentication required" in lowered
+        or "not logged into" in lowered
+        or "http 401" in lowered
+    ):
+        return "auth_missing"
+    if "rate limit" in lowered or "http 429" in lowered:
+        return "rate_limited"
+    if "unknown json field" in lowered:
+        return "schema_unavailable"
+    if (
+        "http 5" in lowered
+        or "timeout" in lowered
+        or "timed out" in lowered
+        or "temporarily unavailable" in lowered
+        or "connection reset" in lowered
+    ):
+        return "transient_unknown"
+    return "unknown"
+
+
+def pr_metadata_failure_limitation(*, exit_code, stderr, default_code, default_message):
+    classification = classify_github_stderr(stderr)
+    stderr_sha256 = hashlib.sha256((stderr or "").encode()).hexdigest()
+    base = {
+        "capability": "pull_request_read",
+        "api": "gh pr view --json headRefOid,url,state,isDraft,number",
+        "source": "gh_pr_view",
+        "token_source": token_source(),
+        "secret_redacted": True,
+        "stderr_sha256": stderr_sha256,
+        "exit_code": exit_code,
+    }
+    if classification == "permission_denied":
+        return {
+            **base,
+            "code": "github_token_permission_denied",
+            "status": "permission_denied",
+            "severity": "blocking",
+            "message": "GitHub token lacks permission for fixed PR metadata API",
+            "recommended_next_action": "fix_github_token_permissions",
+        }
+    if classification == "auth_missing":
+        return {
+            **base,
+            "code": "github_auth_missing",
+            "status": "auth_missing",
+            "severity": "blocking",
+            "message": "GitHub authentication is unavailable for fixed PR metadata API",
+            "recommended_next_action": "authenticate_github_cli",
+        }
+    if classification == "rate_limited":
+        return {
+            **base,
+            "code": "github_rate_limited",
+            "status": "rate_limited",
+            "severity": "blocking",
+            "message": "GitHub rate limit blocked fixed PR metadata API",
+            "recommended_next_action": "wait_or_retry_later",
+        }
+    if classification == "schema_unavailable":
+        return {
+            **base,
+            "code": "github_api_schema_unavailable",
+            "status": "schema_unavailable",
+            "severity": "blocking",
+            "message": "fixed read-only PR metadata schema is unavailable",
+            "recommended_next_action": "inspect_github_api_schema",
+        }
+    if classification == "transient_unknown":
+        return {
+            **base,
+            "code": "github_transient_unknown",
+            "status": "transient_unknown",
+            "severity": "blocking",
+            "message": "transient GitHub failure blocked fixed PR metadata API",
+            "recommended_next_action": "retry_observation",
+        }
+    return {
+        "code": default_code,
+        "source": "gh_pr_view",
+        "severity": "blocking",
+        "message": default_message,
+        "exit_code": exit_code,
+        "stderr_sha256": stderr_sha256,
+    }
+
+
 def classify_snapshot():
     ci_status = ci_payload.get("status") or summary.get("ci") or "unknown"
     review_status = review_payload.get("status") or summary.get("review") or "unknown"
@@ -360,14 +461,12 @@ if gh_exit != 0:
         except OSError:
             stderr_text = ""
     limitations.append(
-        {
-            "code": "pr_metadata_collection_failed",
-            "source": "gh_pr_view",
-            "severity": "blocking",
-            "message": "fixed read-only PR metadata collection failed",
-            "exit_code": gh_exit,
-            "stderr_sha256": hashlib.sha256(stderr_text.encode()).hexdigest(),
-        }
+        pr_metadata_failure_limitation(
+            exit_code=gh_exit,
+            stderr=stderr_text,
+            default_code="pr_metadata_collection_failed",
+            default_message="fixed read-only PR metadata collection failed",
+        )
     )
 elif not metadata or not current_head_sha:
     limitations.append(
@@ -404,14 +503,12 @@ else:
             except OSError:
                 stderr_text = ""
         limitations.append(
-            {
-                "code": "pr_head_revalidation_failed",
-                "source": "gh_pr_view",
-                "severity": "blocking",
-                "message": "fixed read-only PR head revalidation failed after snapshot collection",
-                "exit_code": final_gh_exit,
-                "stderr_sha256": hashlib.sha256(stderr_text.encode()).hexdigest(),
-            }
+            pr_metadata_failure_limitation(
+                exit_code=final_gh_exit,
+                stderr=stderr_text,
+                default_code="pr_head_revalidation_failed",
+                default_message="fixed read-only PR head revalidation failed after snapshot collection",
+            )
         )
     elif not final_current_head_sha:
         limitations.append(

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh
@@ -299,6 +299,14 @@ def has_blocking_limitation(ignored_codes=None):
     )
 
 
+def has_permission_limitation():
+    return any(
+        item.get("code") == "github_token_permission_denied"
+        for item in limitations
+        if isinstance(item, dict)
+    )
+
+
 def classify_snapshot():
     ci_status = ci_payload.get("status") or summary.get("ci") or "unknown"
     review_status = review_payload.get("status") or summary.get("review") or "unknown"
@@ -323,8 +331,12 @@ def classify_snapshot():
         return "failed", "fix_ci", False
     if ci_status in {"pending", "running", "none"}:
         if has_blocking_limitation(ignored_codes={"required_checks_missing_or_pending"}):
+            if has_permission_limitation():
+                return "unknown", "fix_github_token_permissions", False
             return "unknown", "human_gate", False
         return ci_status, "wait", False
+    if has_permission_limitation():
+        return "unknown", "fix_github_token_permissions", False
     if has_blocking_limitation():
         return "unknown", "human_gate", False
     if ci_status != "passed":

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
@@ -74,12 +74,20 @@ expected_head_sha_lower = expected_head_sha.lower()
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def classify_github_stderr(stderr):
     lowered = (stderr or "").lower()
-    if "resource not accessible by personal access token" in lowered or "permission denied" in lowered:
+    if (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    ):
         return "permission_denied"
     if (
         "requires authentication" in lowered

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh
@@ -73,6 +73,136 @@ expected_head_sha = os.environ["OBS_HEAD_SHA"]
 expected_head_sha_lower = expected_head_sha.lower()
 
 
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def classify_github_stderr(stderr):
+    lowered = (stderr or "").lower()
+    if "resource not accessible by personal access token" in lowered or "permission denied" in lowered:
+        return "permission_denied"
+    if (
+        "requires authentication" in lowered
+        or "authentication required" in lowered
+        or "not logged into" in lowered
+        or "http 401" in lowered
+    ):
+        return "auth_missing"
+    if "rate limit" in lowered or "http 429" in lowered:
+        return "rate_limited"
+    if "unknown json field" in lowered:
+        return "schema_unavailable"
+    if (
+        "http 5" in lowered
+        or "timeout" in lowered
+        or "timed out" in lowered
+        or "temporarily unavailable" in lowered
+        or "connection reset" in lowered
+    ):
+        return "transient_unknown"
+    return "unknown"
+
+
+def capability_for_api(api):
+    if api == "gh_pr_view.statusCheckRollup":
+        return "status_check_rollup_read"
+    if api.endswith("/check-runs"):
+        return "check_runs_read"
+    if api.endswith("/status"):
+        return "commit_statuses_read"
+    if "/actions/runs/" in api and api.endswith("/jobs"):
+        return "actions_read"
+    return "unknown"
+
+
+def github_failure_limitation(*, api, source, exit_code, stderr, default_code, default_message, default_severity):
+    classification = classify_github_stderr(stderr)
+    stderr_sha256 = hashlib.sha256((stderr or "").encode()).hexdigest()
+    if classification == "permission_denied":
+        return {
+            "code": "github_token_permission_denied",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "permission_denied",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub token lacks permission for fixed PR observation API",
+            "recommended_next_action": "fix_github_token_permissions",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "auth_missing":
+        return {
+            "code": "github_auth_missing",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "auth_missing",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub authentication is unavailable for fixed PR observation API",
+            "recommended_next_action": "authenticate_github_cli",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "rate_limited":
+        return {
+            "code": "github_rate_limited",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "rate_limited",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "GitHub rate limit blocked fixed PR observation API",
+            "recommended_next_action": "wait_or_retry_later",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "schema_unavailable":
+        return {
+            "code": "github_api_schema_unavailable",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "schema_unavailable",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "fixed read-only GitHub API schema is unavailable",
+            "recommended_next_action": "inspect_github_api_schema",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    if classification == "transient_unknown":
+        return {
+            "code": "github_transient_unknown",
+            "capability": capability_for_api(api),
+            "api": api,
+            "source": source,
+            "status": "transient_unknown",
+            "token_source": token_source(),
+            "severity": "blocking",
+            "message": "transient GitHub failure blocked fixed PR observation API",
+            "recommended_next_action": "retry_observation",
+            "secret_redacted": True,
+            "stderr_sha256": stderr_sha256,
+            "exit_code": exit_code,
+        }
+    return {
+        "code": default_code,
+        "source": source,
+        "severity": default_severity,
+        "message": default_message,
+        "exit_code": exit_code,
+        "stderr_sha256": stderr_sha256,
+    }
+
+
 def sha_prefix_matches(left, right):
     left_lower = str(left or "").lower()
     right_lower = str(right or "").lower()
@@ -85,14 +215,15 @@ def gh_api(path):
     command = ["gh", "api", path, "--paginate"]
     completed = subprocess.run(command, capture_output=True, text=True, check=False)
     if completed.returncode != 0:
-        return None, {
-            "code": "github_api_collection_failed",
-            "source": path,
-            "severity": "blocking",
-            "message": "fixed read-only GitHub API collection failed",
-            "exit_code": completed.returncode,
-            "stderr_sha256": hashlib.sha256(completed.stderr.encode()).hexdigest(),
-        }
+        return None, github_failure_limitation(
+            api=path,
+            source=path,
+            exit_code=completed.returncode,
+            stderr=completed.stderr,
+            default_code="github_api_collection_failed",
+            default_message="fixed read-only GitHub API collection failed",
+            default_severity="blocking",
+        )
     try:
         return parse_gh_paginated_stdout(completed.stdout), None
     except json.JSONDecodeError:
@@ -108,14 +239,15 @@ def gh_pr_view():
     command = ["gh", "pr", "view", str(pr), "--repo", repo, "--json", "mergeStateStatus,statusCheckRollup"]
     completed = subprocess.run(command, capture_output=True, text=True, check=False)
     if completed.returncode != 0:
-        return {}, {
-            "code": "pr_required_check_state_unavailable",
-            "source": "gh_pr_view",
-            "severity": "informational",
-            "message": "fixed read-only PR required check state collection failed",
-            "exit_code": completed.returncode,
-            "stderr_sha256": hashlib.sha256(completed.stderr.encode()).hexdigest(),
-        }
+        return {}, github_failure_limitation(
+            api="gh_pr_view.statusCheckRollup",
+            source="gh_pr_view",
+            exit_code=completed.returncode,
+            stderr=completed.stderr,
+            default_code="pr_required_check_state_unavailable",
+            default_message="fixed read-only PR required check state collection failed",
+            default_severity="informational",
+        )
     try:
         payload = json.loads(completed.stdout or "{}")
     except json.JSONDecodeError:
@@ -487,7 +619,9 @@ elif merge_state_blocking:
         }
     )
 
-if (
+if any(item.get("code") == "github_token_permission_denied" for item in limitations):
+    ci_status = "unknown"
+elif (
     check_counts["failed"]
     or status_counts["failure"]
     or status_counts["error"]

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
@@ -159,12 +159,20 @@ def limitation(code, message, **extra):
 
 
 def token_source():
-    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
+    return "gh_saved_auth"
 
 
 def is_permission_denied(stderr):
     lowered = (stderr or "").lower()
-    return "resource not accessible by personal access token" in lowered or "permission denied" in lowered
+    return (
+        "resource not accessible by personal access token" in lowered
+        or "resource not accessible by integration" in lowered
+        or "permission denied" in lowered
+    )
 
 
 def trigger_permission_limitation(stderr, exit_code):

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/trigger_codex_review.sh
@@ -68,6 +68,7 @@ TRIGGER_PR="$pr" \
 TRIGGER_HEAD_SHA="$head_sha" \
 python3 - <<'PY'
 import json
+import hashlib
 import os
 import subprocess
 from datetime import datetime, timezone
@@ -147,8 +148,39 @@ def emit(payload):
 
 def limitation(code, message, **extra):
     payload = {"code": code, "message": message, "source": "trigger_codex_review.sh"}
-    payload.update(extra)
+    sanitized_extra = {}
+    for key, value in extra.items():
+        if key.endswith("gh_stderr") or key == "gh_stderr":
+            sanitized_extra[f"{key}_sha256"] = hashlib.sha256(str(value or "").encode()).hexdigest()
+        else:
+            sanitized_extra[key] = value
+    payload.update(sanitized_extra)
     return payload
+
+
+def token_source():
+    return "GH_TOKEN" if os.environ.get("GH_TOKEN") else "gh_saved_auth"
+
+
+def is_permission_denied(stderr):
+    lowered = (stderr or "").lower()
+    return "resource not accessible by personal access token" in lowered or "permission denied" in lowered
+
+
+def trigger_permission_limitation(stderr, exit_code):
+    return limitation(
+        "github_token_permission_denied",
+        "GitHub token lacks permission to post the fixed Codex review trigger comment",
+        capability="trigger_comment_write",
+        api=endpoint,
+        status="permission_denied",
+        token_source=token_source(),
+        severity="blocking",
+        recommended_next_action="fix_github_token_permissions",
+        secret_redacted=True,
+        stderr_sha256=hashlib.sha256((stderr or "").encode()).hexdigest(),
+        exit_code=exit_code,
+    )
 
 
 def head_matches(actual, expected):
@@ -296,6 +328,8 @@ if post_exit == 0 and isinstance(post_payload, dict):
 else:
     payload["trigger"]["action"] = "failed"
     payload["overall_status"] = "trigger_post_failed"
+    if is_permission_denied(post_stderr):
+        payload["limitations"].append(trigger_permission_limitation(post_stderr, post_exit))
     payload["limitations"].append(
         limitation(
             "trigger_post_failed",

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh
@@ -250,6 +250,13 @@ def has_zero_check_limitation(payload: dict) -> bool:
     )
 
 
+def has_permission_limitation(payload: dict) -> bool:
+    return any(
+        isinstance(item, dict) and item.get("code") == "github_token_permission_denied"
+        for item in payload.get("limitations", [])
+    )
+
+
 def sanitized_review_signals(payload: dict) -> list:
     review = payload.get("review")
     if not isinstance(review, dict):
@@ -626,7 +633,10 @@ def trigger_failure_result(trigger_payload: dict, trigger_stdout: str, trigger_s
     normalized_status = trigger_payload.get("overall_status") or trigger_payload.get("status") or "unknown"
     if normalized_status == "trigger_posted":
         normalized_status = "unknown"
-    if normalized_status == "stale_head":
+    if has_permission_limitation(trigger_payload):
+        normalized_status = "human_gate"
+        next_action = "fix_github_token_permissions"
+    elif normalized_status == "stale_head":
         next_action = "rerun_for_current_head"
     elif normalized_status == "draft_pr":
         normalized_status = "human_gate"
@@ -809,6 +819,8 @@ def classify(payload: dict, poll: int, zero_check_grace_polls: int) -> tuple[str
         return "human_gate", "human_gate", top_level_next_action, False, True
     if ci_status == "none" and has_zero_check_limitation(payload):
         if has_blocking_limitation(payload, ignored_codes={"zero_checks_s03_non_success"}):
+            if has_permission_limitation(payload):
+                return "unknown", "unknown", "fix_github_token_permissions", False, True
             return "unknown", "unknown", "human_gate", False, True
         if poll < zero_check_grace_polls:
             return "none", "none", "wait", False, False
@@ -817,8 +829,12 @@ def classify(payload: dict, poll: int, zero_check_grace_polls: int) -> tuple[str
         return "failed", "failed", "fix_ci", False, True
     if ci_status in {"pending", "running", "none"}:
         if has_blocking_limitation(payload, ignored_codes={"required_checks_missing_or_pending"}):
+            if has_permission_limitation(payload):
+                return "unknown", "unknown", "fix_github_token_permissions", False, True
             return "unknown", "unknown", "human_gate", False, True
         return ci_status, ci_status, "wait", False, False
+    if has_permission_limitation(payload):
+        return "unknown", "unknown", "fix_github_token_permissions", False, True
     if has_blocking_limitation(payload):
         return "unknown", "unknown", "human_gate", False, True
     if ci_status != "passed":

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
@@ -83,7 +83,7 @@ GitHubCapabilityStatus = Literal[
     "schema_unavailable",
     "skipped",
 ]
-GitHubCapabilityTokenSource = Literal["GH_TOKEN", "gh_saved_auth", "unknown"]
+GitHubCapabilityTokenSource = Literal["GH_TOKEN", "GITHUB_TOKEN", "gh_saved_auth", "unknown"]
 GitHubCapabilitySeverity = Literal["info", "warning", "blocking"]
 GitHubCapabilityGroup = Literal["core", "extended"]
 GitHubCapabilityDiagnosticCode = Literal[

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/contracts.py
@@ -57,7 +57,68 @@ class ValidationResult:
 
 @dataclass(frozen=True)
 class DoctorRequest:
-    pass
+    github_repo: str | None = None
+    github_pr: int | None = None
+    github_head_sha: str | None = None
+    github_extended: bool = False
+
+
+GitHubCapability = Literal[
+    "repo_metadata_read",
+    "pull_request_read",
+    "check_runs_read",
+    "commit_statuses_read",
+    "status_check_rollup_read",
+    "actions_read",
+    "issue_comments_read",
+    "trigger_comment_write",
+]
+GitHubCapabilityStatus = Literal[
+    "ok",
+    "permission_denied",
+    "auth_missing",
+    "rate_limited",
+    "target_unavailable",
+    "transient_unknown",
+    "schema_unavailable",
+    "skipped",
+]
+GitHubCapabilityTokenSource = Literal["GH_TOKEN", "gh_saved_auth", "unknown"]
+GitHubCapabilitySeverity = Literal["info", "warning", "blocking"]
+GitHubCapabilityGroup = Literal["core", "extended"]
+GitHubCapabilityDiagnosticCode = Literal[
+    "github_capability_ok",
+    "github_token_permission_denied",
+    "github_auth_missing",
+    "github_rate_limited",
+    "github_target_unavailable",
+    "github_transient_unknown",
+    "github_schema_unavailable",
+    "github_capability_skipped",
+]
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityProbeRequest:
+    github_repo: str
+    github_pr: int
+    github_head_sha: str
+    include_extended: bool = False
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityDiagnostic:
+    code: GitHubCapabilityDiagnosticCode
+    capability: GitHubCapability
+    status: GitHubCapabilityStatus
+    token_source: GitHubCapabilityTokenSource
+    api: str
+    severity: GitHubCapabilitySeverity
+    message: str
+    recommended_next_action: str
+    secret_redacted: bool
+    stderr_sha256: str | None
+    group: GitHubCapabilityGroup
 
 
 @dataclass(frozen=True)
@@ -81,6 +142,7 @@ class DoctorResult:
     ok: bool
     findings: list[DoctorFinding]
     warnings: list[str]
+    github_capability_diagnostics: list[GitHubCapabilityDiagnostic] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -678,7 +740,7 @@ class UseCases:
         RuntimeError("issue_finish is not configured")
     )
     doctor: Callable[[DoctorRequest], DoctorResult] = (
-        lambda _req: DoctorResult(ok=True, findings=[], warnings=[])
+        lambda _req: DoctorResult(ok=True, findings=[], warnings=[], github_capability_diagnostics=[])
     )
     worktree_create: Callable[[WorktreeCreateRequest], WorktreeCreateResult] = lambda _req: (_ for _ in ()).throw(
         RuntimeError("worktree_create is not configured")

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py
@@ -10,6 +10,7 @@ from ..infra.contracts import ActiveManifestEntry, StoredMetaRecord
 from . import create_node as app_create_node
 from .artifact_preflight import validate_required_artifacts_for_graph
 from .contracts import DoctorFinding, DoctorRequest, DoctorResult
+from .contracts import GitHubCapabilityDiagnostic, GitHubCapabilityProbeRequest
 from .ports import Ports
 from .repo_context import resolve_current_repo_slug
 
@@ -322,8 +323,53 @@ def _stale_create_lock_finding(specdock_dir: Path) -> DoctorFinding | None:
     )
 
 
+def _github_target_unavailable_diagnostic() -> GitHubCapabilityDiagnostic:
+    return GitHubCapabilityDiagnostic(
+        code="github_target_unavailable",
+        capability="check_runs_read",
+        status="target_unavailable",
+        token_source="unknown",
+        api="github_pr_core_probe",
+        severity="info",
+        message="GitHub PR capability probe skipped because repo, PR, or head SHA was not provided.",
+        recommended_next_action="provide_github_repo_pr_and_head_sha_for_capability_probe",
+        secret_redacted=True,
+        stderr_sha256=None,
+        group="core",
+    )
+
+
+def _github_gateway_unavailable_diagnostic() -> GitHubCapabilityDiagnostic:
+    return GitHubCapabilityDiagnostic(
+        code="github_capability_skipped",
+        capability="check_runs_read",
+        status="skipped",
+        token_source="unknown",
+        api="github_pr_core_probe",
+        severity="info",
+        message="GitHub capability gateway is unavailable.",
+        recommended_next_action="run_in_installed_runtime_with_github_capability_gateway",
+        secret_redacted=True,
+        stderr_sha256=None,
+        group="core",
+    )
+
+
+def _github_capability_diagnostics(req: DoctorRequest, ports: Ports) -> list[GitHubCapabilityDiagnostic]:
+    if not (req.github_repo and req.github_pr is not None and req.github_head_sha):
+        return [_github_target_unavailable_diagnostic()]
+    if ports.github_capability_gateway is None:
+        return [_github_gateway_unavailable_diagnostic()]
+    probe_request = GitHubCapabilityProbeRequest(
+        github_repo=req.github_repo,
+        github_pr=req.github_pr,
+        github_head_sha=req.github_head_sha,
+        include_extended=req.github_extended,
+    )
+    return ports.github_capability_gateway.probe(probe_request)
+
+
 def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
-    del req
     warnings: list[str] = []
     findings: list[DoctorFinding] = []
     graph: SpecGraph | None = None
@@ -335,7 +381,12 @@ def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
 
     if has_legacy_workspace and not has_current_workspace:
         findings.append(_legacy_only_workspace_finding(legacy_dir=legacy_dir))
-        return DoctorResult(ok=False, findings=findings, warnings=warnings)
+        return DoctorResult(
+            ok=False,
+            findings=findings,
+            warnings=warnings,
+            github_capability_diagnostics=_github_capability_diagnostics(req, ports),
+        )
 
     try:
         records = ports.node_reader.load_node_records()
@@ -380,4 +431,9 @@ def doctor(req: DoctorRequest, ports: Ports) -> DoctorResult:
     if has_current_workspace and has_legacy_workspace and not findings:
         _append_unique(warnings, "legacy_cleanup_pending")
 
-    return DoctorResult(ok=(len(findings) == 0), findings=findings, warnings=warnings)
+    return DoctorResult(
+        ok=(len(findings) == 0),
+        findings=findings,
+        warnings=warnings,
+        github_capability_diagnostics=_github_capability_diagnostics(req, ports),
+    )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/ports.py
@@ -7,6 +7,8 @@ from typing import Protocol
 
 from .contracts import ArtifactWriteResult
 from .contracts import BootstrapResult
+from .contracts import GitHubCapabilityDiagnostic
+from .contracts import GitHubCapabilityProbeRequest
 from .contracts import GitWorktreeRecord
 from .contracts import SyncCommandResult
 from .contracts import SyncRequest
@@ -167,6 +169,11 @@ class GitGateway(Protocol):
         ...
 
 
+class GitHubCapabilityGateway(Protocol):
+    def probe(self, request: GitHubCapabilityProbeRequest) -> list[GitHubCapabilityDiagnostic]:
+        ...
+
+
 class BootstrapGateway(Protocol):
     def run_make_init_if_available(self, worktree_path: Path) -> BootstrapResult:
         ...
@@ -228,6 +235,7 @@ class Ports:
     active_state_store: ActiveStateStore | None = None
     deps_topology_reader: DepsTopologyReader | None = None
     git_gateway: GitGateway | None = None
+    github_capability_gateway: GitHubCapabilityGateway | None = None
     json_store: JsonStore | None = None
     clock: Clock | None = None
     artifact_writer: ArtifactWriter | None = None

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/cli/bootstrap.py
@@ -37,6 +37,7 @@ from ..infra import derived_state_reader as infra_derived_state_reader
 from ..infra import fs_cli as infra_fs_cli
 from ..infra import fs_repo as infra_fs_repo
 from ..infra import git_cli as infra_git_cli
+from ..infra import github_capability_cli as infra_github_capability_cli
 from ..infra import github_cli as infra_github_cli
 from ..infra import json_store as infra_json_store
 from ..infra import make_cli as infra_make_cli
@@ -205,6 +206,12 @@ class _GitGateway:
 
 
 @dataclass(frozen=True)
+class _GitHubCapabilityGateway:
+    def probe(self, request):
+        return infra_github_capability_cli.GitHubCapabilityCliGateway().probe(request)
+
+
+@dataclass(frozen=True)
 class _BootstrapGateway:
     def run_make_init_if_available(self, worktree_path: Path):
         return infra_make_cli.run_make_init_if_available(worktree_path)
@@ -264,6 +271,7 @@ def build_runtime(specdock_dir: Path, *, repo_root: Path | None = None) -> Boots
         active_state_store=_ActiveStateStore(),
         deps_topology_reader=_DepsTopologyReader(),
         git_gateway=_GitGateway(),
+        github_capability_gateway=_GitHubCapabilityGateway(),
         bootstrap_gateway=_BootstrapGateway(),
         environment_gateway=_EnvironmentGateway(),
         filesystem_gateway=_FilesystemGateway(),

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 from dataclasses import dataclass
 
 from ..application.contracts import DoctorRequest, UseCases
@@ -27,9 +28,21 @@ def command_specs() -> dict[str, CommandSpec]:
 
 
 def _add_doctor_arguments(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--github-repo", help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo")
-    parser.add_argument("--github-pr", type=int, help="GitHub pull request number for fixed capability diagnostics")
-    parser.add_argument("--github-head-sha", help="GitHub PR head SHA for fixed capability diagnostics")
+    parser.add_argument(
+        "--github-repo",
+        type=_github_repo_arg,
+        help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo",
+    )
+    parser.add_argument(
+        "--github-pr",
+        type=_github_pr_arg,
+        help="GitHub pull request number for fixed capability diagnostics",
+    )
+    parser.add_argument(
+        "--github-head-sha",
+        type=_github_head_sha_arg,
+        help="GitHub PR head SHA for fixed capability diagnostics",
+    )
     parser.add_argument(
         "--github-extended",
         action="store_true",
@@ -64,3 +77,25 @@ def _expect_doctor_args(args: CommandArgs) -> DoctorArgs:
     if not isinstance(args, DoctorArgs):
         raise RuntimeError("Invalid command args for doctor")
     return args
+
+
+def _github_repo_arg(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", value or ""):
+        return value
+    raise argparse.ArgumentTypeError("--github-repo must be OWNER/REPO")
+
+
+def _github_pr_arg(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("--github-pr must be a positive integer") from exc
+    if parsed > 0:
+        return parsed
+    raise argparse.ArgumentTypeError("--github-pr must be a positive integer")
+
+
+def _github_head_sha_arg(value: str) -> str:
+    if re.fullmatch(r"[0-9A-Fa-f]{7,64}", value or ""):
+        return value
+    raise argparse.ArgumentTypeError("--github-head-sha must be a 7-64 character hex SHA")

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/commands/doctor.py
@@ -10,7 +10,10 @@ from .contracts import CommandArgs, CommandOutcome, CommandSpec
 
 @dataclass(frozen=True)
 class DoctorArgs(CommandArgs):
-    pass
+    github_repo: str | None = None
+    github_pr: int | None = None
+    github_head_sha: str | None = None
+    github_extended: bool = False
 
 
 def command_specs() -> dict[str, CommandSpec]:
@@ -24,17 +27,35 @@ def command_specs() -> dict[str, CommandSpec]:
 
 
 def _add_doctor_arguments(parser: argparse.ArgumentParser) -> None:
-    del parser
+    parser.add_argument("--github-repo", help="GitHub repo slug for fixed capability diagnostics, e.g. owner/repo")
+    parser.add_argument("--github-pr", type=int, help="GitHub pull request number for fixed capability diagnostics")
+    parser.add_argument("--github-head-sha", help="GitHub PR head SHA for fixed capability diagnostics")
+    parser.add_argument(
+        "--github-extended",
+        action="store_true",
+        help="Include fixed optional GitHub capability diagnostics",
+    )
 
 
 def _doctor_args(ns: argparse.Namespace) -> CommandArgs:
-    del ns
-    return DoctorArgs()
+    return DoctorArgs(
+        github_repo=ns.github_repo,
+        github_pr=ns.github_pr,
+        github_head_sha=ns.github_head_sha,
+        github_extended=bool(ns.github_extended),
+    )
 
 
 def _run_doctor(args: CommandArgs, use_cases: UseCases) -> CommandOutcome:
-    _expect_doctor_args(args)
-    result = use_cases.doctor(DoctorRequest())
+    doctor_args = _expect_doctor_args(args)
+    result = use_cases.doctor(
+        DoctorRequest(
+            github_repo=doctor_args.github_repo,
+            github_pr=doctor_args.github_pr,
+            github_head_sha=doctor_args.github_head_sha,
+            github_extended=doctor_args.github_extended,
+        )
+    )
     text = render_doctor_text(result)
     return CommandOutcome(exit_code=(0 if result.ok else 1), text=text)
 

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from dataclasses import dataclass
+
+from ..application.contracts import GitHubCapability
+from ..application.contracts import GitHubCapabilityDiagnostic
+from ..application.contracts import GitHubCapabilityDiagnosticCode
+from ..application.contracts import GitHubCapabilityGroup
+from ..application.contracts import GitHubCapabilityProbeRequest
+from ..application.contracts import GitHubCapabilitySeverity
+from ..application.contracts import GitHubCapabilityStatus
+from ..application.contracts import GitHubCapabilityTokenSource
+
+
+@dataclass(frozen=True)
+class GitHubCapabilityCliGateway:
+    def probe(self, request: GitHubCapabilityProbeRequest) -> list[GitHubCapabilityDiagnostic]:
+        checks: list[tuple[GitHubCapability, GitHubCapabilityGroup, str, list[str]]] = [
+            (
+                "repo_metadata_read",
+                "core",
+                "gh repo view",
+                ["gh", "repo", "view", request.github_repo, "--json", "nameWithOwner"],
+            ),
+            (
+                "pull_request_read",
+                "core",
+                "gh pr view",
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(request.github_pr),
+                    "--repo",
+                    request.github_repo,
+                    "--json",
+                    "number,headRefOid",
+                ],
+            ),
+            (
+                "check_runs_read",
+                "core",
+                "GET /repos/{repo}/commits/{sha}/check-runs",
+                [
+                    "gh",
+                    "api",
+                    f"repos/{request.github_repo}/commits/{request.github_head_sha}/check-runs",
+                    "--paginate",
+                ],
+            ),
+            (
+                "commit_statuses_read",
+                "core",
+                "GET /repos/{repo}/commits/{sha}/status",
+                ["gh", "api", f"repos/{request.github_repo}/commits/{request.github_head_sha}/status"],
+            ),
+            (
+                "status_check_rollup_read",
+                "core",
+                "gh pr view --json statusCheckRollup",
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(request.github_pr),
+                    "--repo",
+                    request.github_repo,
+                    "--json",
+                    "statusCheckRollup",
+                ],
+            ),
+        ]
+        if request.include_extended:
+            checks.extend(
+                [
+                    (
+                        "actions_read",
+                        "extended",
+                        "GET /repos/{repo}/actions/runs",
+                        ["gh", "api", f"repos/{request.github_repo}/actions/runs"],
+                    ),
+                    (
+                        "issue_comments_read",
+                        "extended",
+                        "GET /repos/{repo}/issues/{pr}/comments",
+                        ["gh", "api", f"repos/{request.github_repo}/issues/{request.github_pr}/comments"],
+                    ),
+                ]
+            )
+        return [
+            _diagnostic_from_completed_process(
+                capability=capability,
+                group=group,
+                api=api,
+                completed=_run_fixed_gh(command),
+            )
+            for capability, group, api, command in checks
+        ]
+
+
+def _run_fixed_gh(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _diagnostic_from_completed_process(
+    *,
+    capability: GitHubCapability,
+    group: GitHubCapabilityGroup,
+    api: str,
+    completed: subprocess.CompletedProcess[str],
+) -> GitHubCapabilityDiagnostic:
+    status = _classify_status(completed)
+    code = _code_for_status(status)
+    return GitHubCapabilityDiagnostic(
+        code=code,
+        capability=capability,
+        status=status,
+        token_source=_token_source(),
+        api=api,
+        severity=_severity_for_status(status),
+        message=_message_for_status(status),
+        recommended_next_action=_action_for_status(status),
+        secret_redacted=True,
+        stderr_sha256=_stderr_sha256(completed.stderr),
+        group=group,
+    )
+
+
+def _token_source() -> GitHubCapabilityTokenSource:
+    if os.environ.get("GH_TOKEN"):
+        return "GH_TOKEN"
+    return "gh_saved_auth"
+
+
+def _stderr_sha256(stderr: str) -> str | None:
+    if not stderr:
+        return None
+    return hashlib.sha256(stderr.encode("utf-8")).hexdigest()
+
+
+def _classify_status(completed: subprocess.CompletedProcess[str]) -> GitHubCapabilityStatus:
+    if completed.returncode == 0:
+        return "ok"
+    stderr = completed.stderr.lower()
+    if "resource not accessible by personal access token" in stderr or "permission denied" in stderr:
+        return "permission_denied"
+    if "authentication" in stderr or "not logged into" in stderr or "could not resolve to a repository" in stderr:
+        return "auth_missing"
+    if "rate limit" in stderr or "api rate limit exceeded" in stderr:
+        return "rate_limited"
+    if "unknown json field" in stderr:
+        return "schema_unavailable"
+    if "field" in stderr and ("not found" in stderr or "doesn't exist" in stderr):
+        return "schema_unavailable"
+    if completed.returncode in (1, 2, 4):
+        return "transient_unknown"
+    return "transient_unknown"
+
+
+def _code_for_status(status: GitHubCapabilityStatus) -> GitHubCapabilityDiagnosticCode:
+    if status == "ok":
+        return "github_capability_ok"
+    if status == "permission_denied":
+        return "github_token_permission_denied"
+    if status == "auth_missing":
+        return "github_auth_missing"
+    if status == "rate_limited":
+        return "github_rate_limited"
+    if status == "schema_unavailable":
+        return "github_schema_unavailable"
+    if status == "skipped":
+        return "github_capability_skipped"
+    if status == "target_unavailable":
+        return "github_target_unavailable"
+    return "github_transient_unknown"
+
+
+def _severity_for_status(status: GitHubCapabilityStatus) -> GitHubCapabilitySeverity:
+    if status == "ok" or status == "skipped" or status == "target_unavailable":
+        return "info"
+    if status == "transient_unknown" or status == "rate_limited" or status == "schema_unavailable":
+        return "warning"
+    return "blocking"
+
+
+def _message_for_status(status: GitHubCapabilityStatus) -> str:
+    messages = {
+        "ok": "GitHub capability probe succeeded.",
+        "permission_denied": "GitHub token lacks permission for this fixed capability.",
+        "auth_missing": "GitHub authentication is missing or unavailable.",
+        "rate_limited": "GitHub API rate limit blocked this fixed capability probe.",
+        "target_unavailable": "GitHub target context is unavailable.",
+        "transient_unknown": "GitHub capability probe failed with an unclassified transient error.",
+        "schema_unavailable": "GitHub response schema is unavailable for this fixed capability.",
+        "skipped": "GitHub capability probe was skipped.",
+    }
+    return messages[status]
+
+
+def _action_for_status(status: GitHubCapabilityStatus) -> str:
+    actions = {
+        "ok": "none",
+        "permission_denied": "fix_github_token_permissions",
+        "auth_missing": "authenticate_gh_or_set_token",
+        "rate_limited": "retry_after_rate_limit_reset",
+        "target_unavailable": "provide_github_repo_pr_and_head_sha_for_capability_probe",
+        "transient_unknown": "retry_or_inspect_github",
+        "schema_unavailable": "inspect_gh_version_or_api_schema",
+        "skipped": "run_in_installed_runtime_with_github_capability_gateway",
+    }
+    return actions[status]

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/infra/github_capability_cli.py
@@ -102,13 +102,16 @@ class GitHubCapabilityCliGateway:
 
 
 def _run_fixed_gh(command: list[str]) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        command,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    try:
+        return subprocess.run(
+            command,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except FileNotFoundError:
+        return subprocess.CompletedProcess(command, 127, "", "gh executable not found")
 
 
 def _diagnostic_from_completed_process(
@@ -138,6 +141,8 @@ def _diagnostic_from_completed_process(
 def _token_source() -> GitHubCapabilityTokenSource:
     if os.environ.get("GH_TOKEN"):
         return "GH_TOKEN"
+    if os.environ.get("GITHUB_TOKEN"):
+        return "GITHUB_TOKEN"
     return "gh_saved_auth"
 
 
@@ -151,9 +156,18 @@ def _classify_status(completed: subprocess.CompletedProcess[str]) -> GitHubCapab
     if completed.returncode == 0:
         return "ok"
     stderr = completed.stderr.lower()
-    if "resource not accessible by personal access token" in stderr or "permission denied" in stderr:
+    if (
+        "resource not accessible by personal access token" in stderr
+        or "resource not accessible by integration" in stderr
+        or "permission denied" in stderr
+    ):
         return "permission_denied"
-    if "authentication" in stderr or "not logged into" in stderr or "could not resolve to a repository" in stderr:
+    if (
+        "authentication" in stderr
+        or "not logged into" in stderr
+        or "could not resolve to a repository" in stderr
+        or "gh executable not found" in stderr
+    ):
         return "auth_missing"
     if "rate limit" in stderr or "api rate limit exceeded" in stderr:
         return "rate_limited"

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/presentation/cli_text.py
@@ -55,9 +55,13 @@ def render_validate_text(result: ValidationResult) -> CliText:
 
 def render_doctor_text(result: DoctorResult) -> CliText:
     warnings = [_doctor_warning_message(warning) for warning in result.warnings]
+    capability_lines = _render_github_capability_diagnostics(result)
     if result.ok:
         return CliText(
-            stdout_lines=["spec-dock: ok (doctor) findings=0"],
+            stdout_lines=[
+                "spec-dock: ok (doctor) findings=0",
+                *capability_lines,
+            ],
             stderr_lines=[],
             warnings=warnings,
         )
@@ -67,12 +71,35 @@ def render_doctor_text(result: DoctorResult) -> CliText:
         stderr_lines.append(f"- [{finding.code}] {finding.message}")
         for guidance in finding.guidance:
             stderr_lines.append(f"  -> {guidance}")
+    stderr_lines.extend(capability_lines)
 
     return CliText(
         stdout_lines=[],
         stderr_lines=stderr_lines,
         warnings=warnings,
     )
+
+
+def _render_github_capability_diagnostics(result: DoctorResult) -> list[str]:
+    diagnostics = list(result.github_capability_diagnostics)
+    if not diagnostics:
+        return []
+    lines = [f"spec-dock: github capability diagnostics={len(diagnostics)}"]
+    for diagnostic in diagnostics:
+        stderr_hash = f" stderr_sha256={diagnostic.stderr_sha256}" if diagnostic.stderr_sha256 else ""
+        lines.append(
+            f"- [github:{diagnostic.group}] "
+            f"code={diagnostic.code} "
+            f"capability={diagnostic.capability} "
+            f"status={diagnostic.status} "
+            f"api={diagnostic.api} "
+            f"token_source={diagnostic.token_source} "
+            f"severity={diagnostic.severity} "
+            f"recommended_next_action={diagnostic.recommended_next_action} "
+            f"secret_redacted={str(diagnostic.secret_redacted).lower()}"
+            f"{stderr_hash}"
+        )
+    return lines
 
 
 def _rel_path_for_output(path_text: str) -> str:

--- a/tests/cli_runtime/test_runtime_doctor_s04.py
+++ b/tests/cli_runtime/test_runtime_doctor_s04.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import time
@@ -9,6 +10,11 @@ from pathlib import Path
 
 import contextlib
 import pytest
+
+
+_SECRET_TOKEN = "ghp_secret_token_value"
+
+
 def _runtime_modules():
     runtime_scripts_dir = (
         Path(__file__).resolve().parents[2]
@@ -45,6 +51,58 @@ def _runtime_fs_repo():
     finally:
         sys.path.pop(0)
     return infra_fs_repo
+
+
+def _runtime_doctor_command():
+    runtime_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "spec_dock"
+        / "assets"
+        / "spec_dock"
+        / "scripts"
+    )
+    sys.path.insert(0, str(runtime_scripts_dir))
+    try:
+        from spec_dock_runtime.commands import doctor as command_doctor
+    finally:
+        sys.path.pop(0)
+    return command_doctor
+
+
+def _runtime_github_capability_cli():
+    runtime_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "spec_dock"
+        / "assets"
+        / "spec_dock"
+        / "scripts"
+    )
+    sys.path.insert(0, str(runtime_scripts_dir))
+    try:
+        from spec_dock_runtime.infra import github_capability_cli
+    finally:
+        sys.path.pop(0)
+    return github_capability_cli
+
+
+def _render_doctor_text(app_contracts, result):
+    runtime_scripts_dir = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "spec_dock"
+        / "assets"
+        / "spec_dock"
+        / "scripts"
+    )
+    sys.path.insert(0, str(runtime_scripts_dir))
+    try:
+        from spec_dock_runtime.presentation.cli_text import render_doctor_text
+    finally:
+        sys.path.pop(0)
+    del app_contracts
+    return render_doctor_text(result)
 
 
 def _record(
@@ -193,7 +251,314 @@ class _StubGitGateway:
         return self._origin_slug
 
 
+class _StubGitHubCapabilityGateway:
+    def __init__(self, diagnostics):
+        self.diagnostics = list(diagnostics)
+        self.requests = []
+
+    def probe(self, request):
+        self.requests.append(request)
+        return list(self.diagnostics)
+
+
 class TestRuntimeDoctorS04:
+    def test_doctor_command_surface_rejects_raw_github_api_arguments(self) -> None:
+        import argparse
+
+        command_doctor = _runtime_doctor_command()
+        spec = command_doctor.command_specs()["doctor"]
+        parser = argparse.ArgumentParser(prog="doctor")
+        spec.add_arguments(parser)
+
+        parsed = parser.parse_args(
+            [
+                "--github-repo",
+                "example/repo",
+                "--github-pr",
+                "123",
+                "--github-head-sha",
+                "abcde12345",
+                "--github-extended",
+            ]
+        )
+        args = spec.args_factory(parsed)
+        assert args.github_repo == "example/repo"
+        assert args.github_pr == 123
+        assert args.github_head_sha == "abcde12345"
+        assert args.github_extended is True
+
+        for forbidden in ("--api", "--endpoint", "--method", "--jq", "--header", "--raw"):
+            with pytest.raises(SystemExit):
+                parser.parse_args([forbidden, "value"])
+
+    def test_doctor_renders_targeted_github_permission_diagnostic_without_secret(self) -> None:
+        _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            specdock_dir = repo_root / "spec-dock"
+            records, _issue_dir = _build_valid_records(infra_contracts, specdock_dir=specdock_dir)
+            diagnostic = app_contracts.GitHubCapabilityDiagnostic(
+                code="github_token_permission_denied",
+                capability="check_runs_read",
+                status="permission_denied",
+                token_source="GH_TOKEN",
+                api="GET /repos/{repo}/commits/{sha}/check-runs",
+                severity="blocking",
+                message=f"Resource not accessible by personal access token: {_SECRET_TOKEN}",
+                recommended_next_action="fix_github_token_permissions",
+                secret_redacted=True,
+                stderr_sha256="abc123",
+                group="core",
+            )
+            gateway = _StubGitHubCapabilityGateway([diagnostic])
+            ports = app_ports.Ports(
+                node_reader=_StubNodeReader(records),
+                repo_root=repo_root,
+                specdock_dir=specdock_dir,
+                github_capability_gateway=gateway,
+            )
+
+            result = app_doctor.doctor(
+                app_contracts.DoctorRequest(
+                    github_repo="example/repo",
+                    github_pr=123,
+                    github_head_sha="abcde12345",
+                ),
+                ports,
+            )
+
+            assert result.ok
+            assert result.github_capability_diagnostics == [diagnostic]
+            assert gateway.requests[0].github_repo == "example/repo"
+            text = _render_doctor_text(app_contracts, result)
+            rendered = "\n".join(text.stdout_lines + text.stderr_lines + text.warnings)
+            assert "github capability diagnostics=1" in rendered
+            assert "capability=check_runs_read" in rendered
+            assert "status=permission_denied" in rendered
+            assert "api=GET /repos/{repo}/commits/{sha}/check-runs" in rendered
+            assert "token_source=GH_TOKEN" in rendered
+            assert "fix_github_token_permissions" in rendered
+            assert _SECRET_TOKEN not in rendered
+
+    def test_doctor_without_github_target_skips_capability_probe_without_structural_failure(self) -> None:
+        _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            specdock_dir = repo_root / "spec-dock"
+            records, _issue_dir = _build_valid_records(infra_contracts, specdock_dir=specdock_dir)
+            gateway = _StubGitHubCapabilityGateway([])
+            ports = app_ports.Ports(
+                node_reader=_StubNodeReader(records),
+                repo_root=repo_root,
+                specdock_dir=specdock_dir,
+                github_capability_gateway=gateway,
+            )
+
+            result = app_doctor.doctor(app_contracts.DoctorRequest(), ports)
+
+            assert result.ok
+            assert gateway.requests == []
+            assert len(result.github_capability_diagnostics) == 1
+            diagnostic = result.github_capability_diagnostics[0]
+            assert diagnostic.capability == "check_runs_read"
+            assert diagnostic.status == "target_unavailable"
+            assert diagnostic.token_source == "unknown"
+            text = _render_doctor_text(app_contracts, result)
+            rendered = "\n".join(text.stdout_lines + text.stderr_lines + text.warnings)
+            assert "status=target_unavailable" in rendered
+            assert "capability=check_runs_read" in rendered
+
+    def test_doctor_renders_optional_extended_diagnostics_separately(self) -> None:
+        _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            specdock_dir = repo_root / "spec-dock"
+            records, _issue_dir = _build_valid_records(infra_contracts, specdock_dir=specdock_dir)
+            gateway = _StubGitHubCapabilityGateway(
+                [
+                    app_contracts.GitHubCapabilityDiagnostic(
+                        code="github_capability_ok",
+                        capability="check_runs_read",
+                        status="ok",
+                        token_source="gh_saved_auth",
+                        api="GET /repos/{repo}/commits/{sha}/check-runs",
+                        severity="info",
+                        message="ok",
+                        recommended_next_action="none",
+                        secret_redacted=True,
+                        stderr_sha256=None,
+                        group="core",
+                    ),
+                    app_contracts.GitHubCapabilityDiagnostic(
+                        code="github_rate_limited",
+                        capability="actions_read",
+                        status="rate_limited",
+                        token_source="gh_saved_auth",
+                        api="GET /repos/{repo}/actions/runs",
+                        severity="warning",
+                        message="GitHub API rate limit exceeded.",
+                        recommended_next_action="retry_after_rate_limit_reset",
+                        secret_redacted=True,
+                        stderr_sha256="def456",
+                        group="extended",
+                    ),
+                    app_contracts.GitHubCapabilityDiagnostic(
+                        code="github_auth_missing",
+                        capability="issue_comments_read",
+                        status="auth_missing",
+                        token_source="gh_saved_auth",
+                        api="GET /repos/{repo}/issues/{pr}/comments",
+                        severity="blocking",
+                        message="GitHub authentication is missing.",
+                        recommended_next_action="authenticate_gh_or_set_token",
+                        secret_redacted=True,
+                        stderr_sha256="ghi789",
+                        group="extended",
+                    ),
+                ]
+            )
+            ports = app_ports.Ports(
+                node_reader=_StubNodeReader(records),
+                repo_root=repo_root,
+                specdock_dir=specdock_dir,
+                github_capability_gateway=gateway,
+            )
+
+            result = app_doctor.doctor(
+                app_contracts.DoctorRequest(
+                    github_repo="example/repo",
+                    github_pr=123,
+                    github_head_sha="abcde12345",
+                    github_extended=True,
+                ),
+                ports,
+            )
+
+            assert result.ok
+            assert gateway.requests[0].include_extended is True
+            text = _render_doctor_text(app_contracts, result)
+            rendered = "\n".join(text.stdout_lines + text.stderr_lines + text.warnings)
+            assert "github capability diagnostics=3" in rendered
+            assert "[github:core]" in rendered
+            assert "[github:extended]" in rendered
+            assert "capability=actions_read status=rate_limited" in rendered
+            assert "capability=issue_comments_read status=auth_missing" in rendered
+
+    def test_doctor_distinguishes_auth_missing_from_permission_denied_without_gh_token(self) -> None:
+        _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            specdock_dir = repo_root / "spec-dock"
+            records, _issue_dir = _build_valid_records(infra_contracts, specdock_dir=specdock_dir)
+            gateway = _StubGitHubCapabilityGateway(
+                [
+                    app_contracts.GitHubCapabilityDiagnostic(
+                        code="github_auth_missing",
+                        capability="pull_request_read",
+                        status="auth_missing",
+                        token_source="unknown",
+                        api="gh pr view",
+                        severity="blocking",
+                        message="GitHub authentication is missing.",
+                        recommended_next_action="authenticate_gh_or_set_token",
+                        secret_redacted=True,
+                        stderr_sha256="sha",
+                        group="core",
+                    )
+                ]
+            )
+            ports = app_ports.Ports(
+                node_reader=_StubNodeReader(records),
+                repo_root=repo_root,
+                specdock_dir=specdock_dir,
+                github_capability_gateway=gateway,
+            )
+
+            result = app_doctor.doctor(
+                app_contracts.DoctorRequest(
+                    github_repo="example/repo",
+                    github_pr=123,
+                    github_head_sha="abcde12345",
+                ),
+                ports,
+            )
+
+            text = _render_doctor_text(app_contracts, result)
+            rendered = "\n".join(text.stdout_lines + text.stderr_lines + text.warnings)
+            assert result.ok
+            assert "token_source=unknown" in rendered
+            assert "status=auth_missing" in rendered
+            assert "status=permission_denied" not in rendered
+            assert _SECRET_TOKEN not in rendered
+
+    def test_doctor_renders_rate_transient_and_schema_statuses_distinctly(self) -> None:
+        _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
+        statuses = [
+            ("github_rate_limited", "commit_statuses_read", "rate_limited"),
+            ("github_transient_unknown", "pull_request_read", "transient_unknown"),
+            ("github_schema_unavailable", "status_check_rollup_read", "schema_unavailable"),
+        ]
+        diagnostics = [
+            app_contracts.GitHubCapabilityDiagnostic(
+                code=code,
+                capability=capability,
+                status=status,
+                token_source="GH_TOKEN",
+                api="fixed api",
+                severity="warning",
+                message=status,
+                recommended_next_action="retry_or_inspect_github",
+                secret_redacted=True,
+                stderr_sha256=status,
+                group="core",
+            )
+            for code, capability, status in statuses
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            specdock_dir = repo_root / "spec-dock"
+            records, _issue_dir = _build_valid_records(infra_contracts, specdock_dir=specdock_dir)
+            ports = app_ports.Ports(
+                node_reader=_StubNodeReader(records),
+                repo_root=repo_root,
+                specdock_dir=specdock_dir,
+                github_capability_gateway=_StubGitHubCapabilityGateway(diagnostics),
+            )
+
+            result = app_doctor.doctor(
+                app_contracts.DoctorRequest(
+                    github_repo="example/repo",
+                    github_pr=123,
+                    github_head_sha="abcde12345",
+                ),
+                ports,
+            )
+
+            text = _render_doctor_text(app_contracts, result)
+            rendered = "\n".join(text.stdout_lines + text.stderr_lines + text.warnings)
+            assert result.ok
+            assert "status=rate_limited" in rendered
+            assert "status=transient_unknown" in rendered
+            assert "status=schema_unavailable" in rendered
+            assert "status=permission_denied" not in rendered
+
+    @pytest.mark.parametrize("stderr", ("Unknown JSON field: \"statusCheckRollup\"", "unknown json field: statusCheckRollup"))
+    def test_github_capability_cli_classifies_unknown_json_field_as_schema_unavailable(self, stderr: str) -> None:
+        github_capability_cli = _runtime_github_capability_cli()
+        completed = subprocess.CompletedProcess(["gh"], 1, "", stderr)
+
+        diagnostic = github_capability_cli._diagnostic_from_completed_process(
+            capability="status_check_rollup_read",
+            group="core",
+            api="gh pr view --json statusCheckRollup",
+            completed=completed,
+        )
+
+        assert diagnostic.status == "schema_unavailable"
+        assert diagnostic.code == "github_schema_unavailable"
+        assert diagnostic.recommended_next_action == "inspect_gh_version_or_api_schema"
+        assert diagnostic.secret_redacted is True
+
     def test_doctor_detects_missing_artifact(self) -> None:
         _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/cli_runtime/test_runtime_doctor_s04.py
+++ b/tests/cli_runtime/test_runtime_doctor_s04.py
@@ -291,6 +291,25 @@ class TestRuntimeDoctorS04:
             with pytest.raises(SystemExit):
                 parser.parse_args([forbidden, "value"])
 
+    @pytest.mark.parametrize(
+        "args",
+        (
+            ["--github-repo", "not-a-repo", "--github-pr", "123", "--github-head-sha", "abcde12345"],
+            ["--github-repo", "example/repo", "--github-pr", "0", "--github-head-sha", "abcde12345"],
+            ["--github-repo", "example/repo", "--github-pr", "123", "--github-head-sha", "not-a-sha"],
+        ),
+    )
+    def test_doctor_command_surface_rejects_malformed_github_targets(self, args: list[str]) -> None:
+        import argparse
+
+        command_doctor = _runtime_doctor_command()
+        spec = command_doctor.command_specs()["doctor"]
+        parser = argparse.ArgumentParser(prog="doctor")
+        spec.add_arguments(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(args)
+
     def test_doctor_renders_targeted_github_permission_diagnostic_without_secret(self) -> None:
         _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/cli_runtime/test_runtime_doctor_s04.py
+++ b/tests/cli_runtime/test_runtime_doctor_s04.py
@@ -578,6 +578,62 @@ class TestRuntimeDoctorS04:
         assert diagnostic.recommended_next_action == "inspect_gh_version_or_api_schema"
         assert diagnostic.secret_redacted is True
 
+    def test_github_capability_cli_classifies_integration_permission_denied(self) -> None:
+        github_capability_cli = _runtime_github_capability_cli()
+        completed = subprocess.CompletedProcess(
+            ["gh"],
+            1,
+            "",
+            "GraphQL: Resource not accessible by integration",
+        )
+
+        diagnostic = github_capability_cli._diagnostic_from_completed_process(
+            capability="check_runs_read",
+            group="core",
+            api="GET /repos/{repo}/commits/{sha}/check-runs",
+            completed=completed,
+        )
+
+        assert diagnostic.status == "permission_denied"
+        assert diagnostic.code == "github_token_permission_denied"
+        assert diagnostic.recommended_next_action == "fix_github_token_permissions"
+        assert diagnostic.secret_redacted is True
+
+    def test_github_capability_cli_token_source_uses_github_token_when_gh_token_absent(self, monkeypatch) -> None:
+        github_capability_cli = _runtime_github_capability_cli()
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret_github_token")
+
+        assert github_capability_cli._token_source() == "GITHUB_TOKEN"
+
+    def test_github_capability_cli_token_source_prefers_gh_token(self, monkeypatch) -> None:
+        github_capability_cli = _runtime_github_capability_cli()
+        monkeypatch.setenv("GH_TOKEN", "ghp_secret_gh_token")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret_github_token")
+
+        assert github_capability_cli._token_source() == "GH_TOKEN"
+
+    def test_github_capability_cli_reports_missing_gh_as_auth_missing(self, monkeypatch) -> None:
+        github_capability_cli = _runtime_github_capability_cli()
+
+        def raise_missing_binary(*_args, **_kwargs):
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(github_capability_cli.subprocess, "run", raise_missing_binary)
+
+        diagnostic = github_capability_cli._diagnostic_from_completed_process(
+            capability="pull_request_read",
+            group="core",
+            api="gh pr view",
+            completed=github_capability_cli._run_fixed_gh(["gh", "pr", "view", "13"]),
+        )
+
+        assert diagnostic.status == "auth_missing"
+        assert diagnostic.code == "github_auth_missing"
+        assert diagnostic.recommended_next_action == "authenticate_gh_or_set_token"
+        assert diagnostic.secret_redacted is True
+        assert diagnostic.stderr_sha256 is not None
+
     def test_doctor_detects_missing_artifact(self) -> None:
         _runtime_app, app_contracts, app_doctor, app_ports, infra_contracts = _runtime_modules()
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -12216,7 +12216,7 @@ elif args == ["api", "repos/owner/repo/issues/13/comments", "--method", "POST", 
             "html_url": "https://github.com/owner/repo/issues/13#issuecomment-456",
         }))
     else:
-        print("simulated post failure", file=sys.stderr)
+        print(scenario.get("post_stderr", "simulated post failure"), file=sys.stderr)
         sys.exit(44)
 else:
     print(f"unexpected gh call: {' '.join(args)}", file=sys.stderr)
@@ -12260,6 +12260,8 @@ else:
                 "GH_FAKE_TRIGGER_STATE": str(state_path),
                 "GH_FAKE_LOG": str(gh_log),
             }
+            if "env_gh_token" in scenario:
+                env["GH_TOKEN"] = str(scenario["env_gh_token"])
 
             result = subprocess.run(
                 [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
@@ -12547,6 +12549,158 @@ exit 44
             "new_exact_comment_count": 2,
         }
         assert "trigger_recovery_ambiguous" in [item["code"] for item in payload["limitations"]]
+
+    def test_issue_180_s02_trigger_helper_classifies_comment_permission_denied_without_secret(self) -> None:
+        token_marker = "ghp_secret_marker_1234567890"
+        result, calls = self._issue_176_run_trigger(
+            scenario={
+                "head": "a" * 40,
+                "before_comments": [],
+                "post_success": False,
+                "post_stderr": f"GraphQL: Resource not accessible by personal access token {token_marker}",
+                "env_gh_token": token_marker,
+                "after_comments": [],
+            },
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert token_marker not in result.stdout
+        payload = json.loads(result.stdout)
+        permission_limitations = [
+            item
+            for item in payload["limitations"]
+            if item.get("code") == "github_token_permission_denied"
+        ]
+        assert len(permission_limitations) == 1
+        limitation = permission_limitations[0]
+        assert limitation["capability"] == "trigger_comment_write"
+        assert limitation["api"] == "repos/owner/repo/issues/13/comments"
+        assert limitation["token_source"] == "GH_TOKEN"
+        assert limitation["secret_redacted"] is True
+        assert limitation["recommended_next_action"] == "fix_github_token_permissions"
+        assert "stderr_sha256" in limitation
+        assert "gh_stderr" not in limitation
+        assert payload["overall_status"] == "trigger_post_failed"
+        assert len([
+            call for call in calls
+            if call == [
+                "api",
+                "repos/owner/repo/issues/13/comments",
+                "--method",
+                "POST",
+                "--raw-field",
+                "body=@codex review",
+            ]
+        ]) == 1
+
+    def test_issue_180_s02_trigger_helper_classifies_generic_permission_denied(self) -> None:
+        result, _calls = self._issue_176_run_trigger(
+            scenario={
+                "head": "a" * 40,
+                "before_comments": [],
+                "post_success": False,
+                "post_stderr": "permission denied while posting issue comment",
+                "after_comments": [],
+            },
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        payload = json.loads(result.stdout)
+        permission_limitations = [
+            item
+            for item in payload["limitations"]
+            if item.get("code") == "github_token_permission_denied"
+        ]
+        assert len(permission_limitations) == 1
+        limitation = permission_limitations[0]
+        assert limitation["capability"] == "trigger_comment_write"
+        assert limitation["status"] == "permission_denied"
+        assert limitation["recommended_next_action"] == "fix_github_token_permissions"
+
+    def test_issue_180_s02_wait_maps_trigger_comment_permission_denied_to_human_gate(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        wait_script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh"
+        )
+        token_marker = "ghp_secret_marker_wait_trigger"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "pr view 13 --repo owner/repo --json headRefOid,url,state,isDraft,number")
+    cat <<'JSON'
+{{"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","url":"https://github.com/owner/repo/pull/13","state":"OPEN","isDraft":false,"number":13}}
+JSON
+    ;;
+  "api repos/owner/repo/issues/13/comments --paginate")
+    printf '[]\\n'
+    ;;
+  "api repos/owner/repo/issues/13/comments --method POST --raw-field body=@codex review")
+    printf 'GraphQL: Resource not accessible by personal access token {token_marker}\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [
+                    str(wait_script_path),
+                    "--repo",
+                    "owner/repo",
+                    "--pr",
+                    "13",
+                    "--head-sha",
+                    "a" * 40,
+                    "--timeout-seconds",
+                    "4",
+                    "--poll-interval-seconds",
+                    "1",
+                    "--quiet-seconds",
+                    "1",
+                    "--progress",
+                    "none",
+                ],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            assert payload["script"] == "wait_pr_observation.sh"
+            assert payload["normalized_status"] == "human_gate"
+            assert payload["overall_status"] == "human_gate"
+            assert payload["observation_complete"] is False
+            assert payload["recommended_next_action"] == "fix_github_token_permissions"
+            limitation = next(
+                item
+                for item in payload["limitations"]
+                if item.get("code") == "github_token_permission_denied"
+            )
+            assert limitation["capability"] == "trigger_comment_write"
+            assert limitation["api"] == "repos/owner/repo/issues/13/comments"
+            assert limitation["secret_redacted"] is True
+            assert "stderr_sha256" in limitation
 
     def test_issue_176_s01_trigger_helper_fails_when_head_changes_after_post(self) -> None:
         result, calls = self._issue_176_run_trigger(
@@ -16713,6 +16867,187 @@ esac
             assert payload["ci"]["check_runs"]["success"] == 1
             assert payload["ci"]["check_runs"]["stale"] == 0
             assert "stale_head_check" not in [item["code"] for item in payload["limitations"]]
+
+    def test_issue_180_s02_snapshot_maps_check_runs_permission_denied_to_unknown_limitation(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh"
+        )
+        token_marker = "ghp_secret_marker_check_runs"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "pr view 13 --repo owner/repo --json headRefOid,url,state,isDraft,number")
+    cat <<'JSON'
+{{"headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","url":"https://github.com/owner/repo/pull/13","state":"OPEN","isDraft":false,"number":13}}
+JSON
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs --paginate")
+    printf 'permission denied while reading checks {token_marker}\\n' >&2
+    exit 1
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status --paginate")
+    cat <<'JSON'
+{{"state":"success","statuses":[]}}
+JSON
+    ;;
+  "pr view 13 --repo owner/repo --json mergeStateStatus,statusCheckRollup")
+    cat <<'JSON'
+{{"mergeStateStatus":"CLEAN","statusCheckRollup":[]}}
+JSON
+    ;;
+  "api repos/owner/repo/issues/13/comments --paginate")
+    printf '[]\\n'
+    ;;
+  "api repos/owner/repo/pulls/13/reviews --paginate")
+    printf '[]\\n'
+    ;;
+  "api repos/owner/repo/pulls/13/comments --paginate")
+    printf '[]\\n'
+    ;;
+  "api repos/owner/repo/pulls/13 --paginate")
+    cat <<'JSON'
+{{"requested_reviewers":[],"requested_teams":[]}}
+JSON
+    ;;
+  api\\ graphql*)
+    cat <<'JSON'
+{{"data":{{"repository":{{"pullRequest":{{"reviewDecision":null,"reviewThreads":{{"nodes":[]}}}}}}}}}}
+JSON
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            assert payload["normalized_status"] == "unknown"
+            assert payload["overall_status"] == "unknown"
+            assert payload["observation_complete"] is False
+            assert payload["recommended_next_action"] == "fix_github_token_permissions"
+            assert payload["ci"]["status"] == "unknown"
+            limitation = next(
+                item
+                for item in payload["limitations"]
+                if item.get("code") == "github_token_permission_denied"
+            )
+            assert limitation["capability"] == "check_runs_read"
+            assert limitation["api"] == "repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs"
+            assert limitation["token_source"] == "GH_TOKEN"
+            assert limitation["secret_redacted"] is True
+            assert limitation["recommended_next_action"] == "fix_github_token_permissions"
+            assert "stderr_sha256" in limitation
+
+    def test_issue_180_s02_checks_collector_keeps_non_permission_failures_distinct(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh"
+        )
+
+        cases = (
+            ("auth", "HTTP 401: Requires authentication", "github_auth_missing"),
+            ("rate", "API rate limit exceeded for user", "github_rate_limited"),
+            ("transient", "HTTP 502: upstream temporarily unavailable", "github_transient_unknown"),
+            ("schema", "Unknown JSON field: statusCheckRollup", "github_api_schema_unavailable"),
+        )
+
+        for name, stderr_text, expected_code in cases:
+            with _case(name=name):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    tmp_path = Path(tmp_dir)
+                    fake_bin = tmp_path / "bin"
+                    fake_bin.mkdir()
+                    fake_gh = fake_bin / "gh"
+                    fake_gh.write_text(
+                        f"""#!/usr/bin/env bash
+case "$*" in
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs --paginate")
+    printf '{stderr_text}\\n' >&2
+    exit 1
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status --paginate")
+    cat <<'JSON'
+{{"state":"success","statuses":[]}}
+JSON
+    ;;
+  "pr view 13 --repo owner/repo --json mergeStateStatus,statusCheckRollup")
+    cat <<'JSON'
+{{"mergeStateStatus":"CLEAN","statusCheckRollup":[]}}
+JSON
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                        encoding="utf-8",
+                    )
+                    fake_gh.chmod(0o755)
+                    env = {
+                        **os.environ,
+                        "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                    }
+
+                    result = subprocess.run(
+                        [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                        env=env,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+
+                    assert result.returncode == 0, result.stdout + result.stderr
+                    payload = json.loads(result.stdout)
+                    codes = [item.get("code") for item in payload["limitations"]]
+                    assert expected_code in codes
+                    assert "github_token_permission_denied" not in codes
+
+    def test_issue_180_s02_checks_collector_invalid_input_remains_usage_error(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh"
+        )
+
+        result = subprocess.run(
+            [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "not-a-sha"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 64
+        assert "github_token_permission_denied" not in result.stdout
+        assert "github_token_permission_denied" not in result.stderr
 
     def test_issue_75_pr_observation_checks_collector_merges_paginated_json_objects(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -13729,6 +13729,130 @@ exit 44
             assert payload["limitations"][0]["code"] == "pr_metadata_collection_failed"
             assert gh_log.read_text(encoding="utf-8").startswith("pr view 13 --repo owner/repo --json ")
 
+    def test_issue_180_s02_snapshot_maps_pr_metadata_permission_denied_to_limitation(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh"
+        )
+        token_marker = "ghp_secret_marker_pr_metadata"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "pr view 13 --repo owner/repo --json headRefOid,url,state,isDraft,number")
+    printf 'GraphQL: Resource not accessible by personal access token {token_marker}\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            assert payload["normalized_status"] == "unknown"
+            assert payload["overall_status"] == "unknown"
+            assert payload["observation_complete"] is False
+            assert payload["recommended_next_action"] == "fix_github_token_permissions"
+            limitation = payload["limitations"][0]
+            assert limitation["code"] == "github_token_permission_denied"
+            assert limitation["capability"] == "pull_request_read"
+            assert limitation["api"] == "gh pr view --json headRefOid,url,state,isDraft,number"
+            assert limitation["source"] == "gh_pr_view"
+            assert limitation["status"] == "permission_denied"
+            assert limitation["token_source"] == "GH_TOKEN"
+            assert limitation["secret_redacted"] is True
+            assert limitation["recommended_next_action"] == "fix_github_token_permissions"
+            assert "stderr_sha256" in limitation
+            assert "gh_stderr" not in limitation
+
+    def test_issue_180_s02_snapshot_maps_pr_metadata_integration_denied_to_limitation(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh"
+        )
+        token_marker = "ghs_secret_marker_pr_metadata"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "pr view 13 --repo owner/repo --json headRefOid,url,state,isDraft,number")
+    printf 'GraphQL: Resource not accessible by integration {token_marker}\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            assert payload["normalized_status"] == "unknown"
+            assert payload["overall_status"] == "unknown"
+            assert payload["observation_complete"] is False
+            assert payload["recommended_next_action"] == "fix_github_token_permissions"
+            limitation = payload["limitations"][0]
+            assert limitation["code"] == "github_token_permission_denied"
+            assert limitation["capability"] == "pull_request_read"
+            assert limitation["api"] == "gh pr view --json headRefOid,url,state,isDraft,number"
+            assert limitation["source"] == "gh_pr_view"
+            assert limitation["status"] == "permission_denied"
+            assert limitation["token_source"] == "GH_TOKEN"
+            assert limitation["secret_redacted"] is True
+            assert limitation["recommended_next_action"] == "fix_github_token_permissions"
+            assert "stderr_sha256" in limitation
+            assert "gh_stderr" not in limitation
+
     def test_issue_170_pr_observation_snapshot_derives_terminal_status_from_collectors(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
         script_path = (
@@ -14460,6 +14584,141 @@ esac
                     ).hexdigest(),
                 }
             ]
+
+    def test_issue_180_s02_checks_collector_maps_commit_status_permission_denied(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh"
+        )
+        token_marker = "ghp_secret_marker_commit_status"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs --paginate")
+    cat <<'JSON'
+{{"total_count":1,"check_runs":[{{"id":1,"name":"test","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"completed","conclusion":"success"}}]}}
+JSON
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status --paginate")
+    printf 'GraphQL: Resource not accessible by personal access token {token_marker}\\n' >&2
+    exit 1
+    ;;
+  "pr view 13 --repo owner/repo --json mergeStateStatus,statusCheckRollup")
+    cat <<'JSON'
+{{"mergeStateStatus":"CLEAN","statusCheckRollup":[{{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}}]}}
+JSON
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            limitation = next(
+                item
+                for item in payload["limitations"]
+                if item.get("code") == "github_token_permission_denied"
+            )
+            assert limitation["capability"] == "commit_statuses_read"
+            assert limitation["api"] == "repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status"
+            assert limitation["status"] == "permission_denied"
+            assert limitation["secret_redacted"] is True
+            assert "stderr_sha256" in limitation
+
+    def test_issue_180_s02_checks_collector_maps_status_check_rollup_permission_denied(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh"
+        )
+        token_marker = "ghp_secret_marker_status_rollup"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs --paginate")
+    cat <<'JSON'
+{{"total_count":1,"check_runs":[{{"id":1,"name":"test","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"completed","conclusion":"success"}}]}}
+JSON
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status --paginate")
+    cat <<'JSON'
+{{"state":"success","statuses":[]}}
+JSON
+    ;;
+  "pr view 13 --repo owner/repo --json mergeStateStatus,statusCheckRollup")
+    printf 'GraphQL: Resource not accessible by personal access token {token_marker}\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GH_TOKEN": token_marker,
+            }
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            limitation = next(
+                item
+                for item in payload["limitations"]
+                if item.get("code") == "github_token_permission_denied"
+            )
+            assert limitation["capability"] == "status_check_rollup_read"
+            assert limitation["api"] == "gh_pr_view.statusCheckRollup"
+            assert limitation["source"] == "gh_pr_view"
+            assert limitation["status"] == "permission_denied"
+            assert limitation["secret_redacted"] is True
+            assert "stderr_sha256" in limitation
 
     def test_issue_170_pr_observation_snapshot_keeps_required_checks_pending_as_wait(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -1151,6 +1151,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00174-refine-pr-observation-two-stage-progress-output/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00176-github-pr-observation-codex-review-trigger-and-completion/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00178-review-feedback-triage/.meta.json",
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/issues/iss-00078-installer-coexistence-contract-and-migration-flow/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00090-github-default-sync-contract/.meta.json",
@@ -1270,6 +1271,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00174-refine-pr-observation-two-stage-progress-output/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00176-github-pr-observation-codex-review-trigger-and-completion/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00178-review-feedback-triage/.meta.json": [],
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00067-installed-layout-aligned-asset-source-structure-for-agent-tooling/issues/iss-00180-github-token-capability-preflight/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00077-legacy-hidden-workspace-coexistence-and-migration/issues/iss-00078-installer-coexistence-contract-and-migration-flow/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00090-github-default-sync-contract/.meta.json": [],
@@ -12262,6 +12264,10 @@ else:
             }
             if "env_gh_token" in scenario:
                 env["GH_TOKEN"] = str(scenario["env_gh_token"])
+            if "env_github_token" in scenario:
+                env["GITHUB_TOKEN"] = str(scenario["env_github_token"])
+                if "env_gh_token" not in scenario:
+                    env.pop("GH_TOKEN", None)
 
             result = subprocess.run(
                 [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
@@ -12557,8 +12563,9 @@ exit 44
                 "head": "a" * 40,
                 "before_comments": [],
                 "post_success": False,
-                "post_stderr": f"GraphQL: Resource not accessible by personal access token {token_marker}",
+                "post_stderr": f"GraphQL: Resource not accessible by integration {token_marker}",
                 "env_gh_token": token_marker,
+                "env_github_token": "lower_priority_github_token_marker",
                 "after_comments": [],
             },
         )
@@ -12592,6 +12599,31 @@ exit 44
                 "body=@codex review",
             ]
         ]) == 1
+
+    def test_issue_180_s02_trigger_helper_reports_github_token_source(self) -> None:
+        token_marker = "ghs_secret_marker_trigger"
+        result, _calls = self._issue_176_run_trigger(
+            scenario={
+                "head": "a" * 40,
+                "before_comments": [],
+                "post_success": False,
+                "post_stderr": f"GraphQL: Resource not accessible by integration {token_marker}",
+                "env_github_token": token_marker,
+                "after_comments": [],
+            },
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert token_marker not in result.stdout
+        payload = json.loads(result.stdout)
+        limitation = next(
+            item
+            for item in payload["limitations"]
+            if item.get("code") == "github_token_permission_denied"
+        )
+        assert limitation["capability"] == "trigger_comment_write"
+        assert limitation["token_source"] == "GITHUB_TOKEN"
+        assert limitation["secret_redacted"] is True
 
     def test_issue_180_s02_trigger_helper_classifies_generic_permission_denied(self) -> None:
         result, _calls = self._issue_176_run_trigger(
@@ -12658,6 +12690,7 @@ esac
                 **os.environ,
                 "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
                 "GH_TOKEN": token_marker,
+                "GITHUB_TOKEN": "lower_priority_github_token_marker",
             }
 
             result = subprocess.run(
@@ -13853,6 +13886,59 @@ esac
             assert "stderr_sha256" in limitation
             assert "gh_stderr" not in limitation
 
+    def test_issue_180_s02_snapshot_maps_pr_metadata_github_token_source(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/fetch_pr_observation_snapshot.sh"
+        )
+        token_marker = "ghs_secret_marker_pr_metadata_github_token"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "pr view 13 --repo owner/repo --json headRefOid,url,state,isDraft,number")
+    printf 'GraphQL: Resource not accessible by integration {token_marker}\\n' >&2
+    exit 1
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GITHUB_TOKEN": token_marker,
+            }
+            env.pop("GH_TOKEN", None)
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            limitation = payload["limitations"][0]
+            assert limitation["code"] == "github_token_permission_denied"
+            assert limitation["capability"] == "pull_request_read"
+            assert limitation["token_source"] == "GITHUB_TOKEN"
+            assert limitation["secret_redacted"] is True
+
     def test_issue_170_pr_observation_snapshot_derives_terminal_status_from_collectors(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
         script_path = (
@@ -14652,6 +14738,73 @@ esac
             assert limitation["secret_redacted"] is True
             assert "stderr_sha256" in limitation
 
+    def test_issue_180_s02_checks_collector_maps_integration_permission_denied(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        script_path = (
+            repo_root
+            / "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/fetch_pr_checks_snapshot.sh"
+        )
+        token_marker = "github_token_secret_marker"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            fake_bin = tmp_path / "bin"
+            fake_bin.mkdir()
+            fake_gh = fake_bin / "gh"
+            fake_gh.write_text(
+                f"""#!/usr/bin/env bash
+case "$*" in
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/check-runs --paginate")
+    printf 'GraphQL: Resource not accessible by integration {token_marker}\\n' >&2
+    exit 1
+    ;;
+  "api repos/owner/repo/commits/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/status --paginate")
+    cat <<'JSON'
+{{"state":"success","statuses":[]}}
+JSON
+    ;;
+  "pr view 13 --repo owner/repo --json mergeStateStatus,statusCheckRollup")
+    cat <<'JSON'
+{{"mergeStateStatus":"CLEAN","statusCheckRollup":[]}}
+JSON
+    ;;
+  *)
+    printf 'unexpected gh call: %s\\n' "$*" >&2
+    exit 44
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}",
+                "GITHUB_TOKEN": token_marker,
+            }
+            env.pop("GH_TOKEN", None)
+
+            result = subprocess.run(
+                [str(script_path), "--repo", "owner/repo", "--pr", "13", "--head-sha", "a" * 40],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            assert result.returncode == 0, result.stdout + result.stderr
+            assert token_marker not in result.stdout
+            payload = json.loads(result.stdout)
+            limitation = next(
+                item
+                for item in payload["limitations"]
+                if item.get("code") == "github_token_permission_denied"
+            )
+            assert limitation["capability"] == "check_runs_read"
+            assert limitation["status"] == "permission_denied"
+            assert limitation["token_source"] == "GITHUB_TOKEN"
+            assert limitation["secret_redacted"] is True
+
     def test_issue_180_s02_checks_collector_maps_status_check_rollup_permission_denied(self) -> None:
         repo_root = Path(__file__).resolve().parents[3]
         script_path = (
@@ -14929,7 +15082,9 @@ exit 44
             assert payload["script"] == "wait_pr_observation.sh"
             assert payload["normalized_status"] == "unknown"
             assert payload["observation_complete"] is False
-            assert payload["limitations"][0]["code"] == "pr_metadata_collection_failed"
+            assert payload["limitations"][0]["code"] == "github_rate_limited"
+            assert payload["limitations"][0]["status"] == "rate_limited"
+            assert payload["limitations"][0]["recommended_next_action"] == "wait_or_retry_later"
             assert "poll=1" in result.stderr
             assert "final=stdout_json" in result.stderr
             assert len(result.stderr.strip().splitlines()) == 1


### PR DESCRIPTION
## 概要
- `spec-dock doctor` に GitHub token capability diagnostics を追加し、structural diagnosis と capability finding を分離しました。
- `github-pr-observation` が checks / statuses / statusCheckRollup / PR metadata の権限不足を machine-readable limitation として返すようにしました。
- provider-side assets と dogfooding mirror を同期し、S99 final gate の QA / code / spec reviewer 証跡を `report.md` に記録しました。

## 主な変更
- `GitHubCapabilityDiagnostic` / `GitHubCapabilityGateway` / fixed `gh` adapter を追加。
- `doctor --github-repo --github-pr --github-head-sha [--github-extended]` の固定 surface を追加し、raw endpoint / method / jq / header / raw API surface は追加しない形を維持。
- `Resource not accessible by personal access token`、`permission denied`、`Resource not accessible by integration` を token permission limitation として分類。
- read permission failure は `unknown` semantic non-success、trigger write permission failure は `human_gate` として final JSON に出力。
- token value / raw secret-bearing stderr は出力せず、`stderr_sha256` と `secret_redacted=true` を返す。

## 検証
- `uv run pytest tests/cli_runtime/test_runtime_doctor_s04.py` -> 37 passed
- `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 and pr_metadata'` -> 2 passed, 333 deselected
- `uv run pytest tests/unit/infra/test_init_update.py -k 'issue_180_s02 or github_pr_observation or codex_review or checks_snapshot or checked_in_dogfooding_runtime'` -> 56 passed, 279 deselected
- `diff -qr -x __pycache__ src/spec_dock/assets/install_root/.agents/skills/github-pr-observation .agents/skills/github-pr-observation` -> clean
- `diff -qr -x __pycache__ src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime spec-dock/scripts/spec_dock_runtime` -> clean
- `./spec-dock/scripts/spec-dock validate` -> ok nodes=92
- `git diff --check` -> pass
- final QA reviewer -> pass
- final code-reviewer -> pass
- final spec-reviewer -> pass

## 注意
- live GitHub API は計画どおり自動テストでは使わず、fake `gh` / fixture と parity inspection で検証しています。
- merge は人間判断として残します。

Closes #180
