### PR TITLE
fix(pr-observation): progressのreview表示を対象状態に修正

### DIFF
--- a/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
+++ b/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
@@ -1069,9 +1069,10 @@ def progress_line(
     ci_status = ci_counts["status"]
     review_status = review_counts["status"]
     render_review = review_status
-    if phase == "wait" and not observation_complete and review_status in {"none", "pending", "unknown"}:
+    if phase == "wait" and not observation_complete:
         lifecycle = codex_review_lifecycle(payload)
         decision = decision_payload(payload)
+        pending_signal_candidate = review_status in {"none", "pending", "unknown", "approved", "passed"}
         completion_signal = decision.get("completion_signal") or lifecycle.get("completion_signal")
         lifecycle_status = lifecycle.get("status")
         has_actionable_feedback = any(
@@ -1079,7 +1080,8 @@ def progress_line(
             for key in ("comments", "threads", "unresolved", "requested")
         )
         if (
-            not has_actionable_feedback
+            pending_signal_candidate
+            and not has_actionable_feedback
             and completion_signal in {None, "", "none"}
             and lifecycle_status in {None, "", "none", "pending", "unknown"}
         ):

--- a/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
+++ b/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
@@ -1069,8 +1069,21 @@ def progress_line(
     ci_status = ci_counts["status"]
     review_status = review_counts["status"]
     render_review = review_status
-    if phase == "wait" and not observation_complete:
-        render_review = "observing"
+    if phase == "wait" and not observation_complete and review_status in {"none", "pending", "unknown"}:
+        lifecycle = codex_review_lifecycle(payload)
+        decision = decision_payload(payload)
+        completion_signal = decision.get("completion_signal") or lifecycle.get("completion_signal")
+        lifecycle_status = lifecycle.get("status")
+        has_actionable_feedback = any(
+            int(review_counts.get(key, 0) or 0) > 0
+            for key in ("comments", "threads", "unresolved", "requested")
+        )
+        if (
+            not has_actionable_feedback
+            and completion_signal in {None, "", "none"}
+            and lifecycle_status in {None, "", "none", "pending", "unknown"}
+        ):
+            render_review = "pending_signal"
 
     fields: list[tuple[str, str, bool]] = [
         ("poll", str(poll), False),

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/design.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/design.md
@@ -61,7 +61,8 @@ ID: "iss-00214"
 - 決定:
   - Wait 中、observation 未完了、Codex review completion / comment signal がまだない target state は `review=pending_signal` と表示する。
   - Actionable review feedback がある場合は、`review=unresolved` を表示し、`comments` / `threads` / `unresolved` count を維持する。
-  - Approved / passed / terminal-like states は existing target state を表示する。
+  - Approved / passed / terminal-like states は trusted completion signal または completed lifecycle がある場合だけ existing target state を表示する。
+  - Legacy / audit 由来の `approved` / `passed` review status でも、trusted completion signal がなく、actionable feedback もなく、lifecycle completion もない wait 中 state では `review=pending_signal` と表示する。
 
 ## pending_signal 導出方針
 
@@ -70,12 +71,13 @@ ID: "iss-00214"
 - `review=pending_signal` を表示する条件:
   - `phase == "wait"`
   - `observation_complete is False`
-  - `review_status` が `none` / `pending` / `unknown` のいずれか、または trusted completion / comment signal がない待機中 state と判断できる
+  - `review_status` が `none` / `pending` / `unknown` のいずれか
+  - または、`review_status` が `approved` / `passed` であっても trusted completion / comment signal がなく、completed lifecycle もない legacy / audit 由来の no-completion wait state と判断できる
   - current trigger boundary の actionable review feedback count がない
   - trusted completion signal が `submitted_pull_request_review` ではない
 - `review=pending_signal` を表示しない条件:
   - `review_status` が `unresolved` / `changes_requested` / `commented` / `requested` のような actionable or explicit target state。
-  - `review_status` が `approved` / `passed` など completion を示す state。
+  - `review_status` が `approved` / `passed` など completion を示し、trusted completion signal または completed lifecycle で裏付けられる state。
   - final phase が `terminal` / `timeout` で、既存 final status を表示するほうが正確な場合。
 - 補足:
   - 実装では `review_progress_counts(payload)`、`decision_payload(payload)`、`codex_review_lifecycle(payload)`、`completion_signal`、selected review/comment counts を使って判定する。

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/design.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/design.md
@@ -3,186 +3,217 @@
 ID: "iss-00214"
 タイトル: "PR Observation Review Target State"
 関連GitHub: ["#214"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-19"
 依存: ["requirement.md"]
 親: ["epic-00158", "init-local-00003"]
 ---
 
-# iss-00214 PR Observation Review Target State — 設計（どう実現するか）
-
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
-## 親図（Diagram）参照
-- Epic 図:
-  - ...
-- Initiative 図:
-  - ...
-- 再利用する決定:
-  - ...
+# iss-00214 PR Observation Review Target State — 設計
 
 ## 目的・制約
+
 - 目的:
-  - ...
-- 必須 / 禁止:
-  - ...
-- 非交渉制約:
-  - ...
+  - `wait_pr_observation.sh` の progress line で、`review=` が Codex review の target state を表示するようにする。
+  - Trigger 済みだが Codex review completion / comment signal がまだない wait 中の状態を `review=pending_signal` と表示する。
+- 必須:
+  - `review=observing` への無条件上書きを廃止する。
+  - Existing final JSON contract、`decision` / `decision_fingerprint`、wait completion 判定を変更しない。
+  - Provider-side source と dogfooding mirror の挙動を揃える。
+- 禁止:
+  - `review=` に observer state を表示する。
+  - `running` のような処理中断定表現を signal なしで使う。
+  - `wait_pr_observation.sh` の trigger / resume / snapshot / token permission semantics を変更する。
 - 前提:
-  - ...
+  - `stderr` progress line は non-authoritative diagnostic。
+  - `stdout` JSON が machine-readable authority。
 
 ## 既存実装 / 規約の理解
+
 - 参照した実装 / docs:
-  - ...
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - `tests/unit/infra/test_init_update.py`
+  - `spec-dock/active/issue/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md`
+  - `spec-dock/active/issue/discussions/20260619t064502z-interview-review-pending-state-naming.md`
 - 現状理解:
-  - ...
+  - `review_progress_counts(payload)` は `review.status` / `summary.review` を target review status として返す。
+  - `progress_line(...)` は `review_status = review_counts["status"]` を取得後、`phase == "wait" and not observation_complete` の場合に `render_review = "observing"` で上書きする。
+  - `classify(...)` と wait finalization は no-completion / latency guard / human gate semantics を別に持つ。
+  - Existing tests には `review=observing` を期待する case が 1 つあり、今回の red target になる。
 - 採用するパターン:
-  - ...
+  - Progress line の表示だけを変える小さな helper / local derivation を追加または更新する。
+  - Final JSON の status / decision / fingerprint は既存 path を使う。
+  - Provider-side source を編集し、dogfooding mirror は同等内容へ反映する。
 - 採用しないもの:
-  - ...
-- 影響範囲:
-  - ...
+  - `observer=` / `wait=` の新規 field 追加。
+  - Snapshot collector、review selection、decision generation の再設計。
+  - Trigger reuse / manual trigger policy の変更。
 
 ## 採用方針 / トレードオフ
+
 - 論点:
-  - ...
-- 選択肢:
-  - ...
+  - `review.status` をそのまま出すだけでは、trigger 済み signal 待ち状態が `review=none` になり、operator-facing clarity が不足する。
+  - `review=triggered` は誤再投稿を防ぎやすいが、何を待っているかが弱い。
+  - `review=pending_signal` は signal 待ちを明示し、処理中を過剰に断定しない。
 - 決定:
-  - ...
+  - Wait 中、observation 未完了、Codex review completion / comment signal がまだない target state は `review=pending_signal` と表示する。
+  - Actionable review feedback がある場合は、`review=unresolved` を表示し、`comments` / `threads` / `unresolved` count を維持する。
+  - Approved / passed / terminal-like states は existing target state を表示する。
+
+## pending_signal 導出方針
+
+`pending_signal` は progress display 専用の operator-facing state とする。Final JSON の authoritative status ではない。
+
+- `review=pending_signal` を表示する条件:
+  - `phase == "wait"`
+  - `observation_complete is False`
+  - `review_status` が `none` / `pending` / `unknown` のいずれか、または trusted completion / comment signal がない待機中 state と判断できる
+  - current trigger boundary の actionable review feedback count がない
+  - trusted completion signal が `submitted_pull_request_review` ではない
+- `review=pending_signal` を表示しない条件:
+  - `review_status` が `unresolved` / `changes_requested` / `commented` / `requested` のような actionable or explicit target state。
+  - `review_status` が `approved` / `passed` など completion を示す state。
+  - final phase が `terminal` / `timeout` で、既存 final status を表示するほうが正確な場合。
+- 補足:
+  - 実装では `review_progress_counts(payload)`、`decision_payload(payload)`、`codex_review_lifecycle(payload)`、`completion_signal`、selected review/comment counts を使って判定する。
+  - Trigger metadata が payload にある場合は補助情報として使ってよいが、display helper は final decision を変更しない。
 
 ## 依存関係分析
-- module 依存:
-  - ...
-- class 依存（必要時）:
-  - ...
-- function 依存（必要時）:
-  - ...
-- file 依存:
-  - ...
+
+- module / file 依存:
+  - `.sh` wrapper は Python entrypoint を呼ぶだけで、今回の表示変換には直接関与しない。
+  - `pr_observation_wait.py` の `progress_line(...)` が progress display の中心。
+  - `review_progress_counts(...)` は target review status と counts を集計する upstream helper。
+  - `classify(...)` / wait finalization は authoritative final JSON status を決める downstream-adjacent logic だが、今回の変更対象ではない。
+  - Tests は provider asset を temp workspace へ copy して script behavior を検証する。
 - 上流 / 前提:
-  - ...
+  - Requirement の `review=pending_signal` user-approved decision。
+  - Existing PR observation skill contract。
 - 下流 / 依存先:
-  - ...
+  - `tests/unit/infra/test_init_update.py` の PR observation wait tests。
+  - Provider-side package data / installed asset parity tests。
 - 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
+  - `tests/unit/infra/test_init_update.py` の existing `review=observing` expectation を red target にする。
+  - Provider-side `pr_observation_wait.py` で display derivation を変更する。
+  - Dogfooding mirror `.agents/.../pr_observation_wait.py` に同じ変更を反映する。
 - 順序への影響:
-  - plan では upstream / prerequisite から順に step を組む
+  - 先に test expectation を更新して red を確認し、その後 provider/mirror helper を変更する。
+  - Final JSON regression tests は既存 suite で確認する。
 
 ## モジュール依存図（Module Dependency Diagram）
-- タイトル:
-  - ...
-- 答える問い:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
-- 範囲:
-  - ...
-- 含めない詳細:
-  - 網羅的な call graph / 全 method / 全 import は描かない
-- 更新条件:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- 図:
-  - 下の `plantuml` block を更新する
 
-### 図表（UML / 原則: モジュール依存 / パッケージ依存差分）
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
 
-rectangle "対象module-a" as A
-rectangle "対象module-b" as B
-A --> B : depends_on
+rectangle "wait_pr_observation.sh" as Shell
+rectangle "pr_observation_wait.py" as WaitPy
+rectangle "review_progress_counts(payload)" as Counts
+rectangle "progress_line(...)" as Progress
+rectangle "classify(...) / final JSON decision" as Decision
+rectangle "tests/unit/infra/test_init_update.py" as Tests
+
+Shell --> WaitPy : dispatches
+WaitPy --> Counts : read target review status and counts
+WaitPy --> Progress : render stderr summary
+WaitPy --> Decision : compute authoritative stdout JSON
+Progress --> Counts : uses target state
+Tests --> Shell : execute copied script fixture
+Tests --> Progress : assert stderr review field
+Tests --> Decision : assert stdout JSON contract
 @enduml
 ```
 
-## ローカル図の差分（Local Diagram Delta / 必要時）
-- 変更する境界 / 責務 / 相互作用:
-  - N/A: 理由
-
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
 
-## シーケンス差分（Sequence Delta / 必要時）
-- 変更する相互作用:
-  - N/A: 理由
-- retry / transaction / external API / queue:
-  - ...
-- UML:
-  - N/A: 理由
-
-## ドメインモデル差分（Domain Model Delta / 必要時）
-- 親 model 参照:
-  - ...
-- aggregate / entity / value object 変更:
-  - N/A: 理由
-- domain event / policy / specification 変更:
-  - ...
-- 不変条件の変更:
-  - ...
-- UML:
-  - N/A: 理由
-
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- 責務:
-  - ...
-- 連携:
-  - ...
-- UML:
-  - N/A: 理由
+- Public CLI:
+  - `wait_pr_observation.sh` arguments and trigger modes remain unchanged.
+  - `fetch_pr_observation_snapshot.sh` remains read-only and unchanged.
+- `stderr` progress line:
+  - `review=` displays target review state.
+  - No-signal wait state after trigger displays `review=pending_signal`.
+  - Actionable unresolved feedback displays `review=unresolved` and the relevant counts.
+  - Progress remains bounded ASCII key/value summary.
+- `stdout` JSON:
+  - `decision` / `decision_fingerprint` remain authoritative.
+  - `normalized_status`, `overall_status`, `recommended_next_action`, `observation_complete` semantics remain unchanged.
 
 ## ディレクトリ / ファイル変更計画
+
 ```text
 .
 |-- src/
-|   |-- package/
-|   |   |-- new_module.py        # 追加: 目的; 依存: ...
-|   |   |-- existing_module.py   # 変更: 目的; 依存: ...
-|   |   `-- renamed_module.py    # 移動/rename 元: src/package/old_module.py; 目的
-|   `-- tests/
-|       `-- test_new_module.py   # 追加/変更: 目的; 依存: src/package/new_module.py
-|-- docs/
-|   `-- reference.md             # 読取のみ: 目的
-`-- legacy/
-    `-- obsolete_file.py         # 削除: 目的; 依存: 代替準備完了
+|   `-- spec_dock/
+|       `-- assets/
+|           `-- install_root/
+|               `-- .agents/
+|                   `-- skills/
+|                       `-- github-pr-observation/
+|                           `-- scripts/
+|                               `-- lib/
+|                                   `-- pr_observation_wait.py   # 変更: progress review display derivation
+|-- .agents/
+|   `-- skills/
+|       `-- github-pr-observation/
+|           `-- scripts/
+|               `-- lib/
+|                   `-- pr_observation_wait.py                   # mirror確認/反映: dogfooding asset behavior
+|-- tests/
+|   `-- unit/
+|       `-- infra/
+|           `-- test_init_update.py                              # 変更: review=pending_signal regression
+`-- spec-dock/
+    `-- initiatives/.../iss-00214-pr-observation-review-target-state/
+        |-- requirement.md
+        |-- design.md
+        |-- plan.md
+        |-- report.md
+        `-- discussions/
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+
+- AC-001 -> `progress_line(...)` display helper maps no-signal wait state to `pending_signal`.
+- AC-002 -> Existing actionable review status / counts path remains target-state based and tests keep `review=unresolved`.
+- AC-003 -> No changes to final JSON decision path; existing stdout assertions remain in the focused regression set.
+- AC-004 -> Provider-side source and dogfooding mirror are both inspected / updated.
+- EC-001 -> Latency-guarded no-completion path remains wait / resume before promotion.
+- EC-002 -> `review_completion_unknown` remains final human gate semantics, separate from `pending_signal`.
+- EC-003 -> Fallback issue comment remains low-confidence human gate / wait_or_resume.
+- EC-004 -> Existing line budget regression remains part of verification.
 
 ## テスト戦略
-- 単体:
-  - ...
-- 統合:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
 
-## 要件 / 例外 -> 検証マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+- Red / regression:
+  - Update the existing test that expects `phase=wait ci=passed review=observing` to expect `review=pending_signal`.
+  - Add or extend a focused assertion that unresolved feedback still renders `review=unresolved` plus counts.
+- Green:
+  - Run the focused PR observation wait tests around issue 176 / 174 / 182 / 187 / 214 as applicable.
+  - Run `uv run pytest tests/unit/infra/test_init_update.py -k "pr_observation_wait and (observing or progress or completion or unresolved or issue_176 or issue_174 or issue_187)"` or a narrower valid expression discovered during implementation.
+- Structural / mirror:
+  - Inspect provider and dogfooding mirror for the same display derivation.
+  - Run `./spec-dock/scripts/spec-dock validate`.
+  - Run `./spec-dock/scripts/spec-dock sync --github` if spec artifacts need projection refresh.
 
-## リスク / 移行 / ロールバック（必要時）
-- ...
+## リスク / 移行 / ロールバック
+
+- Risk:
+  - `pending_signal` could be applied too broadly and hide actionable target states.
+  - Progress display changes could accidentally affect final JSON semantics if implemented in classification rather than display-only derivation.
+  - Provider/mirror drift could leave dogfooding behavior different from shipped asset behavior.
+- Mitigation:
+  - Keep derivation local to progress display.
+  - Preserve existing actionable and final-state tests.
+  - Verify provider-side and mirror files.
+- Rollback:
+  - Revert display helper and test expectation changes. No data migration is involved.
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+
+- Blocking:
+  - なし。
+- Non-blocking:
+  - Focused test command may be adjusted to match available test names after implementation discovery.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md
@@ -1,0 +1,135 @@
+---
+種別: research
+ID: "20260619t064501z-research"
+タイトル: "Review Progress Target State Source Analysis"
+状態: "completed"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-19"
+親: ["iss-00214"]
+関連: []
+authority: "synthesized"
+derived_from:
+  - "GitHub issue #214"
+  - "spec-dock/active/context-pack.md"
+  - "spec-dock/active/issue/requirement.md"
+  - "spec-dock/active/epic/requirement.md"
+  - "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py"
+  - ".agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py"
+  - "src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md"
+  - "tests/unit/infra/test_init_update.py"
+reflected_to: []
+---
+
+# 20260619t064501z-research Review Progress Target State Source Analysis
+
+## 位置づけ
+- 用途: 外部仕様、実装事実、先例、制約、用語衝突、edge case など、検証可能な根拠を整理する。
+- authority default: `synthesized`。通常は doc type から推定し、例外時だけ front matter の `authority` で override する。
+- この artifact は source-grounded research evidence surface であり、main orchestrator が canonical docs / accepted ADR / `report.md` Evidence Adoption Ledger へ採用するまでは canonical authority ではない。
+- 調査結果が選択肢比較を必要とする場合は `disc`、長期判断を支える場合は `adr`、人間判断を必要とする場合は `interview` へつなぐ。
+- 事実、推測、未検証事項、用語衝突、edge case、判断への含意を混ぜない。
+- local context で解ける疑問は人間に聞かず、この artifact に source-grounding を残す。
+
+## 調査目的 (必須)
+- GitHub issue #214 の requirement / design / plan 具体化前に、`wait_pr_observation.sh` の progress line が `review=` に何を表示しているか、どの source が authority か、どの未確定判断だけをユーザーに聞く必要があるかを明らかにする。
+
+## sources / 調査方法 (必須)
+- 参照先:
+  - `spec-dock/active/context-pack.md`
+  - `spec-dock/active/issue/requirement.md`
+  - `spec-dock/active/epic/requirement.md`
+  - GitHub issue #214 body
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `tests/unit/infra/test_init_update.py`
+- 検証手順:
+  - `./spec-dock/scripts/spec-dock issue start --id iss-00214`
+  - `gh issue view 214 --json number,title,body,state,url,labels`
+  - `rg -n "def progress_line|render_review|review_progress_counts|review=observing" ...`
+  - `sed` で `review_progress_counts(...)`, `progress_line(...)`, 関連テスト、PR observation skill contract を確認。
+- 実験条件:
+  - 実装・canonical docs 具体化は未実施。
+  - 調査対象は local worktree の current checkout。
+
+## facts / 観測できた事実 (必須)
+- `iss-00214` は `issue start` 済みで、active issue は `iss-00214`、親 epic は `epic-00158`。
+- active issue の `requirement.md` / `design.md` / `plan.md` は import scaffold のままで、実質的な仕様情報は GitHub issue #214 body にある。
+- GitHub issue #214 は、progress line の `review=observing` が監視対象である Codex review の状態ではなく、観測者側の状態を表示していることを問題としている。
+- `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py` と `.agents/.../pr_observation_wait.py` は同じ問題箇所を持つ。
+- `progress_line(...)` は `review_progress_counts(payload)["status"]` を `review_status` として取得した後、`phase == "wait" and not observation_complete` のとき `render_review = "observing"` で上書きしている。
+- `review_progress_counts(...)` は `review.status` / `summary.review` を target state として返し、comments / threads / unresolved / requested count も集計する。
+- `tests/unit/infra/test_init_update.py` には `phase=wait ci=passed review=observing` を期待するテストがあり、今回の仕様変更で更新対象になる。
+- 既存テストには `review=unresolved`、`review=commented` と count 表示を確認するケースがあり、これらは壊してはいけない。
+- `github-pr-observation/SKILL.md` は、`stderr` progress は非 authoritative、final JSON の `decision` / `decision_fingerprint` が authoritative と明記している。
+- 同 skill は、通常 wait flow では caller / agent が手動 `@codex review` を投稿してはいけないこと、`wait_pr_observation.sh` が default `post-once` で固定 trigger を1回投稿することを明記している。
+
+## inference / 推測 (必須)
+- 事実から推測したこと:
+  - 最小実装は provider-side `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py` の `progress_line(...)` を変更し、dogfooding mirror `.agents/...` へ反映する形になりそう。
+  - `review=observing` の上書きを単純に削除すると、GitHub issue の主目的である target state 表示には近づく。
+  - ただし `review.status="none"` かつ trigger metadata がある場合に `review=none` と出ると、operator-facing には「trigger 済みだが signal 待ち」という文脈が弱くなる可能性がある。
+  - `observer=` や `wait=` の追加は、progress line の bounded key/value と optional field drop order への影響があるため、要求するなら design / tests で明示する必要がある。
+- 推測の根拠:
+  - GitHub issue #214 の実装ヒントは `render_review = "observing"` 上書きの廃止または別フィールド化を主な変更候補としている。
+  - Existing skill contract は progress line を bounded summary として扱い、authoritative contract は final JSON に置いている。
+
+## unverified / 未検証事項 (必須)
+- まだ確認していないこと:
+  - `review.status="none"` / `summary.review` / `codex_review.lifecycle.status` の全組み合わせで、既存 payload がどの状態値を持つか。
+  - `trigger` metadata が `post-once` / `resume` / inferred / unknown の各ケースで progress line にどこまで反映可能か。
+  - progress line の length cap と optional drop order に、`observer=` または `wait=` を追加しても問題ないか。
+- 確認できない理由:
+  - ここでは issue start と clarification 調査が目的で、実装・テスト設計はまだ開始していない。
+
+## question candidates / 質問候補 (必須)
+- source-grounded に解けず、人間判断が必要な候補:
+  - `@codex review` trigger 済みだが、Codex review の completion / comment signal がまだない待機中状態を `review=` で何と表現するか。
+- pressure-test question として切り出すべき候補:
+  - `review=pending_signal` を標準名にするか、`review=none` / `review=triggered` / `review=no_completion_signal` など別名にするか。
+- 質問せずに解決できた候補:
+  - `review=observing` は避けるべき。GitHub issue #214 の問題文と受け入れ条件に明記されている。
+  - final JSON の `decision` / `decision_fingerprint` contract は壊さない。skill contract と issue body に明記されている。
+  - 手動 `@codex review` 投稿仕様、default `post-once`、snapshot read-only contract は非スコープ。
+
+## terminology conflicts / 用語衝突 (必須)
+- 衝突している用語:
+  - `observing`: 現在の progress line では wait 中の observer state として使われているが、operator は `review=` を target review state と読んでしまう。
+  - `pending`: 既存 payload / final status では non-terminal wait state として使われる。`review=pending` にすると「review target pending」なのか「whole wait pending」なのか曖昧になりうる。
+  - `none`: target state としては正確な場合があるが、trigger 済みの文脈が progress line だけでは伝わりにくい。
+- 既存 docs / code / tests / discussions での使われ方:
+  - `review_completion_unknown` は、latency guards を満たした後の non-pass terminal-like review state として skill contract に記載されている。
+  - `pending` / `timeout` / `human_gate` は final JSON status / decision path で既に使われている。
+- 判断が必要な理由:
+  - 状態名は user-facing progress line に出るため、operator の次行動と誤操作リスクに直接影響する。
+
+## edge cases / 具体シナリオ (必須)
+- edge case:
+  - Trigger comment は投稿済み、CI は running、Codex review signal はまだゼロ。
+  - CI は passed、Codex review completion signal はまだゼロ、latency guard 未満。
+  - CI は passed、Codex review completion signal はまだゼロ、latency guard を満たして `review_completion_unknown` / `human_gate` へ進む。
+  - Codex review が `unresolved` / `changes_requested` / `commented` になり、comments / threads / unresolved count を表示する。
+  - Codex review が passed / approved 相当になり、final JSON は merge-prepared / passed path を示す。
+- その edge case が requirement / design / plan に与える影響:
+  - 待機中 signal ゼロの名称を決めないと、acceptance criteria と tests が曖昧になる。
+  - `review_completion_unknown` との境界を誤ると、早すぎる human_gate や、逆に timeout の曖昧化につながる。
+
+## implications / 判断への含意 (必須)
+- Requirement では、`review=observing` を廃止し、`review=` は target state を表示することを受け入れ条件にする。
+- Design では、`progress_line(...)` の target state derivation と、必要なら observer/wait state の別フィールド化を定義する。
+- Plan では、existing `review=observing` expectation を failing test として更新し、待機中・unresolved・passed/approved の代表ケースを確認する。
+- ADR は不要そう。これは public progress display contract の局所修正で、長期 architecture decision というより Issue-local design decision。
+
+## リスク/制約 (任意)
+- Progress line は非 authoritative だが、operator-facing で誤操作を誘発しうるため、表示名の clarity は重要。
+- Provider-side source と dogfooding mirror の両方に影響する。
+- Tests は `tests/unit/infra/test_init_update.py` に大きく集約されており、focused `-k` 実行が必要。
+
+## 反映先 (任意)
+- reflected_to:
+  - `requirement.md` / `design.md` / `plan.md` authoring の input。
+  - `report.md` Evidence Adoption Ledger / Spec Authoring Gate。
+
+## 参考（References） (任意)
+- GitHub issue #214: `PR observation progressのreview状態を監視対象基準で表示する`
+- `20260619t064502z-interview-review-pending-state-naming.md`

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t064502z-interview-review-pending-state-naming.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t064502z-interview-review-pending-state-naming.md
@@ -1,0 +1,190 @@
+---
+種別: interview
+ID: "20260619t064502z-interview"
+タイトル: "Review Pending State Naming"
+状態: "answered"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-19"
+親: ["iss-00214"]
+関連: []
+scope: "<initiative | epic | issue | local-topic>"
+scope_id: "iss-00214"
+created_at: "2026-06-19T06:45:02Z"
+created_by: "iwasawayuuta"
+status: "answered"
+authority: "user-approved"
+adoption_status: "adopted"
+derived_from:
+  - "GitHub issue #214"
+  - "20260619t064501z-research-review-progress-target-state-source-analysis.md"
+reflected_to:
+  - "requirement.md"
+  - "design.md"
+  - "plan.md"
+  - "report.md"
+---
+
+# 20260619t064502z-interview Review Pending State Naming
+
+## 位置づけ
+- 用途: 重要判断に関わる一つの質問を、回答前の source-grounded 正式質問シートとして作成し、回答後に同じ artifact を完成 record にする。
+- authority default: `proposed`。ユーザー回答と採用判断を反映した後は、必要に応じて `user-approved` または `synthesized` に更新する。
+- この artifact は answer capture / adoption target / reflection の evidence surface であり、main orchestrator が canonical docs / accepted ADR / `report.md` Evidence Adoption Ledger へ採用するまでは canonical authority ではない。
+- 技術的に調べられることは先に docs / code / tests / ADR / discussions / primary source を確認する。
+- 一つの `interview` artifact には one essential question / 一つの本質的な質問だけを書く。回答によって新しい高影響な曖昧さが見つかった場合は、追加質問をこの file に増やさず、次の unanswered `interview` を作成する。
+- trivial な yes/no は、重要な判断、後続反映、回答証跡が必要なら `interview` を使い、そうでなければ issue comment や `scratch` で足りる。
+- 回答から複数質問の synthesis が必要になったら `disc`、追加調査が必要になったら `research`、長期判断が固まったら `adr` を新規作成する。
+
+## 正式質問として扱う理由 (必須)
+- 影響する artifact:
+  - `requirement.md`:
+    - progress line の `review=` に表示する target state 名を受け入れ条件へ入れるかが変わる。
+  - `design.md`:
+    - `progress_line(...)` の状態名 derivation と、`observer=` / `wait=` の別フィールド化要否が変わる。
+  - `plan.md`:
+    - failing test の期待文字列と、待機中 signal ゼロケースの test obligation が変わる。
+  - `ADR`:
+    - 不要見込み。Issue-local display contract decision として扱う。
+- chat 上の軽微な一問では足りない理由:
+  - 状態名は user-facing progress line に出るため、operator の次行動と誤操作リスクに影響する。回答は canonical docs と tests に反映される。
+
+## 質問の目的 (必須)
+- 対象者:
+  - この PR observation workflow を dogfooding している operator / product owner。
+- 何を明確にする質問か:
+  - `@codex review` trigger 済みだが、Codex review の completion / comment signal がまだない状態を、progress line の `review=` で何と表示するか。
+- 回答が後続判断へ与える影響:
+  - `review=observing` 廃止後の primary display value、必要なら observer/wait state の別フィールド化、テスト期待値が決まる。
+
+## 質問 (必須)
+- pressure-test question:
+  - `review=` は「監視対象の Codex review 状態」だけを表示し、観測者側の状態は必要なら別 key に逃がす、という方針でよいか。
+- 質問:
+  - Trigger comment は投稿済みだが、Codex review の completion / comment signal がまだ観測できない待機中状態を、progress line ではどの表記にしたいですか？
+- 回答してほしいこと:
+  - 推奨の表示値を 1 つ選ぶか、別案を指定してください。
+  - `observer=` または `wait=` のような別フィールドを追加したいかも合わせて教えてください。
+
+## source-grounded context (必須)
+- 確認済みの docs / code / tests / ADR / discussions / primary source:
+  - GitHub issue #214 body。
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - `tests/unit/infra/test_init_update.py`
+  - `20260619t064501z-research-review-progress-target-state-source-analysis.md`
+- local context で解決できたこと:
+  - `review=observing` は避けるべき。
+  - `review=` は observer state ではなく target review state を表示すべき。
+  - final JSON の `decision` / `decision_fingerprint` は authoritative のまま維持する。
+  - 手動 `@codex review` 投稿、default `post-once`、snapshot read-only contract は非スコープ。
+- まだ人間判断が必要な理由:
+  - issue body は `triggered` / `pending_signal` / `no_completion_signal` を例示しているが、標準名を一つに確定していない。
+  - 状態名は operator-facing な言葉であり、実装だけから最適な語を決めると利用者の認知に合わない可能性がある。
+
+## 回答案 (必須)
+- Option A:
+  - `review=pending_signal`
+  - 意味: trigger 済み / wait 中だが、completion / comment signal はまだない。
+  - 長所: 「まだ signal 待ち」が明確で、`running` より断定しない。
+  - 短所: 既存の internal status ではなく、新しい operator-facing 表示名になる。
+- Option B:
+  - `review=triggered`
+  - 意味: `@codex review` trigger は投稿済み。
+  - 長所: 手動再投稿が不要であることを強く示せる。
+  - 短所: trigger 済み後に何を待っているかは弱い。
+- Option C:
+  - `review=none`
+  - 意味: payload 上の target review status をそのまま表示する。
+  - 長所: 実装上の状態を最も素直に出す。
+  - 短所: trigger 済みなのに未起動に見え、今回の誤認を十分に防げない可能性がある。
+- Option D:
+  - `review=no_completion_signal`
+  - 意味: completion signal がまだない。
+  - 長所: 後段の `review_completion_unknown` との意味的連続性がある。
+  - 短所: 初期 wait 中から出すにはやや重く、terminal-like unknown と混同しうる。
+
+## Codex の分析 (必須)
+- 判断軸:
+  - operator が手動 `@codex review` を再投稿しないで済むか。
+  - GitHub / Codex 側の処理中を過剰に断定しないか。
+  - final JSON authoritative contract と混同しないか。
+  - progress line の bounded ASCII key/value summary に収まるか。
+- tradeoff:
+  - `triggered` は誤再投稿を防ぎやすいが、signal 待ちの状態説明が薄い。
+  - `pending_signal` は実際の待ち状態をよく表すが、新しい表示語として requirement / tests へ固定する必要がある。
+  - `none` は既存 payload への忠実度が高いが、operator-facing clarity は低い。
+- リスク:
+  - 表示名が曖昧だと、今回と同じく手動 trigger 追加や trigger boundary 混乱を再発させる。
+  - `review_completion_unknown` と近すぎる名前にすると、latency guard 後の human gate と通常 wait 中の区別が曖昧になる。
+- 具体シナリオ / edge case:
+  - `phase=wait ci=running review=pending_signal comments=0 threads=0 unresolved=0`
+  - `phase=wait ci=passed review=pending_signal comments=0 threads=0 unresolved=0`
+  - `phase=terminal ci=passed review=unresolved comments=4 threads=3 unresolved=3`
+
+## Codex の推奨案 (必須)
+- 推奨:
+  - Option A: `review=pending_signal`
+  - observer 側の状態は、今回は追加しない。必要なら将来 `wait=active` を別 issue / design decision として扱う。
+- 理由:
+  - `pending_signal` は「trigger 済みだが Codex review completion / comment signal 待ち」という operator-facing 目的に近く、`running` のように処理中を断定しない。
+  - `review=observing` の問題を直接解消しつつ、`review_completion_unknown` の terminal-like human gate とは区別しやすい。
+  - progress line の既存 key set を増やさずに済むため、line budget と drop order への影響が小さい。
+- 未回答時の影響:
+  - requirement / design / plan の具体化で表示名を仮置きする必要があり、後から test expectation と docs の修正が発生する可能性がある。
+
+## ユーザー回答 (回答後に必須)
+- answer capture:
+  - `review=pending_signal` を採用する。
+  - `review=` は観測者側の状態ではなく、観測対象である Codex review の状態を表示する。
+- 回答:
+  - 「review=pending_signal これが良いと思います。観測する自分の状態を表示するのではなくて、観測対象の状態を表示するべきです。」
+- 回答日時:
+  - 2026-06-19
+
+## 追加確認の要否 (回答後に必須)
+- 追加確認が必要か:
+  - no
+- 必要な場合に次の unanswered `interview` として切り出す質問:
+  - none
+
+## 採用判断 (回答後に必須)
+- adoption_status:
+  - adopted
+- adoption target:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `report.md` Evidence Adoption Ledger / Spec Authoring Gate
+- 採用 / 棄却 / deferred の理由:
+  - ユーザーが operator-facing 表示値として `review=pending_signal` を承認し、`review=` は observer state ではなく target state を表示するべきだと明示したため。
+- `report.md` Evidence Adoption Ledger への反映要否:
+  - yes
+
+## requirement / design / plan / ADR への含意 (回答後に必須)
+- `requirement.md`:
+  - `review=observing` を廃止し、trigger 済みだが Codex review completion / comment signal がまだない状態を `review=pending_signal` と表示する acceptance criteria を追加する。
+- `design.md`:
+  - `progress_line(...)` の `review=` は target review state を表示し、observer state で上書きしない。signal 待ち状態は `pending_signal` として導出する。
+- `plan.md`:
+  - 既存 `review=observing` expectation を red / regression test として更新し、`review=pending_signal` を検出する step を置く。
+- `ADR`:
+  - 不要。Issue-local display contract decision として扱う。
+- reflected_to 更新方針:
+  - Canonical docs authoring 時に front matter `reflected_to` と `report.md` adoption evidence を更新する。
+- adoption reflection:
+  - `review=pending_signal` is user-approved for the no-completion/comment-signal wait state after a trigger.
+
+## 条件付き補足 (必要な場合だけ)
+- PlantUML 図:
+  ```plantuml
+  @startuml
+  ' TODO: 質問依存、意思決定フロー、before/after、責務境界が必要なら追加する
+  @enduml
+  ```
+- 詳細 tradeoff:
+  - ...
+- 後続 reflection proposal:
+  - ...
+- 追加で作る discussion docs:
+    - ...

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105436z-pr-repair-batch-pr-repair-batch.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105436z-pr-repair-batch-pr-repair-batch.md
@@ -21,17 +21,17 @@ reflected_to: []
 - Repository: chemitaro/spec-dock
 - Base branch: main
 - Head branch: iss-00214-pr-observation-review-target-state
-- Latest head SHA: f3b95994d94923c3e700e4fc54e52f5e70ee8c92
+- Latest head SHA: 397900ef60152ef5bb00c0d5012014b358fa02c2
 - Observation command: `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 216 --head-sha f3b95994d94923c3e700e4fc54e52f5e70ee8c92 --timeout-seconds 900 --poll-interval-seconds 30 --quiet-seconds 30 --same-fingerprint-count 2 --progress stderr-summary`
 - Observation final JSON / evidence: `normalized_status=failed`, `recommended_next_action=fix_ci`, `head_matches_expected=true`
 - Observation status: failed
 - Trigger comment id: 4750792642
 - Trigger created_at: 2026-06-19T10:41:29Z
-- Trigger boundary: fixed trigger comment for head `f3b95994d94923c3e700e4fc54e52f5e70ee8c92`; repair push requires a new latest-head observation.
+- Trigger boundary: repair observation trigger comment `4750906881` for head `397900ef60152ef5bb00c0d5012014b358fa02c2`.
 - Resume metadata: not used; observation completed with CI failure.
-- New trigger approved: no
-- Observation limitation: Codex review returned a low-confidence fallback issue comment with no blocking finding; provider CI failed.
-- Batch status: repair-needed
+- New trigger approved: yes; repair push required a latest-head observation.
+- Observation limitation: Initial observation failed on provider CI; repair observation has all checks passing but remains `human_gate` because Codex review completion is a low-confidence fallback issue comment.
+- Batch status: human-gate
 
 ## Batch Purpose
 
@@ -79,7 +79,7 @@ Use this batch to triage review findings, CI failures, merge blockers, and obser
 
 | unit_id | source_batch | covered_ids | disposition | risk_class | repair_unit_disc | status | Implementation Plan | Re-observation Result | Residual Risk |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| U001 | 20260619t105436z-pr-repair-batch | INV-001 | fix-now | blocking | `20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md` | implemented | Add `iss-00214.../.meta.json` to both checked-in dogfooding snapshot constants and run the focused failing test. | Pending repair push and latest-head observation. | Low; snapshot-only change. |
+| U001 | 20260619t105436z-pr-repair-batch | INV-001 | fix-now | blocking | `20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md` | reobserved-pass | Add `iss-00214.../.meta.json` to both checked-in dogfooding snapshot constants and run the focused failing test. | CI passed on latest head; observation remains `human_gate` because the Codex completion signal is a low-confidence fallback issue comment. | Low; snapshot-only change is repaired, but merge-prepared remains blocked by observation completion policy. |
 
 ## Unit Discussion Plan
 

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105436z-pr-repair-batch-pr-repair-batch.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105436z-pr-repair-batch-pr-repair-batch.md
@@ -1,0 +1,139 @@
+---
+種別: pr-repair-batch
+ID: "20260619t105436z-pr-repair-batch"
+タイトル: "PR Repair Batch"
+状態: "draft | proposed | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-19"
+親: ["iss-00214"]
+関連: []
+authority: "proposed"
+derived_from: []
+reflected_to: []
+---
+
+# 20260619t105436z-pr-repair-batch PR Repair Batch
+
+## PR / Observation Metadata
+
+- PR URL: https://github.com/chemitaro/spec-dock/pull/216
+- PR number: 216
+- Repository: chemitaro/spec-dock
+- Base branch: main
+- Head branch: iss-00214-pr-observation-review-target-state
+- Latest head SHA: f3b95994d94923c3e700e4fc54e52f5e70ee8c92
+- Observation command: `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 216 --head-sha f3b95994d94923c3e700e4fc54e52f5e70ee8c92 --timeout-seconds 900 --poll-interval-seconds 30 --quiet-seconds 30 --same-fingerprint-count 2 --progress stderr-summary`
+- Observation final JSON / evidence: `normalized_status=failed`, `recommended_next_action=fix_ci`, `head_matches_expected=true`
+- Observation status: failed
+- Trigger comment id: 4750792642
+- Trigger created_at: 2026-06-19T10:41:29Z
+- Trigger boundary: fixed trigger comment for head `f3b95994d94923c3e700e4fc54e52f5e70ee8c92`; repair push requires a new latest-head observation.
+- Resume metadata: not used; observation completed with CI failure.
+- New trigger approved: no
+- Observation limitation: Codex review returned a low-confidence fallback issue comment with no blocking finding; provider CI failed.
+- Batch status: repair-needed
+
+## Batch Purpose
+
+Use this batch to triage review findings, CI failures, merge blockers, and observation limitations after PR observation and before repair delegation. The batch separates validity from need-to-fix, groups related concerns, creates repair units when needed, and records residual risk for the final merge-prepared decision.
+
+## Concern Catalog
+
+| concern_id | concern | related_inventory_ids | suspected_root_cause | repair_unit | notes |
+| --- | --- | --- | --- | --- | --- |
+| C001 | Provider CI `provider-tests` failed after PR observation | INV-001 | checked-in dogfooding `.meta.json` path/dependency baseline omitted newly imported `iss-00214` metadata | U001 | Snapshot-only repair; no runtime behavior change intended. |
+
+## Inventory
+
+| ID | source_type | concern | failure_class | evidence | summary | validity | risk_class | need_to_fix | disposition | repair_unit | status | rationale | residual_risk |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| INV-001 | ci | `Provider CI / provider-tests` failed | check_failure:provider-tests | GitHub Actions run `27820892612`, job `82333463397`; `tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_use_meta_json_dependencies` assertion reported one extra `iss-00214.../.meta.json` path | The PR imported/started `iss-00214`, but the checked-in dogfooding metadata snapshot in `test_init_update.py` was not updated. | valid | blocking | yes | fix-now | U001 | unit-created | Required CI check cannot pass while checked-in dogfooding tree and baseline diverge. | Low; repair should only align test baseline with committed dogfooding metadata. |
+
+## Classification Values
+
+- `validity`: `valid` / `partially-valid` / `false-positive` / `duplicate` / `unknown`
+- `failure_class`: `check_failure:<job_or_check_name>` / `review_feedback:<topic>` / `merge_conflict` / `base_branch_conflict` / `permission_or_auth` / `external_or_flaky` / `timeout` / `unknown`
+- `risk_class`: `blocking` / `material-follow-up` / `minor` / `false-positive` / `duplicate`
+- `need_to_fix`: `yes` / `no` / `follow-up` / `human-decision`
+- `disposition`: `fix-now` / `follow-up` / `no-action` / `covered-by` / `needs-human`
+- `status`: `untriaged` / `triaged` / `unit-needed` / `unit-created` / `implemented` / `reobserved-pass` / `blocked`
+
+## Per-Concern Analysis
+
+### CXXX
+
+### C001
+
+- Covered inventory IDs: INV-001
+- Validity analysis: Valid CI failure. The checked-in dogfooding tree contains `iss-00214-pr-observation-review-target-state/.meta.json`; the cutover snapshot in `tests/unit/infra/test_init_update.py` does not.
+- Need-to-fix decision: Fix now because `Provider CI / provider-tests` is a merge-blocking check.
+- Root cause: Issue scaffold/import changed the checked-in dogfooding metadata surface after the earlier local targeted validation, but the snapshot constants were not updated.
+- Options considered:
+  - Update only `_CHECKED_IN_DOGFOODING_META_JSON_PATHS`.
+  - Update both `_CHECKED_IN_DOGFOODING_META_JSON_PATHS` and `_CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH`.
+- Recommended disposition: Update both snapshot constants so path and dependency baselines remain internally consistent.
+- Rationale: `iss-00214` currently has no `depends_on` values, so the correct dependency baseline entry is an empty list.
+- Residual risk: Full provider test runtime is longer than the focused failure, so re-observation is still required after push.
+
+## Repair Queue
+
+| unit_id | source_batch | covered_ids | disposition | risk_class | repair_unit_disc | status | Implementation Plan | Re-observation Result | Residual Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| U001 | 20260619t105436z-pr-repair-batch | INV-001 | fix-now | blocking | `20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md` | implemented | Add `iss-00214.../.meta.json` to both checked-in dogfooding snapshot constants and run the focused failing test. | Pending repair push and latest-head observation. | Low; snapshot-only change. |
+
+## Unit Discussion Plan
+
+Create a repair unit `disc` for each `fix-now` item and each `needs-human` item that needs implementation analysis, design judgment, or options comparison. The worker must use the repair unit discussion, not raw findings, as the source of truth.
+
+Required repair unit checklist:
+
+- `source_batch`
+- `unit_id`
+- `covered_ids`
+- `source_links`
+- `failure_class`
+- `risk_class`
+- `disposition`
+- `Validity Analysis`
+- `Need-To-Fix Decision`
+- `Root Cause`
+- `Options Considered`
+- `Recommended Design`
+- `Implementation Plan`
+- `Validation Plan`
+- `Implementation Result`
+- `Commit Evidence`
+- `Re-observation Result`
+- `Residual Risk / Follow-up`
+
+## Stop Conditions
+
+Stop at a human gate when any condition applies:
+
+- Any inventory item remains `untriaged`.
+- Any unresolved `needs-human` item remains.
+- A `blocking` `fix-now` repair unit is incomplete or repeatedly fails.
+- Observation output is not for the latest head SHA.
+- Timeout or observation limitation lacks resume metadata.
+- Resume would cross the recorded trigger boundary.
+- A new trigger would be required but has not been approved.
+- Scope expansion, requirement expansion, breaking change, migration, secret, deployment setting, permission/auth, external/flaky, or ambiguous review intent is involved.
+- Loop limits for the same failure class or total repair attempts are reached.
+
+## Merge-Prepared Gate
+
+Report `merge-prepared: yes` only when all conditions are true:
+
+- PR is open.
+- Latest head re-observation is complete and matches the latest head SHA.
+- No required check failure remains.
+- No non-required check failure remains unless the check is known optional or the user explicitly waived it; waived or optional non-required failures are recorded as residual risk.
+- No blocking review feedback remains.
+- No visible merge conflict or equivalent merge blocker remains.
+- No `untriaged` inventory item remains.
+- No unresolved `needs-human` item remains.
+- No `blocking` item has an incomplete `fix-now` repair unit.
+- Every `follow-up`, `no-action`, `covered-by`, `duplicate`, or `false-positive` item has rationale and residual risk where relevant.
+- Observation limitation handling, resume metadata, trigger boundary, and new trigger approval status are recorded.
+- Review-thread unresolved state is known, or any unresolved-thread limitation is explicitly waived and recorded as residual risk.
+- `review-clean` is reported separately from `merge-prepared`; `review-clean: no` may still be `merge-prepared: yes` when all remaining items are triaged and non-blocking.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md
@@ -1,0 +1,83 @@
+---
+種別: disc
+ID: "20260619t105634z-disc"
+タイトル: "PR Repair Unit U001 CI Snapshot"
+状態: "draft | proposed | archived"
+作成者: "iwasawayuuta"
+最終更新: "2026-06-19"
+親: ["iss-00214"]
+関連: []
+authority: "proposed"
+derived_from: []
+reflected_to: []
+---
+
+# 20260619t105634z-disc PR Repair Unit U001 CI Snapshot
+
+## source_batch
+- `20260619t105436z-pr-repair-batch`
+
+## unit_id
+- U001
+
+## covered_ids
+- INV-001
+
+## source_links
+- PR: https://github.com/chemitaro/spec-dock/pull/216
+- GitHub Actions run: `27820892612`
+- GitHub Actions job: `82333463397`
+- Local failing surface: `tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_use_meta_json_dependencies`
+
+## failure_class
+- `check_failure:provider-tests`
+
+## risk_class
+- `blocking`
+
+## disposition
+- `fix-now`
+
+## Validity Analysis
+- `Provider CI / provider-tests` failed on the checked-in dogfooding metadata cutover snapshot.
+- The observed tree contains `spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/.meta.json`.
+- `_CHECKED_IN_DOGFOODING_META_JSON_PATHS` did not include that path when CI ran.
+
+## Need-To-Fix Decision
+- Fix now. The failure is in a required provider CI lane and blocks merge preparation.
+
+## Root Cause
+- The issue scaffold/import added checked-in dogfooding metadata for `iss-00214`, but the baseline constants in `tests/unit/infra/test_init_update.py` were not updated.
+
+## Options Considered
+- Update only `_CHECKED_IN_DOGFOODING_META_JSON_PATHS`.
+- Update both `_CHECKED_IN_DOGFOODING_META_JSON_PATHS` and `_CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH`.
+
+## Recommended Design
+- Add the `iss-00214.../.meta.json` path to `_CHECKED_IN_DOGFOODING_META_JSON_PATHS`.
+- Add the same path to `_CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH` with `[]`, because the issue metadata has no `depends_on` entries.
+
+## Implementation Plan
+- Patch `tests/unit/infra/test_init_update.py`.
+- Run the focused failing test.
+- If the focused test passes, update this unit and the repair batch evidence.
+- Push the repair and re-observe PR #216 on the new head SHA.
+
+## Validation Plan
+- `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json`
+- PR latest-head observation after push.
+
+## Implementation Result
+- Added the `iss-00214.../.meta.json` path to `_CHECKED_IN_DOGFOODING_META_JSON_PATHS`.
+- Added the same path to `_CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH` with `[]`.
+- Focused test command used the actual local test name: `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json`.
+- Focused test result: passed, `1 passed in 0.08s`.
+
+## Commit Evidence
+- Pending.
+
+## Re-observation Result
+- Pending.
+
+## Residual Risk / Follow-up
+- Low. This repair is expected to affect only the checked-in dogfooding baseline test, not runtime behavior.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/discussions/20260619t105634z-disc-pr-repair-unit-u001-ci-snapshot.md
@@ -74,10 +74,14 @@ reflected_to: []
 - Focused test result: passed, `1 passed in 0.08s`.
 
 ## Commit Evidence
-- Pending.
+- `397900ef` `test(dogfooding): iss-00214のメタデータsnapshotを更新`
 
 ## Re-observation Result
-- Pending.
+- Latest head: `397900ef60152ef5bb00c0d5012014b358fa02c2`
+- `gh pr checks 216 --repo chemitaro/spec-dock` showed all four checks passing: two `validate` and two `provider-tests` entries.
+- PR observation on trigger comment `4750906881` found CI passed, no review threads, and no unresolved feedback.
+- Observation result remained `human_gate` because the Codex review signal was classified as `fallback_issue_comment_low_confidence`; `observation_complete=false`, `recommended_next_action=wait_or_resume`.
 
 ## Residual Risk / Follow-up
-- Low. This repair is expected to affect only the checked-in dogfooding baseline test, not runtime behavior.
+- Snapshot repair risk is low and verified by focused local test plus CI.
+- Merge preparation remains blocked by observation policy, not by the snapshot repair itself.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/plan.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/plan.md
@@ -217,6 +217,7 @@ ID: "iss-00214"
     - Need to add observer/wait field.
     - Need to change trigger / resume / snapshot behavior.
     - `pending_signal` cannot be derived without weakening AC-001 or AC-003.
+    - QA/final review discovers a no-completion wait payload shape that requires adding a new `review_status` candidate outside `none` / `pending` / `unknown`; in that case amend design/plan and rerun fresh spec review before final handoff.
 
 #### 委任契約（delegation contract）
 
@@ -258,10 +259,11 @@ ID: "iss-00214"
 
 - `tc-s01-001` acceptance: no-signal wait progress uses pending_signal
   - 前提: Existing fixture produces wait-phase payload where CI passed, review status is `none` or `pending`, lifecycle is pending/none, and no Codex completion/comment signal exists.
+  - 追加前提: Existing latency-guard no-completion fixture may report legacy `approved` / `passed` review status without a trusted Codex completion signal; this is still a no-signal wait display state and must render `review=pending_signal` while final JSON remains wait/resume / non-terminal.
   - 操作: Update the existing `test_issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint` expectation before implementation.
   - 期待結果: Pre-implementation run fails because stderr still contains `review=observing`; post-implementation run passes with `review=pending_signal`.
   - 失敗検出: Observer state remains displayed in `review=`.
-  - 検証方法: Focused `uv run pytest ... -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint"`.
+  - 検証方法: Focused `uv run pytest ... -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_187_s204_wait_does_not_promote_unknown_before_trigger_age"`.
   - 関連 closure id: tc-001
 - `tc-s01-002` regression: unresolved feedback keeps unresolved target state and counts
   - 前提: Existing issue 174 fixture contains current unresolved Codex review feedback with review comments and threads.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/plan.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/plan.md
@@ -3,268 +3,381 @@
 ID: "iss-00214"
 タイトル: "PR Observation Review Target State"
 関連GitHub: ["#214"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-19"
 依存: ["requirement.md", "design.md"]
 親: ["epic-00158", "init-local-00003"]
 ---
 
-# iss-00214 PR Observation Review Target State — 実装計画（実行契約 / Execution Contract）
-
-> このテンプレートは executable scaffold です。`plan.md` は計画済み契約（planned contract）と、実装者が step を上から順に実行できる command queue を書く場所です。実行結果、逸脱、発見された tests、reviewer verdict、commit/no-op evidence は `report.md` の観測証跡台帳（observed evidence ledger）に記録する。workflow authority は skills / `workflow_issue.md` が持ち、Issue 計画の field semantics と詳しい書き方は `phase_plan_issue.md` と `docs/authoring/issue-plan.md` を detail-reference として参照する。
+# iss-00214 PR Observation Review Target State — 実装計画
 
 ## この計画で満たす要件ID
+
 - AC:
-  - ...
+  - AC-001: no-signal wait state shows `review=pending_signal`.
+  - AC-002: unresolved current review feedback shows `review=unresolved` with counts.
+  - AC-003: final JSON `decision` / `decision_fingerprint` contract remains unchanged.
+  - AC-004: provider-side source and dogfooding mirror stay aligned.
 - EC:
-  - ...
+  - EC-001: latency-guarded no-completion path remains wait / resume before promotion.
+  - EC-002: `review_completion_unknown` human gate remains distinct from `pending_signal`.
+  - EC-003: fallback issue comment semantics remain low-confidence human gate / wait_or_resume.
+  - EC-004: progress line budget remains bounded.
 - 制約:
-  - ...
+  - `review=` must show target review state, not observer state.
+  - `observer=` / `wait=` field is not added in this issue.
+  - Trigger / resume / snapshot / token permission semantics are out of scope.
 
 ## 依存関係から導く実装順序
+
 - 依存関係の参照元:
-  - `design.md` の依存関係、図、ファイル変更計画
+  - `design.md` の `依存関係分析`、`Module Dependency Diagram`、`ディレクトリ / ファイル変更計画`。
 - 順序ルール:
-  - prerequisite / lower-dependency slice から先に閉じる
-  - downstream slice は前提が固定されてから置く
+  - Existing `review=observing` expectation を red target として先に固定する。
+  - Provider-side display derivation を変更し、dogfooding mirror へ同等内容を反映する。
+  - Focused regression tests で wait display、unresolved counts、final JSON no-completion path、line budget を確認する。
 - step 依存サマリー:
   - S01:
-    - 依存:
-    - unblock:
-    - 対象ファイル:
+    - 依存: approved `requirement.md`, approved `design.md`
+    - unblock: S90 docs impact inspection, S99 final quality gate
+    - 対象ファイル: PR observation wait provider/mirror script and focused tests
+  - S90:
+    - 依存: S01 implementation diff
+    - unblock: S99 final spec review
+    - 対象ファイル: PR observation skill docs if inspection shows required update
+  - S99:
+    - 依存: S01 and S90 complete
+    - unblock: issue execution completion / PR delivery workflow
+    - 対象ファイル: issue-wide diff and report evidence
 
 ## ステップ一覧
+
 - S01:
-  - 観測可能な振る舞い:
-  - 依存:
-  - unblock:
+  - 観測可能な振る舞い: wait progress line displays `review=pending_signal` for trigger-boundary no-signal wait state and preserves actionable review target states.
+  - 依存: requirement/design approved.
+  - unblock: docs impact inspection and final quality gate.
   - 対象ファイル:
-  - 閉じる要件:
-  - レビューゲート:
-- S02:
-  - ...
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+    - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+    - `tests/unit/infra/test_init_update.py`
+    - `spec-dock/active/issue/report.md`
+  - 閉じる要件: AC-001, AC-002, AC-003, AC-004, EC-001, EC-002, EC-003, EC-004.
+  - レビューゲート: code-reviewer pass before step commit.
+- S90:
+  - 観測可能な振る舞い: docs impact is explicitly resolved as update-needed or no-update with evidence.
+  - 依存: S01 diff known.
+  - unblock: S99 final spec review.
+  - 対象ファイル:
+    - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+    - `.agents/skills/github-pr-observation/SKILL.md`
+    - `spec-dock/active/issue/report.md`
+  - 閉じる要件: AC-003, AC-004.
+  - レビューゲート: spec-reviewer docs/spec alignment pass.
+- S99:
+  - 観測可能な振る舞い: issue-wide quality gates pass and execution handoff readiness is recorded.
+  - 依存: S01 committed, S90 resolved.
+  - unblock: PR delivery / merge-prep / issue finish workflow.
+  - 対象ファイル: issue-wide diff.
+  - 閉じる要件: all AC / EC.
+  - レビューゲート: qa-reviewer pass, issue-wide code-reviewer pass, final spec-reviewer pass.
 
 ## 要件 ↔ ステップ対応
+
 - AC-001 -> S01
-- EC-001 -> S02
+- AC-002 -> S01
+- AC-003 -> S01, S90, S99
+- AC-004 -> S01, S90
+- EC-001 -> S01
+- EC-002 -> S01
+- EC-003 -> S01
+- EC-004 -> S01
 
 ## 仕様固定クロージャ索引（Spec-Locked Closure Index）
 
-> これは Issue 全体のテスト一覧ではなく、仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の step-local obligation と concrete seeds は各 implementation step の `具体テストケース一覧` に置く。
-
 | 識別子（ID） | ステップ（step） | スライス（slice） | 種別（type） | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル（evidence level） | クロージャ証跡（closure evidence） |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | 受け入れ（acceptance） | AC-001 | ... | ... | 仕様 drift（spec drift） | yes | red-required | ステップ完了証跡（report step closure） |
-| tc-002 | S01 | <behavior> | 否定系（negative） | EC-001 | ... | ... | 沈黙失敗（silent failure） | yes | inspect-only | ステップ完了証跡（report step closure） |
-
-- 証跡レベル（evidence level）:
-  - red-required: 実装前に失敗する新規 test / characterization を固定する。
-  - covered-existing: 既存 test が対象 behavior を検出できる根拠を固定する。
-  - inspect-only: docs / template / config などを inspection、structural assertion、review evidence で閉じる。
-  - manual-required: 自動化できない確認手順、期待結果、記録先を固定する。
-- 詳細化方針:
-  - 件数ではなく、AC、changed contract、failure mode、regression risk、invariant、manual / integration risk から必要な obligation を決める。
-  - private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+| tc-001 | S01 | pending_signal progress display | acceptance | AC-001 | `phase=wait` no-signal state renders `review=pending_signal`, not `review=observing` | wait progress stderr for trigger/resume boundary with no review completion/comment signal | observer state leaks into target review state | yes | red-required | Step Contract Closure / Test Contract Closure |
+| tc-002 | S01 | actionable review progress display | acceptance/regression | AC-002 | current unresolved feedback renders `review=unresolved` plus comments/threads/unresolved counts | wait or terminal progress stderr with unresolved Codex feedback | actionable review target state hidden by pending display | yes | covered-existing | Step Contract Closure / Test Contract Closure |
+| tc-003 | S01 | final JSON authority preservation | regression | AC-003, EC-001, EC-002, EC-003 | `decision`, `decision_fingerprint`, `recommended_next_action`, no-completion and fallback semantics remain unchanged | stdout JSON for timeout, wait_or_resume, review_completion_unknown, fallback issue comment cases | display-only change mutates authoritative decision semantics | yes | covered-existing | Test Contract Closure |
+| tc-004 | S01 | provider/mirror parity | structural | AC-004 | provider-side wait script and dogfooding mirror have equivalent progress display derivation | file inspection / diff of provider and mirror scripts | shipped asset and dogfooding behavior drift | yes | inspect-only | Closure Coverage |
+| tc-005 | S90 | docs impact resolution | docs/spec | AC-003, AC-004 | PR observation skill docs either need no update with rationale or are updated consistently | inspection of provider and mirror `github-pr-observation/SKILL.md` | docs contract stale after progress display change | yes | inspect-only | Docs Impact Resolution |
+| tc-006 | S99 | final handoff readiness | final gate | all AC/EC | QA/code/spec reviewers pass and report records handoff readiness | final reviewer results and report ledgers | execution proceeds with missing quality evidence | yes | inspect-only | Final Quality Gate |
 
 ## レビュー / QA ゲート方針
-- RG1 step review:
-  - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only）
-  - pass 条件: review_status: pass
-- QG1 final QA:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage、missing high-value tests、manual / integration test 要否
-- SG1 final spec review:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / docs 整合
+
+- S01 step review:
+  - reviewer: `code-reviewer`
+  - pass 条件: `review_status: pass`
+  - focus: provider/mirror parity, progress display derivation, final JSON contract preservation, tests.
+- S90 docs/spec review:
+  - reviewer: `spec-reviewer`
+  - pass 条件: `review_status: pass`
+  - focus: docs impact resolution and spec consistency.
+- S99 final QA:
+  - reviewer: `qa-reviewer`
+  - pass 条件: `review_status: pass`
+  - focus: obligation coverage and whether integration/manual tests are needed.
+- S99 final code review:
+  - reviewer: `code-reviewer`
+  - pass 条件: `review_status: pass`
+  - focus: issue-wide integrated diff.
+- S99 final spec review:
+  - reviewer: `spec-reviewer`
+  - pass 条件: `review_status: pass`
+  - focus: requirement/design/plan/report and implementation alignment.
 
 ## 実行ルール（全ステップ共通）
-- 各 implementation step は 1 behavior slice / 1 review scope / 1 commit boundary とする。例外が必要な場合は実装前に plan amendment と fresh re-review を通し、final review / final commit で per-step review / commit を代替しない。
-- `plan.md` には planned requirements、evidence destination、closure 条件だけを書く。observed result は `report.md` に書く。
-- docs-only / inspect-only / manual-required step は code test 前提にせず、代替 evidence path と rationale を implementation 前に固定する。
-- implementation 中に新しい仕様、bug class、外部 contract risk、未計画の closure が見つかった場合は、report 記録だけで足りるか、plan amendment と re-review が必要かを判断する。
+
+- Observed evidence は `report.md` に記録し、`plan.md` へ実行結果を追記しない。
+- `review=pending_signal` の exact derivation を変える必要が出た場合は、実装前に plan amendment と fresh spec review を行う。
+- Final JSON decision semantics に触る必要が出た場合は、今回の scope を超えるため実装を停止し、requirement/design へ戻す。
+- Provider-side source と dogfooding mirror は同じ behavior を保つ。
 
 ## 実装ステップ
 
-### 実装ステップ S01 — <観測可能な振る舞い>
-- 振る舞いの目標（behavior goal）:
-  - ...
+### 実装ステップ S01 — Target review progress display
+
+- 振る舞いの目標:
+  - Wait progress line の `review=` が target Codex review state を表示し、no-signal wait state では `pending_signal` を表示する。
 - design 参照:
-  - ...
+  - `pending_signal 導出方針`
+  - `インターフェース契約`
+  - `ディレクトリ / ファイル変更計画`
 - 依存:
-  - ...
+  - approved `requirement.md`
+  - approved `design.md`
 - unblock:
-  - ...
+  - S90, S99
 - 対象ファイル:
-  - ...
-- 計画済み契約（planned contract）:
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `tests/unit/infra/test_init_update.py`
+  - `spec-dock/active/issue/report.md`
+- 計画済み契約:
   - scope:
-    - 実装・文書化する範囲:
-  - テスト義務（test obligation）:
-    - closure id:
-      - tc-001
+    - `progress_line(...)` の review display derivation。
+    - Focused tests for pending signal, unresolved counts, decision preservation, line budget.
+  - テスト義務:
+    - closure id: tc-001, tc-002, tc-003, tc-004
     - coverage rationale:
-      - AC / changed contract / failure mode / regression risk / invariant / manual risk から必要性を書く:
+      - AC-001 は existing `review=observing` expectation を red target にできる。
+      - AC-002 / EC-004 は existing progress/count/line-budget tests で regression sensitivity を持つ。
+      - AC-003 / EC-001 / EC-002 / EC-003 は existing no-completion / fallback JSON tests で regression sensitivity を持つ。
+      - AC-004 は provider/mirror inspection で閉じる。
   - Red / 代替証跡の要件:
-    - red-required / covered-existing:
-      - 実装前に確認する failing test、characterization、または既存 test sensitivity:
-    - docs-only / inspect-only / manual-required:
-      - code test を置かない理由:
-      - 代替 evidence path:
-      - manual 手順と期待結果:
-  - 実装範囲（implementation scope）:
+    - red-required:
+      - Existing `review=observing` assertion を `review=pending_signal` に変更し、実装前に失敗することを確認する。
+    - covered-existing:
+      - `test_issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review`
+      - `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age`
+      - `test_issue_187_s204_wait_does_not_promote_unknown_before_ci_passed_age`
+      - `test_issue_187_s204_wait_resume_preserves_prior_ci_passed_age`
+      - `test_issue_187_s204_wait_promotes_unknown_after_trigger_and_ci_ages`
+      - `test_issue_187_s204_wait_late_unresolved_review_overrides_unknown_candidate`
+      - `test_issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback`
+      - `test_issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence`
+      - `test_issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget`
+    - inspect-only:
+      - Provider and mirror wait script display derivation match.
+  - 実装範囲:
     - allowed paths:
-      - ...
+      - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+      - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+      - `tests/unit/infra/test_init_update.py`
+      - `spec-dock/active/issue/report.md`
     - forbidden changes:
-      - ...
+      - `trigger_codex_review.sh`, `fetch_pr_observation_snapshot.sh`, `pr_observation_snapshot.py`, `pr_review_snapshot.py`
+      - GitHub auth / token permission behavior
+      - final JSON decision schema / fingerprint semantics
+      - unrelated tests or broad refactors
   - Green 検証:
-    - command / inspection / manual evidence:
-      - ...
+    - Focused red/green command:
+      - `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"`
+    - Structural:
+      - `rg -n "review=observing|pending_signal|render_review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py .agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py tests/unit/infra/test_init_update.py`
   - Refactor / cleanup ガードレール:
     - 目的:
+      - Display derivation stays readable and local.
     - 禁止する広がり:
+      - Classification / decision rewrite, trigger flow changes, broad fixture rewrites.
   - closure 証跡要件:
-    - Step Contract Closure:
-    - Test Contract Closure:
-    - Closure Coverage:
+    - Step Contract Closure: S01 closes tc-001 through tc-004.
+    - Test Contract Closure: red evidence, green focused pytest, structural inspection.
+    - Closure Coverage: AC/EC mapping remains complete.
   - report 証跡の記録先:
-    - `report.md` の対象 section / ledger:
-  - amendment trigger（plan amendment が必要になる契機）:
-    - plan amendment と re-review が必要になる発見:
+    - `report.md` TDD evidence
+    - Step Contract Closure
+    - Test Contract Closure
+    - Closure Coverage
+    - Reviewer Gate Status
+    - Step Commit Gate
+  - amendment trigger:
+    - Need to change final JSON decision semantics.
+    - Need to add observer/wait field.
+    - Need to change trigger / resume / snapshot behavior.
+    - `pending_signal` cannot be derived without weakening AC-001 or AC-003.
 
 #### 委任契約（delegation contract）
-- 委任ロール（delegated role）:
-  - dev-coder / doc-writer / other named worker / N/A
-  - N/A は read-only / approved-no-op step、または `workflow_issue.md` に従う事前承認済み Parent Implementation Exception だけに使う。file mutation を伴う通常の implementation success path として使わない。
-- 入力 docs:
-  - `requirement.md`
-  - `design.md`
-  - `plan.md`
-  - workflow / authoring docs:
-  - current target files:
-- 許可 paths:
-  - ...
-- 禁止 changes:
-  - ...
-- 受け入れ条件:
-  - closure id / step close condition:
-- 必須 tests または docs-only verification:
-  - targeted command / inspection / docs diff / manual evidence:
+
+- delegated role:
+  - `dev-coder`
+- input docs:
+  - `spec-dock/active/issue/requirement.md`
+  - `spec-dock/active/issue/design.md`
+  - `spec-dock/active/issue/plan.md`
+  - `spec-dock/docs/workflow_issue.md`
+  - `spec-dock/docs/phase_plan_issue.md`
+  - `spec-dock/docs/authoring/issue-plan.md`
+  - target files listed above
+- allowed paths:
+  - Same as S01 implementation scope.
+- forbidden changes:
+  - Same as S01 forbidden changes.
+- acceptance criteria:
+  - `tc-001` through `tc-004` pass or are closed with planned inspection evidence.
+- required tests or docs-only verification:
+  - Focused pytest command listed in Green 検証.
+  - Provider/mirror structural `rg` inspection.
 - reviewer focus:
-  - code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only docs/spec alignment）
-- 必須出力（output required）:
-  - changed files:
-  - verification result:
-  - report evidence to update:
-  - unresolved risks:
-- 停止条件（stop conditions）:
-  - input docs conflict / path outside allowed scope / verification cannot run / acceptance cannot be met:
+  - `code-reviewer` for runtime/tests/scaffold behavior.
+- output required:
+  - changed files
+  - red evidence result
+  - green verification result
+  - provider/mirror parity note
+  - unresolved risks
+  - `Ledger Note` or `No material implementation decisions beyond the approved plan.`
+- stop conditions:
+  - Requirement/design conflict.
+  - Need to change forbidden paths.
+  - Focused tests cannot run.
+  - `pending_signal` derivation would alter final JSON decision semantics.
 
 #### 具体テストケース一覧
 
-> この欄は full test inventory ではありません。step-local obligation と concrete red / characterization / inspect / manual seeds を、実装前に固定するための欄です。
-
-- `tc-s01-001` acceptance: <短い説明>
-  - 前提: ...
-  - 操作: ...
-  - 期待結果: ...
-  - 失敗検出: ...
-  - 検証方法: ...
+- `tc-s01-001` acceptance: no-signal wait progress uses pending_signal
+  - 前提: Existing fixture produces wait-phase payload where CI passed, review status is `none` or `pending`, lifecycle is pending/none, and no Codex completion/comment signal exists.
+  - 操作: Update the existing `test_issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint` expectation before implementation.
+  - 期待結果: Pre-implementation run fails because stderr still contains `review=observing`; post-implementation run passes with `review=pending_signal`.
+  - 失敗検出: Observer state remains displayed in `review=`.
+  - 検証方法: Focused `uv run pytest ... -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint"`.
   - 関連 closure id: tc-001
-
-- `tc-s01-002` inspect-only / manual-required: <短い説明>
-  - テスト不要理由: <自動テスト不要の理由>
-  - 代替検証方法: <確認手順>
-  - 期待結果: <期待される状態>
-  - 記録先: <証跡の保存先>
+- `tc-s01-002` regression: unresolved feedback keeps unresolved target state and counts
+  - 前提: Existing issue 174 fixture contains current unresolved Codex review feedback with review comments and threads.
+  - 操作: Run `test_issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review`.
+  - 期待結果: stderr contains `review=unresolved`, `comments=2`, `threads=2`, and `unresolved=2`.
+  - 失敗検出: `pending_signal` masks actionable unresolved state or drops counts.
+  - 検証方法: Focused pytest including issue 174 human-gate review test.
   - 関連 closure id: tc-002
+- `tc-s01-003` regression: final JSON no-completion and fallback semantics stay unchanged
+  - 前提: Existing issue 187 no-completion tests cover latency guards and `review_completion_unknown`; existing issue 176 / issue 187 fallback tests cover fallback issue comment `human_gate` and `wait_or_resume`.
+  - 操作: Run focused issue 187 S204 tests plus `test_issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback` and `test_issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence`.
+  - 期待結果: Existing stdout JSON assertions continue to pass.
+  - 失敗検出: Display-only change mutates `decision`, `decision_fingerprint`, `recommended_next_action`, or `observation_complete`.
+  - 検証方法: Focused pytest including `issue_187_s204_wait`, `issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback`, and `issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence`.
+  - 関連 closure id: tc-003
+- `tc-s01-004` structural: provider and mirror use equivalent display derivation
+  - 前提: Provider-side source and dogfooding mirror both contain `pr_observation_wait.py`.
+  - 操作: Inspect both files for `pending_signal` and absence of `render_review = "observing"`.
+  - 期待結果: Both files contain the same display derivation behavior.
+  - 失敗検出: Shipped asset and local dogfooding behavior diverge.
+  - 検証方法: `rg -n "review=observing|pending_signal|render_review" ...`.
+  - 関連 closure id: tc-004
 
 #### ステップ完了契約（step closure contract）
+
 - closure id:
   - tc-001
+  - tc-002
+  - tc-003
+  - tc-004
 - close 条件:
-  - ...
-- 検証 evidence:
-  - targeted command / inspection / manual evidence:
+  - Red evidence confirms existing `review=observing` expectation fails after test update and before implementation, unless implementation and test are intentionally batched with documented characterization evidence.
+  - Focused pytest passes after implementation.
+  - Structural inspection confirms provider/mirror parity.
+  - `code-reviewer` returns `review_status: pass`.
+  - Step commit is created and post-commit worktree is clean except intentional next-step artifacts.
 - report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-  - Closure Delta:
+  - TDD evidence, Step Contract Closure, Test Contract Closure, Closure Coverage, Reviewer Gate Status, Step Commit Gate.
 - 残リスク:
-  - ...
+  - Live GitHub/Codex timing behavior still depends on external service signals; this issue fixes local display contract and regression coverage.
 
 #### ステップゲート（step gate）
+
 - step reviewer gate:
-  - reviewer:
-  - review 範囲:
-  - pass 条件: review_status: pass
-  - re-review rule: 指摘を修正し pass まで再実行
+  - reviewer: `code-reviewer`
+  - review 範囲: S01 changed runtime/test/mirror files and report evidence.
+  - pass 条件: `review_status: pass`
+  - re-review rule: findings are fixed and fresh `code-reviewer` pass is obtained before commit.
 - commit / no-op gate:
-  - closure 状態: committed / approved-no-op
-  - commit 範囲:
-  - no-op の場合の確認対象、差分なし確認コマンド、read-only evidence:
+  - closure 状態: `committed`
+  - commit 範囲: S01 implementation, tests, mirror parity, and S01 report evidence only.
+  - no-op: not allowed for S01 because behavior change is required.
 
-### 実装ステップ Sxx — <次に観測可能な振る舞い>
-- S01 の subsections を複製して記入する。
-- `planned contract`、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`step gate` がない implementation step は implementation-ready ではない。
+### ドキュメント影響の解消ステップ S90 — Docs impact resolution
 
-### ドキュメント影響の解消ステップ S90（docs impact resolution / docs refresh）
 - 対象:
-  - docs / templates / README / workflow / skill / migration notes / none
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md`
+  - `.agents/skills/github-pr-observation/SKILL.md`
+  - `spec-dock/active/issue/report.md`
 - 対応:
-  - ...
+  - Inspect whether the skill docs already state enough: progress is non-authoritative, bounded key/value summary, final JSON authoritative, no manual `@codex review`.
+  - If docs do not mention a conflicting `review=observing` contract, record no-update rationale.
+  - If S01 changes public progress vocabulary enough to require docs, update provider-side skill doc and mirror consistently.
 - doc update owner:
-  - doc-writer when updates are required
+  - `doc-writer` if docs update is required.
+  - `N/A` approved-no-op if inspection proves no docs update is required.
+- verification:
+  - `rg -n "observing|pending_signal|progress lines|review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md .agents/skills/github-pr-observation/SKILL.md`
 - spec/doc review:
-  - reviewer: spec-reviewer
-  - pass 条件: docs が requirement / design / plan と整合し、未解決の必須 docs 影響が残っていない
+  - reviewer: `spec-reviewer`
+  - pass 条件: docs impact evidence aligns with requirement/design/plan and no stale public docs contract remains.
 
-### 最終品質ゲートステップ S99（final quality gate）
+### 最終品質ゲートステップ S99 — Final quality gate
+
 - branch diff 範囲:
-  - ...
+  - All issue branch changes since base, including specs, discussion evidence, implementation, tests, mirror updates, and report evidence.
 - 必須 validation:
-  - ...
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync --github`
+  - Focused pytest from S01.
 - final QA gate:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage と integration test 要否
-  - pass 条件: reviewer pass
-- final code review ゲート:
-  - reviewer: code-reviewer
-  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性
-  - pass 条件: review_status: pass
-- final spec review ゲート:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合
-  - pass 条件: reviewer pass
+  - reviewer: `qa-reviewer`
+  - 範囲: Issue obligation coverage, missing high-value tests, manual/integration need.
+  - pass 条件: `review_status: pass`
+- final code review gate:
+  - reviewer: `code-reviewer`
+  - 範囲: issue-wide integrated runtime/test/mirror diff.
+  - pass 条件: `review_status: pass`
+- final spec review gate:
+  - reviewer: `spec-reviewer`
+  - 範囲: requirement / design / plan / report / implementation / tests / docs alignment.
+  - pass 条件: `review_status: pass`
 - final commit gate:
   - commit 範囲:
+    - Final report ledger and any final evidence-only adjustments.
   - final report ledger:
+    - All closure ids tc-001 through tc-006 closed.
+    - S01 committed, S90 resolved, S99 reviews passed.
   - post-commit external evidence destination:
-
-## 未確定事項
-- Q-001:
-  - 質問:
-  - 推奨案:
-  - 影響範囲:
+    - Final response / PR body / issue comment as applicable.
 
 ## 最終完了条件
+
 - AC/EC 達成:
-  - ...
+  - AC-001 through AC-004 and EC-001 through EC-004 have closure evidence.
 - docs 影響解決:
-  - ...
+  - S90 records docs update or no-update rationale with spec-reviewer pass.
 - 全 implementation step 完了:
-  - committed / approved-no-op:
+  - S01 committed.
 - final quality gate pass:
-  - qa-reviewer:
-  - issue-wide code-reviewer:
-  - spec-reviewer:
+  - qa-reviewer pass.
+  - issue-wide code-reviewer pass.
+  - spec-reviewer pass.
 - final commit 完了:
-  - ...
+  - Final report ledger committed or external final evidence records final commit boundary.
 - 必須 closure id 完了:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
+  - tc-001 through tc-006 closed in report Step Contract Closure / Test Contract Closure / Closure Coverage.
 - final clean state:
-  - no unintended staged / unstaged changes:
+  - no unintended staged / unstaged changes.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -316,4 +316,52 @@ Notes:
 - S01: committed in `b476e6f3`.
 - S90: docs impact resolved as approved-no-op in `488aaf9c`.
 - S99: validation commands passed after amendment commit `2b4f6b48`; final QA/code/spec re-review passed.
-- PR delivery / merge preparation / issue finish: pending final report commit, PR delivery gate, merge preparation gate, and issue finish.
+- PR delivery: PR #216 created for branch `iss-00214-pr-observation-review-target-state`.
+- PR repair: initial observation on `f3b95994d94923c3e700e4fc54e52f5e70ee8c92` found `Provider CI / provider-tests` failure caused by the checked-in dogfooding metadata snapshot missing `iss-00214.../.meta.json`; repaired in `397900ef`.
+- Merge preparation / issue finish: pending human gate resolution for low-confidence fallback Codex review observation.
+
+## PR Delivery / Merge Preparation Evidence
+
+### PR Delivery Gate
+
+| Item | Evidence |
+|---|---|
+| PR URL | https://github.com/chemitaro/spec-dock/pull/216 |
+| Base / head | `main` / `iss-00214-pr-observation-review-target-state` |
+| Latest head SHA | `397900ef60152ef5bb00c0d5012014b358fa02c2` |
+| Draft state | ready PR (`isDraft=false`) |
+| Merge state | `CLEAN` via `gh pr view 216 --repo chemitaro/spec-dock --json mergeStateStatus` |
+
+### PR Repair Evidence
+
+| Item | Evidence |
+|---|---|
+| Failed observation | `normalized_status=failed`, `recommended_next_action=fix_ci`, head matched `f3b95994d94923c3e700e4fc54e52f5e70ee8c92` |
+| Failed check | `Provider CI / provider-tests`, GitHub Actions run `27820892612`, job `82333463397` |
+| Root cause | `tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` reported the checked-in dogfooding `.meta.json` path set had one extra committed path: `iss-00214-pr-observation-review-target-state/.meta.json` |
+| Repair | Added the `iss-00214.../.meta.json` path to `_CHECKED_IN_DOGFOODING_META_JSON_PATHS` and `_CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH` with `[]`; recorded PR repair batch/unit discussions |
+| Local repair validation | `uv run pytest tests/unit/infra/test_init_update.py::TestInitUpdate::test_checked_in_dogfooding_initiatives_do_not_ship_legacy_deps_json` passed: `1 passed in 0.08s`; `./spec-dock/scripts/spec-dock validate` passed: `spec-dock: ok (validate) nodes=134` |
+
+### Latest PR Observation
+
+| Item | Evidence |
+|---|---|
+| Observation command | `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 216 --head-sha 397900ef60152ef5bb00c0d5012014b358fa02c2 --timeout-seconds 900 --poll-interval-seconds 30 --quiet-seconds 30 --same-fingerprint-count 2 --progress stderr-summary` |
+| Resume command | `./.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh --repo chemitaro/spec-dock --pr 216 --head-sha 397900ef60152ef5bb00c0d5012014b358fa02c2 --trigger-mode resume --trigger-comment-id 4750906881 --trigger-created-at 2026-06-19T10:59:59Z --timeout-seconds 600 --poll-interval-seconds 30 --quiet-seconds 30 --same-fingerprint-count 2 --progress stderr-summary` |
+| Trigger comment | `4750906881`, created at `2026-06-19T10:59:59Z` |
+| Codex review signal | Issue comment `4750944056`, created at `2026-06-19T11:05:37Z`, says no major issues for reviewed commit `397900ef60`; observation classified this as low-confidence fallback issue comment |
+| CI result | `CI / validate` and `Provider CI / provider-tests` all passed for head `397900ef60152ef5bb00c0d5012014b358fa02c2`; `gh pr checks 216 --repo chemitaro/spec-dock` showed 4 passing checks |
+| Review threads | `threads.total=0`, `threads.unresolved=0` |
+| Observation result | `normalized_status=human_gate`, `recommended_next_action=wait_or_resume`, `observation_complete=false`, reason `fallback_issue_comment_low_confidence` |
+
+### Merge-Prepared Gate
+
+| Condition | Status | Evidence / Rationale |
+|---|---|---|
+| PR open and ready | pass | PR #216 is `OPEN` and `isDraft=false` |
+| Latest head matches expected | pass | Observation and `gh pr view` both report `397900ef60152ef5bb00c0d5012014b358fa02c2` |
+| Required / visible checks pass | pass | `validate` and `provider-tests` are all success |
+| Merge conflict absent | pass | `mergeStateStatus=CLEAN` |
+| Blocking review feedback absent | pass-with-limitation | Codex fallback comment says no major issues and no review threads exist; observation classifies fallback comment as low confidence |
+| Observation complete | blocked | `observation_complete=false` because the review completion signal is a low-confidence fallback issue comment |
+| Merge-prepared decision | no | Human gate remains; issue finish is intentionally deferred |

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -21,6 +21,7 @@ ID: "iss-00214"
 | D-001 | resolved | interpretation | user interview | `review=` が観測者側の作業状態を表示していた | `review=observing`; `review=pending`; `review=pending_signal` | no-signal wait state は `review=pending_signal` とし、`review=` は観測対象の Codex review state を表示する | ユーザー回答で `review=pending_signal` が明示され、観測する自分ではなく観測対象の状態を表示すべきとされた | applied | `discussions/20260619t064502z-interview-review-pending-state-naming.md`; `requirement.md`; `design.md`; `plan.md` | なし |
 | D-002 | resolved | scope | orchestrator | `observer=` / `wait=` 追加案の扱い | 今回追加する; 今回は追加しない | この issue では `review=` の target-state 表示だけに限定し、新 field は追加しない | 要件と設計で final JSON / progress line 以外の contract 変更を scope 外に固定した | applied | `requirement.md`; `design.md`; `plan.md` | 必要なら別 issue |
 | D-003 | resolved | test-strategy | spec-reviewer | EC-003 fallback issue comment semantics の検証が条件付きだった | 条件付きのまま; 必須 focused pytest に含める | fallback issue comment regression を必須検証に含める | plan review P1 finding により closure が実装者判断に残ると判定された | applied | `plan.md`; spec-reviewer Avicenna finding; spec-reviewer Epicurus pass | なし |
+| D-004 | resolved | test-strategy | dev-coder | S01 Red が計画した `review=` assertion の前に timeout / fixture 境界で失敗した | 実装を止める; timeout だけ延ばす; S04 fixture を planned payload 観測用に修理する | S04 fixture repair を採用し、Red/Green が計画済みの wait progress behavior を観測できるようにする | 修理は allowed test file に限定され、product final JSON semantics や trigger / snapshot runtime を変更しない。修理後の Red は `review=observing` に対して期待どおり失敗し、Green は focused regression set で pass した | applied | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer が fixture repair を確認する |
 
 ## 証跡採用台帳（Evidence Adoption Ledger）
 
@@ -31,6 +32,7 @@ ID: "iss-00214"
 | EAL-003 | adopted | reviewer | requirement.md | AC-002 の `など` が曖昧という requirement review P2 を受け、`review=unresolved` の exact expectation へ修正した | spec-reviewer Carson finding; spec-reviewer Lorentz pass | なし |
 | EAL-004 | adopted | reviewer | design.md | design は localized/trivial として system-architect draft を省略可能、かつ仕様整合は pass と判定された | spec-reviewer Ohm pass | なし |
 | EAL-005 | adopted | reviewer | plan.md | EC-003 fallback verification を必須化する P1 を受け、focused command と concrete test case に既存 fallback tests を追加した | spec-reviewer Avicenna fail; spec-reviewer Epicurus pass | なし |
+| EAL-006 | adopted | worker | report.md / tests | dev-coder の Ledger Note を親が確認し、S04 fixture repair を evidence-path repair として採用した | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer gate |
 
 ## 目的整合台帳（Objective Alignment Ledger）
 
@@ -61,8 +63,10 @@ ID: "iss-00214"
 
 ## 実装サマリー
 
-- 未実装。今回の作業範囲は Issue Planning workflow に沿った仕様書作成と authoring gate の通過まで。
-- 実装対象は S01 `Target review progress display`、S90 `Docs impact resolution`、S99 `Final quality gate` として `plan.md` に固定した。
+- S01 `Target review progress display` を実装済み。
+- `progress_line(...)` の display-only derivation を変更し、trigger-boundary no-signal wait state は `review=pending_signal`、actionable / explicit review target state は既存 status を表示する。
+- Provider-side source と dogfooding mirror の同等変更を structural inspection で確認した。
+- S90 / S99、step reviewer gate、Step Commit Gate は未実施。Step Commit Gate は parent commit 待ち。
 
 ## 実装記録（セッションログ）
 
@@ -109,6 +113,109 @@ spec-dock: ok (issue checkout) branch=iss-00214-pr-observation-review-target-sta
 - `spec-dock/active/issue/report.md` - planning evidence と execution handoff readiness を記録
 - `spec-dock/active/issue/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md` - source-grounded clarification research
 - `spec-dock/active/issue/discussions/20260619t064502z-interview-review-pending-state-naming.md` - user interview and adoption record
+
+### セッションログ（2026-06-19 16:48 JST）
+
+#### 対象
+
+- Step: S01 `Target review progress display`
+- AC/EC: AC-001, AC-002, AC-003, AC-004, EC-001, EC-002, EC-003, EC-004
+- Closure ids: tc-001, tc-002, tc-003, tc-004
+
+#### Implementation Delegation Gate
+
+| Step | Decision | Required reason | Delegated role | Scope | Source of truth | Allowed changes | Forbidden changes | Required verification | Stop conditions | Output required | Result |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| S01 | delegated | runtime / tests / shipped scaffold behavior across provider and dogfooding mirror | dev-coder | `progress_line(...)` display derivation, focused regression test, provider/mirror inspection | `requirement.md`, `design.md`, `plan.md` S01, `workflow_issue.md`, existing tests | S01 allowed paths only | trigger helper, snapshot collectors, GitHub auth/token behavior, final JSON schema/fingerprint semantics, unrelated tests/refactors | required Red, focused Green pytest, structural `rg` inspection | forbidden path required; final JSON semantics change required; trigger/resume/snapshot behavior change required; focused tests cannot run | changed files, Red/Green/structural result, risks, Ledger Note or no-material statement | delegated worker completed bounded S01 implementation; parent integration pending reviewer/commit |
+
+#### Red evidence
+
+| Command | Result | Evidence |
+|---|---|---|
+| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint"` | failed as expected after evidence-path repair | `AssertionError`: expected `phase=wait ci=passed review=pending_signal`; observed stderr contained `phase=wait ci=passed review=observing` |
+
+Notes:
+
+- Initial Red attempt failed for the wrong reason before reaching the display assertion: the S04 snapshot fixture could timeout before emitting the planned payload, and the existing `payload["codex_review"]` assertion was not valid for the `review_status="none"` case.
+- Evidence-path repair stayed inside `tests/unit/infra/test_init_update.py`: the S04 snapshot fixture now returns `S04_WAIT_PAYLOAD` directly, the timeout budget allows a snapshot poll, and the `codex_review.lifecycle.status` assertion remains scoped to the `pending` case that carries that lifecycle contract.
+
+#### Implementation evidence
+
+| File | Change |
+|---|---|
+| `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py` | Changed wait progress display derivation so no-signal `none` / `pending` / `unknown` review states render `pending_signal` only when there is no actionable feedback and no completion signal. |
+| `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py` | Mirrored the provider-side display derivation. |
+| `tests/unit/infra/test_init_update.py` | Updated the S01 Red expectation to `review=pending_signal` and repaired the S04 fixture so the test observes the intended wait payload. |
+| `spec-dock/active/issue/report.md` | Recorded S01 execution evidence. |
+
+#### Green verification
+
+| Command | Result | Evidence |
+|---|---|---|
+| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | passed | `10 passed, 429 deselected in 27.90s` |
+
+#### Structural inspection
+
+| Command | Result | Evidence |
+|---|---|---|
+| `rg -n "review=observing|pending_signal|render_review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py .agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py tests/unit/infra/test_init_update.py` | passed | No `review=observing` matches. Provider and mirror each contain `render_review = review_status`, `render_review = "pending_signal"`, and `fields.append(("review", str(render_review), False))`; the focused test expects `review=pending_signal`. |
+
+#### Step Contract Closure
+
+| Step | Closure id | Close condition | Evidence | Result |
+|---|---|---|---|---|
+| S01 | tc-001 | no-signal wait progress renders `review=pending_signal` instead of `review=observing` | Red failure on `review=observing`; Green focused pytest pass | pass |
+| S01 | tc-002 | actionable unresolved feedback still renders `review=unresolved` with counts | Focused Green includes `test_issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review` | pass |
+| S01 | tc-003 | final JSON decision / fingerprint / next action / no-completion / fallback semantics remain unchanged | Focused Green includes issue 187 S204 and fallback regression tests | pass |
+| S01 | tc-004 | provider and mirror display derivation match | Structural `rg` inspection for provider and mirror | pass |
+
+#### Test Contract Closure
+
+| Closure id | Step | Evidence level | Pre-implementation evidence | Verification command | Result |
+|---|---|---|---|---|---|
+| tc-001 | S01 | red-required | Red failed because stderr still rendered `review=observing` after test expectation changed to `review=pending_signal` | focused Green pytest command | pass |
+| tc-002 | S01 | covered-existing | Existing issue 174 test covers unresolved review display and counts | focused Green pytest command | pass |
+| tc-003 | S01 | covered-existing | Existing issue 187 / issue 176 tests cover no-completion, wait_or_resume, fallback issue comment semantics | focused Green pytest command | pass |
+| tc-004 | S01 | inspect-only | Provider and mirror target files inspected with planned `rg` | structural `rg` command | pass |
+
+#### Closure Coverage
+
+| Required closure id | AC/EC covered | Verification evidence | Result |
+|---|---|---|---|
+| tc-001 | AC-001, EC-001 | Red/Green focused test for pending signal wait progress | covered |
+| tc-002 | AC-002 | Focused issue 174 unresolved review regression | covered |
+| tc-003 | AC-003, EC-001, EC-002, EC-003, EC-004 | Focused issue 174 / 176 / 187 regression set | covered |
+| tc-004 | AC-004 | Provider/mirror structural inspection | covered |
+
+#### Worker evidence draft
+
+- Worker summary: implemented S01 display-only change in provider and mirror wait scripts; repaired the focused S04 test fixture so Red/Green observe the planned wait payload; final JSON decision path was not edited.
+- Changed files:
+  - `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`
+  - `tests/unit/infra/test_init_update.py`
+  - `spec-dock/active/issue/report.md`
+- Verification result: focused Green command passed with `10 passed, 429 deselected`; structural inspection found no `review=observing` and matching provider/mirror `pending_signal` display derivation.
+- Unresolved risks: per-step `code-reviewer` pass, Step Commit Gate, S90 docs impact resolution, and S99 final gates remain pending outside this S01 worker run.
+- Worker ledger note: material evidence-path repair was required because the initial Red failed for the wrong reason. Parent disposition: adopted in D-004 / EAL-006, pending code-reviewer confirmation.
+
+#### Reviewer Gate Status
+
+| ステップ | ゲート名 | レビュアーロール | 鮮度 | 状態 | リスク受容 | 昇格 / 完了判断 | メモ |
+|---|---|---|---|---|---|---|---|
+| S01 | step code review | code-reviewer | fresh | passed | N/A | proceed to Step Commit Gate | No findings; provider/mirror parity, fixture repair, and S01 closure evidence are consistent |
+
+#### Step Commit Gate
+
+| Step | Review scope | Step reviewer verdict | Commit scope | Closure state | Commit evidence | Post-commit clean check |
+|---|---|---|---|---|---|---|
+| S01 | provider/mirror wait display derivation, focused tests, report evidence | code-reviewer pass | S01 files only | tc-001..tc-004 pass evidence recorded; reviewer passed | pending parent commit | pending parent commit |
+
+#### Closure Delta
+
+| Step | Added | Removed | Changed | Re-review needed |
+|---|---|---|---|---|
+| S01 | none | none | Evidence-path repair in existing S04 focused test fixture; no closure id changed | code-reviewer review pending |
 
 ## 最終品質ゲート（Final Quality Gate）
 

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -172,6 +172,8 @@ Notes:
 | S01 | tc-002 | actionable unresolved feedback still renders `review=unresolved` with counts | Focused Green includes `test_issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review` | pass |
 | S01 | tc-003 | final JSON decision / fingerprint / next action / no-completion / fallback semantics remain unchanged | Focused Green includes issue 187 S204 and fallback regression tests | pass |
 | S01 | tc-004 | provider and mirror display derivation match | Structural `rg` inspection for provider and mirror | pass |
+| S90 | tc-005 | docs impact is resolved as update-needed or no-update with evidence | PR observation skill docs inspection found no stale `review=observing` contract; S90 spec-reviewer passed approved-no-op | pass |
+| S99 | tc-006 | final handoff readiness is recorded after final QA/code/spec reviewers pass | S99 validation passed after amendment commit `2b4f6b48`; final QA, issue-wide code review, and final spec review all passed | pass |
 
 #### Test Contract Closure
 
@@ -181,6 +183,8 @@ Notes:
 | tc-002 | S01 | covered-existing | Existing issue 174 test covers unresolved review display and counts | focused Green pytest command | pass |
 | tc-003 | S01 | covered-existing | Existing issue 187 / issue 176 tests cover no-completion, wait_or_resume, fallback issue comment semantics | focused Green pytest command | pass |
 | tc-004 | S01 | inspect-only | Provider and mirror target files inspected with planned `rg` | structural `rg` command | pass |
+| tc-005 | S90 | inspect-only | Docs inspection found no stale public progress review contract requiring update | S90 docs impact inspection plus spec-reviewer pass | pass |
+| tc-006 | S99 | inspect-only | Final handoff readiness requires final QA/code/spec pass and final report commit | S99 validation commands passed; final QA/code/spec reviewer gates passed | pass |
 
 #### Closure Coverage
 
@@ -190,6 +194,8 @@ Notes:
 | tc-002 | AC-002 | Focused issue 174 unresolved review regression | covered |
 | tc-003 | AC-003, EC-001, EC-002, EC-003, EC-004 | Focused issue 174 / 176 / 187 regression set | covered |
 | tc-004 | AC-004 | Provider/mirror structural inspection | covered |
+| tc-005 | AC-003, AC-004 | S90 docs impact inspection and spec-reviewer pass | covered |
+| tc-006 | all AC/EC | S99 validation passed; final QA/code/spec reviewer gates passed | covered |
 
 #### Worker evidence draft
 
@@ -228,7 +234,7 @@ Notes:
 | Command | Result | Evidence |
 |---|---|---|
 | `./spec-dock/scripts/spec-dock validate` | pass | `spec-dock: ok (validate) nodes=134` |
-| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | pass | `10 passed, 429 deselected in 32.42s` |
+| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | pass | `10 passed, 429 deselected in 30.33s` |
 | `./spec-dock/scripts/spec-dock sync --github` | pass | active unchanged; generated projection wrote successfully and left no git diff |
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
@@ -247,7 +253,7 @@ Notes:
 
 | レビュアー | 範囲 | 統合テスト判断 | 証跡 | 結果 |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | failed, then bounded follow-up implemented | QA P1 found EC-001 latency-guard no-completion progress gap for `review_status="approved"` without trusted completion signal; follow-up committed in `4fc56b26` | pending re-review |
+| qa-reviewer | whole issue obligation coverage | sufficient after bounded follow-up | QA P1 found EC-001 latency-guard no-completion progress gap; follow-up committed in `4fc56b26` and amended in `2b4f6b48`; final QA re-review found no blocking coverage gaps | pass |
 
 #### QA P1 Follow-up Evidence
 
@@ -257,7 +263,7 @@ Notes:
 | Red evidence | After changing `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age` to assert stderr progress, `uv run pytest tests/unit/infra/test_init_update.py -k "test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age"` failed as expected: stderr contained `phase=wait ci=passed review=approved` instead of `review=pending_signal`. |
 | Fix | `progress_line(...)` display-only derivation now treats no-signal `approved` / `passed` legacy review display values as `pending_signal` for wait progress when there is no actionable feedback and no trusted completion signal. Provider and dogfooding mirror were updated equivalently. |
 | Final JSON | No classify / final JSON decision schema / fingerprint code was edited. The focused test still asserts `recommended_next_action == "wait_or_resume"`, `observation_complete is False`, and latency guard remains unsatisfied before trigger age. |
-| Green verification | `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` passed: `10 passed, 429 deselected in 32.42s`. |
+| Green verification | `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` passed: `10 passed, 429 deselected in 30.33s`. |
 | Structural inspection | `rg -n "review=observing|pending_signal|render_review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py .agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py tests/unit/infra/test_init_update.py` found no `review=observing`; provider and mirror both contain matching `render_review` / `pending_signal` derivation. `diff -u` between provider and mirror wait libraries produced no output. |
 | Step Commit Gate | Follow-up committed in `4fc56b26` `fix(pr-observation): no-completion時のreview表示を補強`; post-commit worktree was clean before S99 validation rerun. |
 
@@ -297,17 +303,17 @@ Notes:
 
 | レビュアー | 範囲 | 指摘 / 修正 | 再 review 回数 | 結果 |
 |---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | pending execution | 0 | pending execution |
+| code-reviewer | issue-wide integrated diff | initial final review failed on D-005 spec promotion and `passed` coverage; fixed by `2b4f6b48`; final re-review had no findings | 2 | pass |
 
 ### 最終 spec review ゲート（Final Spec Review Gate）
 
 | レビュアー | 範囲 | 指摘 / 修正 | 再 review 回数 | 結果 |
 |---|---|---|---|---|
-| spec-reviewer | requirement/design/plan/report and implementation alignment | pending execution | 0 | pending execution |
+| spec-reviewer | requirement/design/plan/report and implementation alignment | initial final review required tc-005/tc-006 closure rows and D-005 promotion; fixed in report and `2b4f6b48`; final re-review had no findings | 2 | pass |
 
 ## Execution Status
 
 - S01: committed in `b476e6f3`.
 - S90: docs impact resolved as approved-no-op in `488aaf9c`.
-- S99: validation commands passed after QA P1 follow-up commit `4fc56b26`; final QA/spec re-review is pending.
-- PR delivery / merge preparation / issue finish: pending final gates and final report commit.
+- S99: validation commands passed after amendment commit `2b4f6b48`; final QA/code/spec re-review passed.
+- PR delivery / merge preparation / issue finish: pending final report commit, PR delivery gate, merge preparation gate, and issue finish.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -66,7 +66,9 @@ ID: "iss-00214"
 - S01 `Target review progress display` を実装済み。
 - `progress_line(...)` の display-only derivation を変更し、trigger-boundary no-signal wait state は `review=pending_signal`、actionable / explicit review target state は既存 status を表示する。
 - Provider-side source と dogfooding mirror の同等変更を structural inspection で確認した。
-- S90 / S99、step reviewer gate、Step Commit Gate は未実施。Step Commit Gate は parent commit 待ち。
+- S01 step reviewer gate と Step Commit Gate は完了済み。
+- S90 docs impact は approved-no-op として spec-reviewer pass 済み。
+- S99 final gates は未実施。
 
 ## 実装記録（セッションログ）
 
@@ -209,7 +211,7 @@ Notes:
 
 | Step | Review scope | Step reviewer verdict | Commit scope | Closure state | Commit evidence | Post-commit clean check |
 |---|---|---|---|---|---|---|
-| S01 | provider/mirror wait display derivation, focused tests, report evidence | code-reviewer pass | S01 files only | tc-001..tc-004 pass evidence recorded; reviewer passed | pending parent commit | pending parent commit |
+| S01 | provider/mirror wait display derivation, focused tests, report evidence | code-reviewer pass | S01 files only | committed | `b476e6f3` `fix(pr-observation): progressのreview表示を対象状態に修正` | `git status --short --branch` showed no staged / unstaged changes after S01 commit |
 
 #### Closure Delta
 
@@ -223,7 +225,13 @@ Notes:
 
 | 対象 | 更新要否 | 担当 | 証跡 | 仕様レビュアー結果 |
 |---|---|---|---|---|
-| PR observation skill docs | 未実施 | future S90 | `plan.md` S90 に検査コマンドと更新条件を定義 | pending execution |
+| PR observation skill docs | no | N/A | `rg -n "observing|pending_signal|progress lines|progress line|review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/SKILL.md .agents/skills/github-pr-observation/SKILL.md` confirmed no stale `review=observing` contract; docs describe bounded progress fields and final stdout JSON authority without enumerating review display values | pass |
+
+#### S90 Docs Impact Evidence
+
+- Result: approved-no-op with spec-reviewer pass.
+- Rationale: `github-pr-observation/SKILL.md` describes progress lines as bounded diagnostic key/value summaries and keeps final `stdout` JSON as the authoritative information boundary. It does not document `review=observing` or any conflicting progress review value, so the S01 vocabulary change does not require a docs text update.
+- Provider/mirror docs parity: both provider and dogfooding skill docs have the same relevant matches and no stale `review=observing` contract.
 
 ### 最終 QA ゲート（Final QA Gate）
 

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -3,277 +3,152 @@
 ID: "iss-00214"
 タイトル: "PR Observation Review Target State"
 関連GitHub: ["#214"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-19"
 依存: ["requirement.md", "design.md", "plan.md"]
 親: ["epic-00158", "init-local-00003"]
 ---
 
-# iss-00214 PR Observation Review Target State — 実装報告（観測証跡台帳 / Observed Evidence Ledger）
+# iss-00214 PR Observation Review Target State — 実装報告
 
-> `report.md` は観測証跡台帳（observed evidence ledger）の scaffold です。planned requirements、evidence destination、closure 条件は `plan.md` が持ち、この文書は実際の Red / Green / Refactor evidence、発見された tests、closure delta、reviewer status、commit/no-op evidence を記録する evidence slot です。workflow / compliance authority は skills、docs、accepted ADRs、reviewer gates に置きます。
+この `report.md` は実装前の Issue Planning / Clarification 証跡と、次の Issue Execution へ渡す handoff readiness を記録する。実装結果、Red / Green / Refactor evidence、step commit evidence は実装フェーズで追記する。
 
-## 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger / 必須）
+## 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger）
 
-`report.md` は実装中・文書更新中に発生した material な仕様解釈、判断、plan 逸脱、tradeoff、open question、promotion / follow-up を記録する audit trail でもある。worker の raw note や作業 transcript を貼る場所ではなく、orchestrator が source docs、diff、tests、reviewer output と照合して issue-level の canonical entry に統合する。
-
-Material な判断がない場合もこの section は残し、次を明示する。
-
-- No material interpretation changes.
-- No decision entries.
-
-Ledger entry は次の契約値を使う。
-
-- `Status`: `open` / `resolved` / `superseded`
-- `Type`: `interpretation` / `scope` / `implementation` / `compatibility` / `test-strategy` / `operation` / `deviation` / `follow-up`
-- `Disposition`: `applied` / `rejected` / `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` / `converted_to_followup` / `deferred` / `no_action` / `superseded`
-
-完了時の意味論（completion semantics）:
-- issue completion 前に `Status=open` の entry を残してはならない。
-- `Status=resolved` は `Disposition`、evidence、必要な follow-up を持つ。
-- `Status=superseded` または `Disposition=superseded` は置換先 entry ID を持つ。
-- `Disposition=promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` は昇格先 artifact と evidence を持つ。
-- `Disposition=converted_to_followup` は follow-up issue / discussion / ADR candidate の参照を持つ。
-- `Disposition=deferred` は scope 外である理由、blocking でない根拠、revisit 条件を持つ。
-- `Disposition=no_action` は issue-local な判断で追加対応不要である理由を持つ。将来も効く durable decision を `report.md` だけに閉じ込めてはならない。
-
-Disposition ごとの必須証跡:
-- `applied`: 変更した artifact / 実装証跡と、issue-local 適用で十分な理由。
-- `rejected`: 却下した選択肢、理由、blocking impact が残らない根拠。
-- `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan`: 昇格先 artifact 参照と証跡。
-- `converted_to_followup`: follow-up issue / discussion / ADR candidate 参照と blocking / non-blocking の分類。
-- `deferred`: scope-out 理由、non-blocking の根拠、revisit 条件。
-- `no_action`: 判断が issue-local で durable ではない理由。
-- `superseded`: 置換先 entry ID と置換理由。
-
-| 識別子（ID） | 状態（Status） | 種別（Type） | 起票元（Raised By） | 契機 / 差分（Gap） | 検討した選択肢 | 判断 / 解釈 | 根拠（Rationale） | 処置（Disposition） | 証跡（Evidence） | フォローアップ（Follow-up） |
+| 識別子 | 状態 | 種別 | 起票元 | 契機 / 差分 | 検討した選択肢 | 判断 / 解釈 | 根拠 | 処置 | 証跡 | フォローアップ |
 |---|---|---|---|---|---|---|---|---|---|---|
-| D-001 | 未解決 / 解決済み / 置換済み（open / resolved / superseded） | 解釈 / 範囲 / 実装 / 互換性 / テスト戦略 / 運用 / 逸脱 / フォローアップ（interpretation / scope / implementation / compatibility / test-strategy / operation / deviation / follow-up） | 起票元（orchestrator / reviewer / worker source） | 計画の曖昧さ / 実装制約 / レビュー指摘 / 発見リスク（plan ambiguity / implementation constraint / reviewer finding / discovered risk） | 選択肢 A; 選択肢 B; 対応なし（option A; option B; no action） | ... | ... | 採用 / 却下 / design 昇格 / ADR 昇格 / plan 昇格 / follow-up 化 / 延期 / 対応なし / 置換済み（applied / rejected / promoted_to_design / promoted_to_adr / promoted_to_plan / converted_to_followup / deferred / no_action / superseded） | `path` / コマンド / reviewer 指摘 / discussion（path / command / reviewer finding / discussion） | 対象 artifact / issue / discussion / 置換先 entry / 理由付き対応なし（target artifact / issue / discussion / replacement entry / none with reason） |
+| D-001 | resolved | interpretation | user interview | `review=` が観測者側の作業状態を表示していた | `review=observing`; `review=pending`; `review=pending_signal` | no-signal wait state は `review=pending_signal` とし、`review=` は観測対象の Codex review state を表示する | ユーザー回答で `review=pending_signal` が明示され、観測する自分ではなく観測対象の状態を表示すべきとされた | applied | `discussions/20260619t064502z-interview-review-pending-state-naming.md`; `requirement.md`; `design.md`; `plan.md` | なし |
+| D-002 | resolved | scope | orchestrator | `observer=` / `wait=` 追加案の扱い | 今回追加する; 今回は追加しない | この issue では `review=` の target-state 表示だけに限定し、新 field は追加しない | 要件と設計で final JSON / progress line 以外の contract 変更を scope 外に固定した | applied | `requirement.md`; `design.md`; `plan.md` | 必要なら別 issue |
+| D-003 | resolved | test-strategy | spec-reviewer | EC-003 fallback issue comment semantics の検証が条件付きだった | 条件付きのまま; 必須 focused pytest に含める | fallback issue comment regression を必須検証に含める | plan review P1 finding により closure が実装者判断に残ると判定された | applied | `plan.md`; spec-reviewer Avicenna finding; spec-reviewer Epicurus pass | なし |
 
-## 証跡採用台帳（Evidence Adoption Ledger / 必須）
+## 証跡採用台帳（Evidence Adoption Ledger）
 
-Delegated draft、worker note、research、reviewer finding、discussion、command output を canonical artifact や実装判断へ取り込む場合、この台帳に採用判断を記録する。raw transcript ではなく、orchestrator が検証した採否・理由・証跡・次アクションだけを記録する。
-
-- `adoption_status`: `adopted` / `partially_adopted` / `rejected` / `deferred` / `stale` / `blocked`
-- `blocked` または `stale` の unresolved entry は promotion / implementation start / issue ready / issue finish / phase completion を止める。
-- `deferred` は blocking でない根拠と revisit 条件を持つ場合だけ完了時に残せる。
-- Evidence Adoption Ledger なしで delegated evidence の採用を主張してはならない。
-- Evidence Adoption Ledger fields: ID, adoption_status, source, source_role, claim, target_artifact, target_section, rationale, evidence_strength, evidence_path, adopter, reviewer, blocking, next_action.
-
-| 識別子（ID） | 採用状態（adoption_status） | 出所（source） | 対象（target） | 判断理由（rationale） | 証跡（evidence） | 次アクション（next_action） |
+| 識別子 | 採用状態 | 出所 | 対象 | 判断理由 | 証跡 | 次アクション |
 |---|---|---|---|---|---|---|
-| EAL-001 | 採用（`adopted`） / 部分採用（`partially_adopted`） / 棄却（`rejected`） / 延期（`deferred`） / stale（`stale`） / blocked（`blocked`） | サブエージェント（`sub-agent`） / レビュアー（`reviewer`） / 議論（`discussion`） / コマンド（`command`） / 調査（`research`） | 成果物（`artifact`） / Issue（`issue`） / フォローアップ（`follow-up`） | ... | `path` / コマンド / レビュアー指摘 | なし / フォローアップ（`follow-up`） / 再レビュー（`re-review`） / 再訪条件（`revisit condition`） |
+| EAL-001 | adopted | research | requirement/design/plan | 現行実装が wait 中に `review=observing` を強制し、既存テストもそれを期待していることを確認した | `discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md` | 実装フェーズで S01 の red target として使う |
+| EAL-002 | adopted | discussion | requirement/design/plan | ユーザーが no-signal wait state の表示名として `review=pending_signal` を承認した | `discussions/20260619t064502z-interview-review-pending-state-naming.md` | 実装フェーズで exact string として守る |
+| EAL-003 | adopted | reviewer | requirement.md | AC-002 の `など` が曖昧という requirement review P2 を受け、`review=unresolved` の exact expectation へ修正した | spec-reviewer Carson finding; spec-reviewer Lorentz pass | なし |
+| EAL-004 | adopted | reviewer | design.md | design は localized/trivial として system-architect draft を省略可能、かつ仕様整合は pass と判定された | spec-reviewer Ohm pass | なし |
+| EAL-005 | adopted | reviewer | plan.md | EC-003 fallback verification を必須化する P1 を受け、focused command と concrete test case に既存 fallback tests を追加した | spec-reviewer Avicenna fail; spec-reviewer Epicurus pass | なし |
 
-## 目的整合台帳（Objective Alignment Ledger / 必須）
+## 目的整合台帳（Objective Alignment Ledger）
 
-主要目的と副次要件の主従が逆転していないことを記録する。特に clarification / authoring / handoff の変更では、primary objective evidence、secondary requirement evidence、inversion risk、reviewer verdict を残す。
-
-| 対象 | 主要目的の証跡（primary objective evidence） | 副次要件の証跡（secondary requirement evidence） | 逆転リスク（inversion risk） | レビュアー判定（reviewer verdict） |
+| 対象 | 主要目的の証跡 | 副次要件の証跡 | 逆転リスク | レビュアー判定 |
 |---|---|---|---|---|
-| OAL-001 | ... | ... | なし / 低 / 中 / 高（none / low / medium / high） | 合格 / 不合格 / blocked（pass / fail / blocked） |
+| OAL-001 | `requirement.md` AC-001/AC-002 と `design.md` は `review=` を target Codex review state として定義している | AC-003/EC-001..EC-004 は final JSON、latency guard、fallback、line budget の非回帰を固定している | low | requirement/design/plan の fresh spec-reviewer pass |
 
-## 仕様 authoring ゲート（Spec Authoring Gate / 必須）
+## 仕様 authoring ゲート（Spec Authoring Gate）
 
-Requirement / design / plan の phase promotion ごとに、調査、未確定事項、回答、採用判断、reviewer verdict、blocking / non-blocking、次アクションを記録する。
-
-| フェーズ（phase） | 調査証跡（investigated facts） | 未確定事項 / 回答（open questions / answers） | 採用判断（adoption decision） | レビュアー判定（reviewer verdict） | ブロック有無（blocking） | 昇格 / 次アクション（promotion / next_action） |
+| フェーズ | 調査証跡 | 未確定事項 / 回答 | 採用判断 | レビュアー判定 | ブロック有無 | 昇格 / 次アクション |
 |---|---|---|---|---|---|---|
-| 要件 / 設計 / 計画（requirement / design / plan） | 文書 / コード / discussions / 外部証跡（docs / code / discussions / external evidence） | なし / `discussions/...`（none / `discussions/...`） | 採用 / 部分採用 / 棄却 / 延期 / なし（adopted / partially_adopted / rejected / deferred / none） | 合格 / 不合格 / 利用不可 / 拒否 / waiver / provisional（passed / failed / unavailable / denied / waived / provisional） | はい / いいえ（yes / no） | 昇格 / clarification へ戻す / 再レビュー / フォローアップ（promote / return to clarification / re-review / follow-up） |
+| requirement | source analysis discussion; existing wait script; existing tests | `review=pending_signal` をユーザー回答として取得 | adopted | first review fail -> fixed -> re-review pass | no | design へ昇格済み |
+| design | approved requirement; existing `progress_line(...)`, `review_progress_counts(...)`, `classify(...)`; PlantUML dependency map | additional question none | adopted | pass | no | plan へ昇格済み |
+| plan | approved requirement/design; existing focused tests; review finding for EC-003 | implementation-planner skip acceptable for localized/trivial plan | adopted | first review fail -> fixed -> re-review pass | no | Issue Execution handoff ready |
 
-## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
-- 委任 authoring の使用:
-  - used / not used
-- 未使用の場合:
-  - manual authoring path / 委任ドラフトを昇格証跡として使っていない理由。
-- lifecycle state（契約値）:
-  - `requested`, `produced`, `integrated`, `partially_integrated`, `rejected`, `superseded`, `blocked`, `stale`
-- 昇格不可 state:
-  - `stale`, `rejected`, `superseded`, `blocked`
-- 標準出力先:
-  - 対象 scope の `discussions/` direct child にある flat Markdown
-  - filename: `<ts>-<kind>-<slug>.md` または same-second collision 用 `<ts>-<nn>-<kind>-<slug>.md`
-- 軽量 provenance:
-  - `created_by_role`, `scope_id`, `source_paths`, `intended_targets`, `adoption_status: unreviewed`, `reflected_to: []`, `diff_guard_result`, fallback decision, report evidence destination, adoption ledger note
-  - 互換 label: source artifacts, draft artifact path, status, integration result, rejected portions, blockers, reviewer result, promotion decision
-- 禁止 self-claim:
-  - `authority: accepted`, `adoption_status: adopted`, non-empty `reflected_to`, reviewer pass, phase completion, implementation readiness
-- 禁止 wildcard token:
-  - `*`, `grants.*`, `all`
-- 標準必須にしない field:
-  - task manifest hash, Permission Profile hash, session invocation hash, probe run id, session hash
-- historical note:
-  - 既存 `iss-00126` などの manifest/Profile/probe/session artifacts は grandfathered evidence として残し、削除・rename・validation failure 化しない。
+## 委任ドラフト証跡（Delegated Draft Evidence）
 
-| ロール（created_by_role） | 範囲（scope_id） | ドラフトパス（discussion draft path） | 参照元（source_paths） | 予定反映先（intended_targets） | 採用状態（adoption_status） | 反映先（reflected_to） | 差分ガード結果（diff_guard_result） | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果（reviewer result） | 昇格判断（promotion decision） |
+| ロール | 範囲 | ドラフトパス | 参照元 | 予定反映先 | 採用状態 | 反映先 | 差分ガード結果 | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果 | 昇格判断 |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| 該当なし | 該当なし | 該当なし | 該当なし | 該当なし | 未使用（not used） | なし（[]） | 未実行（not_run） | 手動 authoring | 該当なし | なし（none） | 該当なし | 委任ドラフト昇格なし |
+| system-architect | iss-00214 design | 該当なし | requirement/research/interview | design.md | not used | [] | not_run | manual authoring | 該当なし | none | spec-reviewer pass; skip acceptable | design approved |
+| implementation-planner | iss-00214 plan | 該当なし | requirement/design/tests | plan.md | not used | [] | not_run | manual authoring | 該当なし | none | spec-reviewer pass; skip acceptable | plan approved |
 
-### 委任ドラフトの失敗モード（Delegated Draft Failure Modes）
-| 失敗モード | 期待される判定 | 許可される次アクション | レポート証跡の記録先（report evidence destination） | 昇格可否 |
-|---|---|---|---|---|
-| 同意なし（missing consent） | blocked / incomplete | 範囲付き同意を取得する、または手動 authoring に戻す | この section | ineligible |
-| 前段 reviewer pass 不足 / stale（missing/stale previous reviewer pass） | blocked / incomplete | レビューゲートを再実行する（rerun reviewer gate） | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
-| 設計中の要件 gap（requirement gap during design） | blocked / incomplete | requirement phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| 計画中の設計 gap（design gap during plan） | blocked / incomplete | design phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| ロール利用不可（role unavailable） | blocked / manual path | 利用不可を記録し、妥当なら手動で続行する | この section | ineligible |
-| 禁止行為の試行（forbidden action attempt） | rejected | ドラフトを破棄し incident を記録する | この section / decision ledger | ineligible |
-| 古いドラフト（stale draft） | stale | 再生成または差分調整する | この section | ineligible |
-| 置換済みドラフト（superseded draft） | superseded | 置換先ドラフトを参照する | この section | ineligible |
-| 委任使用主張に対する証跡不足（missing draft evidence when delegated use is claimed） | incomplete | 証跡を追加する、または委任使用 claim を外す | この section | ineligible |
-| reviewer 利用不可 / 拒否 / waiver / provisional（reviewer unavailable/denied/waived/provisional） | blocked / incomplete | fresh な passed reviewer を取得する、または昇格なしの risk acceptance を記録する | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
+## ワークフロー委任同意の証跡（Workflow Delegation Consent）
 
-## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+| 同意元 | リポジトリ / worktree | 対象課題 | セッション | 指名ロール | 境界 | 期限 / 無効化条件 | 拒否 / 利用不可理由 | 次アクション |
+|---|---|---|---|---|---|---|---|---|
+| user instruction | `/Users/iwasawayuuta/.codex/worktrees/26b6/spec-dock` | iss-00214 | current session | spec-reviewer; system-architect; implementation-planner; future dev-coder/code-reviewer/qa-reviewer per plan | same repo, active issue, named role, workflow-scoped; no destructive action, publishing, credential expansion, or scope expansion | issue complete; session end; scope change; host policy conflict; user revocation | none | proceed to Issue Execution when requested |
 
-## 実装記録（セッションログ） (必須)
+## 実装サマリー
 
-### セッションログ（2026-06-19 HH:MM - HH:MM）
+- 未実装。今回の作業範囲は Issue Planning workflow に沿った仕様書作成と authoring gate の通過まで。
+- 実装対象は S01 `Target review progress display`、S90 `Docs impact resolution`、S99 `Final quality gate` として `plan.md` に固定した。
+
+## 実装記録（セッションログ）
+
+### セッションログ（2026-06-19 15:45 - 16:30 JST）
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
-- 計画上の出典（Planned source）:
-  - `plan.md` section:
-  - closure ids:
+
+- Step: planning only
+- AC/EC: AC-001..AC-004, EC-001..EC-004
+- 計画上の出典:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
 
 #### 実施内容
-- ...
+
+- GitHub issue #214 を `iss-00214` として start 済みの active issue 文脈で、source analysis と user interview の discussion artifact を作成した。
+- `requirement.md`、`design.md`、`plan.md` を Issue Planning workflow に沿って作成した。
+- `review=pending_signal` を no-signal wait state の exact expectation として採用した。
+- requirement/design/plan それぞれに fresh `spec-reviewer` gate を実施し、blocking finding を修正して pass を得た。
 
 #### 実行コマンド / 結果
-```bash
-<command>
 
-<result>
+```bash
+./spec-dock/scripts/spec-dock issue start --id iss-00214
+
+spec-dock: ok (issue start) target=iss-00214 initiative=init-local-00003 epic=epic-00158 issue=iss-00214
+spec-dock: ok (issue checkout) branch=iss-00214-pr-observation-review-target-state
 ```
 
-#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
-| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
-|---|---|---|---|---|---|---|
-| S01 | 赤フェーズ / 代替証跡（Red / alternative） | red-required / covered-existing / inspect-only / manual-required | ... | `command` / 文書点検（docs inspection） / 手動記録（manual record） | pass / approved-no-op / fail / blocked | ... |
-| S01 | 緑フェーズ（Green） | ... | ... | `command` / 点検（inspection） / 手動記録（manual record） | pass / fail / blocked | ... |
-| S01 | リファクタリング（Refactor） | guardrail satisfied / no refactor needed | ... | 差分点検（diff inspection） / command | pass / approved-no-op / fail / blocked | ... |
-
-#### 発見されたテスト / リスク（Discovered Tests）
-| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
-|---|---|---|---|---|---|---|
-| S01 | none / ... | implementation / review / QA / user report | recorded / added test / deferred / amended plan | tc-001 / new | yes / no | ... |
-
-#### ステップ契約の完了証跡（Step Contract Closure）
-| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
-|---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved-no-op / fail / blocked | ... |
-
-#### テスト契約の完了証跡（Test Contract Closure）
-| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
-|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required / covered-existing / inspect-only / manual-required | ... | ... | pass / approved-no-op / fail / blocked | ... |
-
-- `closure id / test id` は Spec-Locked Closure Index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
-
-#### クロージャ網羅（Closure Coverage）
-| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
-|---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved-no-op / fail / blocked | ... |
-
-#### クロージャ差分（Closure Delta）
-| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
-|---|---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no | yes / no |
-
-#### ワークフロー委任同意の証跡（Workflow Delegation Consent）
-`workflow_issue.md` is the policy source for workflow-scoped delegation consent. This report records observed consent, boundary, expiry, and denied / unavailable handling only.
-
-| 同意元（consent source） | リポジトリ / worktree（repo/worktree） | 対象課題（active issue） | セッション（session） | 指名ロール（named roles） | 境界（boundary） | 期限 / 無効化条件（expires / invalidation condition） | 拒否 / 利用不可理由（denied / unavailable reason） | 次アクション（next action） |
-|---|---|---|---|---|---|---|---|---|
-| user instruction / explicit approval / none | ... | iss-00214 | current session / ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | same repo, active issue, session, named role; no destructive action / publishing / credentialed access / scope expansion / write-capable delegation / private external system use | issue complete / session end / scope change / host policy conflict / user revocation | none / denied / unavailable / host conflict | proceed / ask user / block gate / record waiver request |
-
-#### 実装委任ゲート（Implementation Delegation Gate）
-`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records observed evidence only.
-
-| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
-
-#### 委任 worker 証跡（Delegated Worker Evidence）
-| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
-|---|---|---|---|---|---|---|---|
-| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
-
-#### 親実装例外（Parent Implementation Exception）
-| ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
-
 #### レビューゲート状態（Reviewer Gate Status）
-| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
-|---|---|---|---|---|---|---|---|
-| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
 
-#### ステップ commit ゲート（Step Commit Gate）
-| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | committed / approved-no-op | ... | <hash or final ledger reference> | `git status --short` -> clean | ... | ... | ... | ... |
+| ステップ | ゲート名 | レビュアーロール | 鮮度 | 状態 | リスク受容 | 昇格 / 完了判断 | メモ |
+|---|---|---|---|---|---|---|---|
+| requirement | requirement spec review | spec-reviewer | fresh | failed -> passed | N/A | proceed | First pass found AC-002 ambiguity; fixed and re-reviewed |
+| design | design spec review | spec-reviewer | fresh | passed | N/A | proceed | system-architect skip accepted as localized/trivial |
+| plan | plan spec review | spec-reviewer | fresh | failed -> passed | N/A | proceed | First pass found EC-003 fallback verification gap; fixed and re-reviewed |
 
 #### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
 
-#### コミット
-- <hash> <message>
+- `spec-dock/active/issue/requirement.md` - `review=` target state 表示の要件、AC/EC、scope constraints を定義
+- `spec-dock/active/issue/design.md` - `pending_signal` display-only derivation、provider/mirror impact、test strategy を定義
+- `spec-dock/active/issue/plan.md` - S01/S90/S99、closure index、delegation contract、concrete tests を定義
+- `spec-dock/active/issue/report.md` - planning evidence と execution handoff readiness を記録
+- `spec-dock/active/issue/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md` - source-grounded clarification research
+- `spec-dock/active/issue/discussions/20260619t064502z-interview-review-pending-state-naming.md` - user interview and adoption record
 
-#### メモ
-- ...
-
----
-
-### セッションログ（2026-06-19 HH:MM - HH:MM）
-
-#### 対象
-- Step: ...
-- AC/EC: ...
-
-#### 実施内容
-- ...
-
----
-
-## 最終品質ゲート（Final Quality Gate / 必須）
+## 最終品質ゲート（Final Quality Gate）
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
-| 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
+
+| 対象 | 更新要否 | 担当 | 証跡 | 仕様レビュアー結果 |
 |---|---|---|---|---|
-| docs / templates / README / workflow / skill / migration notes | yes / no | doc-writer / N/A | ... | pass / fail / blocked |
+| PR observation skill docs | 未実施 | future S90 | `plan.md` S90 に検査コマンドと更新条件を定義 | pending execution |
 
 ### 最終 QA ゲート（Final QA Gate）
-| レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
+
+| レビュアー | 範囲 | 統合テスト判断 | 証跡 | 結果 |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | added / already sufficient / not applicable | ... | pass / fail / blocked |
+| qa-reviewer | whole issue obligation coverage | pending execution | `plan.md` S99 | pending execution |
 
 ### 最終コードレビューゲート（Final Code Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
+
+| レビュアー | 範囲 | 指摘 / 修正 | 再 review 回数 | 結果 |
 |---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | ... | 0 | pass / fail / blocked |
+| code-reviewer | issue-wide integrated diff | pending execution | 0 | pending execution |
 
 ### 最終 spec review ゲート（Final Spec Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
+
+| レビュアー | 範囲 | 指摘 / 修正 | 再 review 回数 | 結果 |
 |---|---|---|---|---|
-| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | ... | 0 | pass / fail / blocked |
+| spec-reviewer | requirement/design/plan/report and implementation alignment | pending execution | 0 | pending execution |
 
-### 最終 commit（Final Commit）
-| 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
-|---|---|---|---|
-| ... | ... | final response / PR / issue comment / other external delivery evidence | ready / blocked |
+## 実行ハンドオフ
 
-## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
+- Handoff state: ready for Issue Execution.
+- Starting step: S01 `Target review progress display`.
+- First red target: update `test_issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint` from `review=observing` to `review=pending_signal`, then observe the expected pre-implementation failure.
+- Mandatory focused command:
 
-## 学んだこと (任意)
-- ...
+```bash
+uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"
+```
 
-## 今後の推奨事項 (任意)
-- ...
-
-## 省略/例外メモ (必須)
-- 該当なし
+- Stop conditions:
+  - final JSON `decision` / `decision_fingerprint` semantics need to change
+  - trigger / resume / snapshot behavior needs to change
+  - new progress field such as `observer=` / `wait=` becomes necessary
+  - `pending_signal` cannot be derived without weakening AC-001 or AC-003

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -12,7 +12,7 @@ ID: "iss-00214"
 
 # iss-00214 PR Observation Review Target State — 実装報告
 
-この `report.md` は実装前の Issue Planning / Clarification 証跡と、次の Issue Execution へ渡す handoff readiness を記録する。実装結果、Red / Green / Refactor evidence、step commit evidence は実装フェーズで追記する。
+この `report.md` は Issue Planning / Clarification 証跡、S01 / S90 / S99 の実行証跡、reviewer gate、commit gate、PR delivery 前の残状態を記録する observed evidence ledger である。
 
 ## 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger）
 
@@ -21,8 +21,8 @@ ID: "iss-00214"
 | D-001 | resolved | interpretation | user interview | `review=` が観測者側の作業状態を表示していた | `review=observing`; `review=pending`; `review=pending_signal` | no-signal wait state は `review=pending_signal` とし、`review=` は観測対象の Codex review state を表示する | ユーザー回答で `review=pending_signal` が明示され、観測する自分ではなく観測対象の状態を表示すべきとされた | applied | `discussions/20260619t064502z-interview-review-pending-state-naming.md`; `requirement.md`; `design.md`; `plan.md` | なし |
 | D-002 | resolved | scope | orchestrator | `observer=` / `wait=` 追加案の扱い | 今回追加する; 今回は追加しない | この issue では `review=` の target-state 表示だけに限定し、新 field は追加しない | 要件と設計で final JSON / progress line 以外の contract 変更を scope 外に固定した | applied | `requirement.md`; `design.md`; `plan.md` | 必要なら別 issue |
 | D-003 | resolved | test-strategy | spec-reviewer | EC-003 fallback issue comment semantics の検証が条件付きだった | 条件付きのまま; 必須 focused pytest に含める | fallback issue comment regression を必須検証に含める | plan review P1 finding により closure が実装者判断に残ると判定された | applied | `plan.md`; spec-reviewer Avicenna finding; spec-reviewer Epicurus pass | なし |
-| D-004 | resolved | test-strategy | dev-coder | S01 Red が計画した `review=` assertion の前に timeout / fixture 境界で失敗した | 実装を止める; timeout だけ延ばす; S04 fixture を planned payload 観測用に修理する | S04 fixture repair を採用し、Red/Green が計画済みの wait progress behavior を観測できるようにする | 修理は allowed test file に限定され、product final JSON semantics や trigger / snapshot runtime を変更しない。修理後の Red は `review=observing` に対して期待どおり失敗し、Green は focused regression set で pass した | applied | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer が fixture repair を確認する |
-| D-005 | resolved | implementation | qa-reviewer / dev-coder / orchestrator | latency-guard no-completion path で `review_status="approved"` だが trusted completion signal がない wait progress が `review=approved` と表示され得た | `none`/`pending`/`unknown` だけを pending signal 候補にする; `approved`/`passed` も no-completion wait に限り候補にする; timeout phase も候補にする | `approved`/`passed` は no trusted completion signal、no actionable feedback、no completed lifecycle の wait progress に限って `pending_signal` 候補にする。timeout phase への拡張は採用しない | QA P1 は EC-001 の wait/progress 可読性 gap を指摘しており、design は final / timeout phase では existing final status を優先し得るため、補修範囲を wait display-only に限定する | applied | `progress_line(...)`; `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age`; focused pytest | code-reviewer / qa-reviewer / spec-reviewer re-review |
+| D-004 | resolved | test-strategy | dev-coder | S01 Red が計画した `review=` assertion の前に timeout / fixture 境界で失敗した | 実装を止める; timeout だけ延ばす; S04 fixture を planned payload 観測用に修理する | S04 fixture repair を採用し、Red/Green が計画済みの wait progress behavior を観測できるようにする | 修理は allowed test file に限定され、product final JSON semantics や trigger / snapshot runtime を変更しない。修理後の Red は `review=observing` に対して期待どおり失敗し、Green は focused regression set で pass した | applied | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence; code-reviewer pass | なし |
+| D-005 | resolved | implementation | qa-reviewer / dev-coder / orchestrator | latency-guard no-completion path で `review_status="approved"` だが trusted completion signal がない wait progress が `review=approved` と表示され得た | `none`/`pending`/`unknown` だけを pending signal 候補にする; `approved`/`passed` も no-completion wait に限り候補にする; timeout phase も候補にする | `approved`/`passed` は no trusted completion signal、no actionable feedback、no completed lifecycle の wait progress に限って `pending_signal` 候補にする。timeout phase への拡張は採用しない | QA P1 は EC-001 の wait/progress 可読性 gap を指摘しており、design は final / timeout phase では existing final status を優先し得るため、補修範囲を wait display-only に限定する | applied | `design.md`; `plan.md`; `progress_line(...)`; `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age`; focused pytest; fresh spec-reviewer pass | final reviewer gates |
 
 ## 証跡採用台帳（Evidence Adoption Ledger）
 
@@ -33,7 +33,7 @@ ID: "iss-00214"
 | EAL-003 | adopted | reviewer | requirement.md | AC-002 の `など` が曖昧という requirement review P2 を受け、`review=unresolved` の exact expectation へ修正した | spec-reviewer Carson finding; spec-reviewer Lorentz pass | なし |
 | EAL-004 | adopted | reviewer | design.md | design は localized/trivial として system-architect draft を省略可能、かつ仕様整合は pass と判定された | spec-reviewer Ohm pass | なし |
 | EAL-005 | adopted | reviewer | plan.md | EC-003 fallback verification を必須化する P1 を受け、focused command と concrete test case に既存 fallback tests を追加した | spec-reviewer Avicenna fail; spec-reviewer Epicurus pass | なし |
-| EAL-006 | adopted | worker | report.md / tests | dev-coder の Ledger Note を親が確認し、S04 fixture repair を evidence-path repair として採用した | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer gate |
+| EAL-006 | adopted | worker | report.md / tests | dev-coder の Ledger Note を親が確認し、S04 fixture repair を evidence-path repair として採用した | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence; code-reviewer pass | なし |
 | EAL-007 | adopted | reviewer / worker | implementation/tests/report | QA P1 と dev-coder follow-up を親が確認し、`approved` / `passed` legacy review values を no-completion wait display の `pending_signal` 候補として採用した | QA reviewer finding; `tests/unit/infra/test_init_update.py`; `pr_observation_wait.py` | final re-review gates |
 
 ## 目的整合台帳（Objective Alignment Ledger）
@@ -228,7 +228,7 @@ Notes:
 | Command | Result | Evidence |
 |---|---|---|
 | `./spec-dock/scripts/spec-dock validate` | pass | `spec-dock: ok (validate) nodes=134` |
-| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | pass | `10 passed, 429 deselected in 27.89s` |
+| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | pass | `10 passed, 429 deselected in 32.42s` |
 | `./spec-dock/scripts/spec-dock sync --github` | pass | active unchanged; generated projection wrote successfully and left no git diff |
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
@@ -247,7 +247,7 @@ Notes:
 
 | レビュアー | 範囲 | 統合テスト判断 | 証跡 | 結果 |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | failed, then bounded follow-up implemented | QA P1 found EC-001 latency-guard no-completion progress gap for `review_status="approved"` without trusted completion signal | pending parent commit / re-review |
+| qa-reviewer | whole issue obligation coverage | failed, then bounded follow-up implemented | QA P1 found EC-001 latency-guard no-completion progress gap for `review_status="approved"` without trusted completion signal; follow-up committed in `4fc56b26` | pending re-review |
 
 #### QA P1 Follow-up Evidence
 
@@ -257,9 +257,18 @@ Notes:
 | Red evidence | After changing `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age` to assert stderr progress, `uv run pytest tests/unit/infra/test_init_update.py -k "test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age"` failed as expected: stderr contained `phase=wait ci=passed review=approved` instead of `review=pending_signal`. |
 | Fix | `progress_line(...)` display-only derivation now treats no-signal `approved` / `passed` legacy review display values as `pending_signal` for wait progress when there is no actionable feedback and no trusted completion signal. Provider and dogfooding mirror were updated equivalently. |
 | Final JSON | No classify / final JSON decision schema / fingerprint code was edited. The focused test still asserts `recommended_next_action == "wait_or_resume"`, `observation_complete is False`, and latency guard remains unsatisfied before trigger age. |
-| Green verification | `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` passed: `10 passed, 429 deselected in 28.40s`. |
+| Green verification | `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` passed: `10 passed, 429 deselected in 32.42s`. |
 | Structural inspection | `rg -n "review=observing|pending_signal|render_review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py .agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py tests/unit/infra/test_init_update.py` found no `review=observing`; provider and mirror both contain matching `render_review` / `pending_signal` derivation. `diff -u` between provider and mirror wait libraries produced no output. |
-| Step Commit Gate | Follow-up changes are not committed. Parent Step Commit Gate is pending after code-reviewer pass. |
+| Step Commit Gate | Follow-up committed in `4fc56b26` `fix(pr-observation): no-completion時のreview表示を補強`; post-commit worktree was clean before S99 validation rerun. |
+
+#### QA / Code Review Follow-up Spec Amendment
+
+| Item | Evidence |
+|---|---|
+| Trigger | Final code/spec review found D-005 changed the exact `pending_signal` derivation without promoting the decision into `design.md` / `plan.md`, and QA noted `passed` legacy value was not explicitly tested. |
+| Amendment | `design.md` now states that legacy/audit `approved` / `passed` values without trusted completion signal, actionable feedback, or completed lifecycle are `pending_signal` candidates only for wait progress. `plan.md` now records this no-completion payload shape and the required focused test. |
+| Test | `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age` is parameterized across `approved` and `passed`. |
+| Spec review | Fresh spec-reviewer pass confirmed the amendment promotes D-005, remains wait-phase scoped, and does not expand timeout/final behavior. |
 
 #### QA P1 Follow-up Reviewer Gate
 
@@ -300,5 +309,5 @@ Notes:
 
 - S01: committed in `b476e6f3`.
 - S90: docs impact resolved as approved-no-op in `488aaf9c`.
-- S99: validation commands passed before final QA; final QA found a P1 coverage / behavior gap and bounded follow-up is now uncommitted pending parent review / commit gate.
+- S99: validation commands passed after QA P1 follow-up commit `4fc56b26`; final QA/spec re-review is pending.
 - PR delivery / merge preparation / issue finish: pending final gates and final report commit.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/report.md
@@ -22,6 +22,7 @@ ID: "iss-00214"
 | D-002 | resolved | scope | orchestrator | `observer=` / `wait=` 追加案の扱い | 今回追加する; 今回は追加しない | この issue では `review=` の target-state 表示だけに限定し、新 field は追加しない | 要件と設計で final JSON / progress line 以外の contract 変更を scope 外に固定した | applied | `requirement.md`; `design.md`; `plan.md` | 必要なら別 issue |
 | D-003 | resolved | test-strategy | spec-reviewer | EC-003 fallback issue comment semantics の検証が条件付きだった | 条件付きのまま; 必須 focused pytest に含める | fallback issue comment regression を必須検証に含める | plan review P1 finding により closure が実装者判断に残ると判定された | applied | `plan.md`; spec-reviewer Avicenna finding; spec-reviewer Epicurus pass | なし |
 | D-004 | resolved | test-strategy | dev-coder | S01 Red が計画した `review=` assertion の前に timeout / fixture 境界で失敗した | 実装を止める; timeout だけ延ばす; S04 fixture を planned payload 観測用に修理する | S04 fixture repair を採用し、Red/Green が計画済みの wait progress behavior を観測できるようにする | 修理は allowed test file に限定され、product final JSON semantics や trigger / snapshot runtime を変更しない。修理後の Red は `review=observing` に対して期待どおり失敗し、Green は focused regression set で pass した | applied | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer が fixture repair を確認する |
+| D-005 | resolved | implementation | qa-reviewer / dev-coder / orchestrator | latency-guard no-completion path で `review_status="approved"` だが trusted completion signal がない wait progress が `review=approved` と表示され得た | `none`/`pending`/`unknown` だけを pending signal 候補にする; `approved`/`passed` も no-completion wait に限り候補にする; timeout phase も候補にする | `approved`/`passed` は no trusted completion signal、no actionable feedback、no completed lifecycle の wait progress に限って `pending_signal` 候補にする。timeout phase への拡張は採用しない | QA P1 は EC-001 の wait/progress 可読性 gap を指摘しており、design は final / timeout phase では existing final status を優先し得るため、補修範囲を wait display-only に限定する | applied | `progress_line(...)`; `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age`; focused pytest | code-reviewer / qa-reviewer / spec-reviewer re-review |
 
 ## 証跡採用台帳（Evidence Adoption Ledger）
 
@@ -33,6 +34,7 @@ ID: "iss-00214"
 | EAL-004 | adopted | reviewer | design.md | design は localized/trivial として system-architect draft を省略可能、かつ仕様整合は pass と判定された | spec-reviewer Ohm pass | なし |
 | EAL-005 | adopted | reviewer | plan.md | EC-003 fallback verification を必須化する P1 を受け、focused command と concrete test case に既存 fallback tests を追加した | spec-reviewer Avicenna fail; spec-reviewer Epicurus pass | なし |
 | EAL-006 | adopted | worker | report.md / tests | dev-coder の Ledger Note を親が確認し、S04 fixture repair を evidence-path repair として採用した | `tests/unit/infra/test_init_update.py`; S01 Red/Green evidence | code-reviewer gate |
+| EAL-007 | adopted | reviewer / worker | implementation/tests/report | QA P1 と dev-coder follow-up を親が確認し、`approved` / `passed` legacy review values を no-completion wait display の `pending_signal` 候補として採用した | QA reviewer finding; `tests/unit/infra/test_init_update.py`; `pr_observation_wait.py` | final re-review gates |
 
 ## 目的整合台帳（Objective Alignment Ledger）
 
@@ -217,9 +219,17 @@ Notes:
 
 | Step | Added | Removed | Changed | Re-review needed |
 |---|---|---|---|---|
-| S01 | none | none | Evidence-path repair in existing S04 focused test fixture; no closure id changed | code-reviewer review pending |
+| S01 | none | none | Evidence-path repair in existing S04 focused test fixture; no closure id changed | code-reviewer pass |
 
 ## 最終品質ゲート（Final Quality Gate）
+
+### S99 Validation Evidence
+
+| Command | Result | Evidence |
+|---|---|---|
+| `./spec-dock/scripts/spec-dock validate` | pass | `spec-dock: ok (validate) nodes=134` |
+| `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` | pass | `10 passed, 429 deselected in 27.89s` |
+| `./spec-dock/scripts/spec-dock sync --github` | pass | active unchanged; generated projection wrote successfully and left no git diff |
 
 ### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
 
@@ -237,7 +247,42 @@ Notes:
 
 | レビュアー | 範囲 | 統合テスト判断 | 証跡 | 結果 |
 |---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | pending execution | `plan.md` S99 | pending execution |
+| qa-reviewer | whole issue obligation coverage | failed, then bounded follow-up implemented | QA P1 found EC-001 latency-guard no-completion progress gap for `review_status="approved"` without trusted completion signal | pending parent commit / re-review |
+
+#### QA P1 Follow-up Evidence
+
+| Item | Evidence |
+|---|---|
+| Trigger | Final QA failed after S01 commit `b476e6f3` because EC-001 latency-guard no-completion progress could show `review=approved` when CI passed, trusted Codex completion signal was absent, and final JSON remained wait/resume / non-terminal. |
+| Red evidence | After changing `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age` to assert stderr progress, `uv run pytest tests/unit/infra/test_init_update.py -k "test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age"` failed as expected: stderr contained `phase=wait ci=passed review=approved` instead of `review=pending_signal`. |
+| Fix | `progress_line(...)` display-only derivation now treats no-signal `approved` / `passed` legacy review display values as `pending_signal` for wait progress when there is no actionable feedback and no trusted completion signal. Provider and dogfooding mirror were updated equivalently. |
+| Final JSON | No classify / final JSON decision schema / fingerprint code was edited. The focused test still asserts `recommended_next_action == "wait_or_resume"`, `observation_complete is False`, and latency guard remains unsatisfied before trigger age. |
+| Green verification | `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` passed: `10 passed, 429 deselected in 28.40s`. |
+| Structural inspection | `rg -n "review=observing|pending_signal|render_review" src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py .agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py tests/unit/infra/test_init_update.py` found no `review=observing`; provider and mirror both contain matching `render_review` / `pending_signal` derivation. `diff -u` between provider and mirror wait libraries produced no output. |
+| Step Commit Gate | Follow-up changes are not committed. Parent Step Commit Gate is pending after code-reviewer pass. |
+
+#### QA P1 Follow-up Reviewer Gate
+
+| レビュアー | 範囲 | 指摘 / 修正 | 結果 |
+|---|---|---|---|
+| code-reviewer | wait-only `pending_signal` derivation, focused latency-guard progress test, report follow-up evidence | no findings | pass |
+
+#### QA P1 Follow-up Ledger Note
+
+- source-agent: dev-coder
+- topic: EC-001 latency-guard no-completion progress display after QA fail
+- trigger: final QA P1 found that `review_status="approved"` with no trusted completion signal could still render `review=approved`
+- ambiguity / constraint: approved/passed review display values can be legacy audit status rather than trusted Codex completion; final JSON decision semantics and fingerprint schema must remain unchanged
+- observed facts: pre-fix focused test failed with stderr containing `phase=wait ci=passed review=approved`
+- options considered: only map `none` / `pending` / `unknown`; map `approved` only while `status_reason` is `missing_current_completion_signal`; map `approved` / `passed` when no completion signal, no actionable feedback, and no completed lifecycle exists
+- proposed decision: display-only pending-signal derivation should include `approved` / `passed` legacy review values under no-completion/no-actionable/no-lifecycle-completion conditions for wait progress lines
+- rationale: this satisfies EC-001 without touching classify, final JSON decision schema, trigger behavior, snapshot collectors, or auth behavior
+- affected files: `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`; `.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py`; `tests/unit/infra/test_init_update.py`; `spec-dock/active/issue/report.md`
+- affected tests: `test_issue_187_s204_wait_does_not_promote_unknown_before_trigger_age`; S01 focused pytest set
+- risk if wrong: progress display could hide a genuinely trusted approved state if future payloads omit completion signal incorrectly; final JSON remains authoritative
+- rollback or revisit: revert the display-only candidate expansion and the stderr assertions, then add a more specific payload field for trusted review display if needed
+- confidence: medium-high
+- needs orchestrator decision: resolved; parent adopted the wait-only follow-up in D-005 / EAL-007 and intentionally did not adopt timeout-phase expansion
 
 ### 最終コードレビューゲート（Final Code Review Gate）
 
@@ -251,19 +296,9 @@ Notes:
 |---|---|---|---|---|
 | spec-reviewer | requirement/design/plan/report and implementation alignment | pending execution | 0 | pending execution |
 
-## 実行ハンドオフ
+## Execution Status
 
-- Handoff state: ready for Issue Execution.
-- Starting step: S01 `Target review progress display`.
-- First red target: update `test_issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint` from `review=observing` to `review=pending_signal`, then observe the expected pre-implementation failure.
-- Mandatory focused command:
-
-```bash
-uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"
-```
-
-- Stop conditions:
-  - final JSON `decision` / `decision_fingerprint` semantics need to change
-  - trigger / resume / snapshot behavior needs to change
-  - new progress field such as `observer=` / `wait=` becomes necessary
-  - `pending_signal` cannot be derived without weakening AC-001 or AC-003
+- S01: committed in `b476e6f3`.
+- S90: docs impact resolved as approved-no-op in `488aaf9c`.
+- S99: validation commands passed before final QA; final QA found a P1 coverage / behavior gap and bounded follow-up is now uncommitted pending parent review / commit gate.
+- PR delivery / merge preparation / issue finish: pending final gates and final report commit.

--- a/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/requirement.md
+++ b/spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/requirement.md
@@ -3,97 +3,167 @@
 ID: "iss-00214"
 タイトル: "PR Observation Review Target State"
 関連GitHub: ["#214"]
-状態: "draft | approved"
+状態: "approved"
 作成者: "iwasawayuuta"
 最終更新: "2026-06-19"
 親: ["epic-00158", "init-local-00003"]
 ---
 
-# iss-00214 PR Observation Review Target State — 要件定義（何を、なぜ行うか）
+# iss-00214 PR Observation Review Target State — 要件定義
 
 ## 目的
-- （1〜3行）...
+
+`wait_pr_observation.sh` の progress line で、`review=` が観測者側の状態ではなく、監視対象である Codex review の状態を表示するようにする。
+通常 wait flow の operator が Codex review 未起動と誤認して、手動で追加の `@codex review` trigger を投稿するリスクを下げる。
 
 ## 背景・現状
-- 現状の挙動:
-  - ...
-- 現状の課題:
-  - ...
-- 再現手順:
-  1. ...
-  2. ...
-- 観測点:
-  - UI:
-  - HTTP:
-  - DB:
-  - ログ:
-- 情報源:
-  - ...
 
-## 対象ユーザー / 利用シナリオ（必要時）
+- 対象 workflow:
+  - `.agents/skills/github-pr-observation/scripts/wait_pr_observation.sh`
+  - provider-side authority: `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/`
+  - dogfooding mirror: `.agents/skills/github-pr-observation/`
+- 現状の挙動:
+  - wait 中かつ observation 未完了の progress line では、`review=` が `review=observing` と表示される。
+  - 例: `pr_obs poll=3 ... phase=wait ci=running ... review=observing comments=0 threads=0 unresolved=0 ...`
+- 現状の課題:
+  - `review=observing` は監視対象の Codex review 状態ではなく、スクリプトが観測中であるという観測者側の状態を表している。
+  - `review=observing comments=0 threads=0 unresolved=0` が続くと、operator は `@codex review` trigger が投稿されていない、または Codex review が起動していないと誤認しやすい。
+  - 通常 wait flow では `wait_pr_observation.sh` が default `post-once` で fixed `@codex review` trigger を 1 回投稿するため、caller / agent は手動で `@codex review` を投稿してはならない。
+- 観測点:
+  - `stderr` progress line の `review=` field。
+  - final `stdout` JSON の `decision` / `decision_fingerprint` / `recommended_next_action` contract。
+  - `tests/unit/infra/test_init_update.py` の PR observation wait regression tests。
+- 情報源:
+  - GitHub issue `#214`
+  - `spec-dock/active/issue/discussions/20260619t064501z-research-review-progress-target-state-source-analysis.md`
+  - `spec-dock/active/issue/discussions/20260619t064502z-interview-review-pending-state-naming.md`
+
+## 対象ユーザー / 利用シナリオ
+
 - 主な利用者:
-  - ...
+  - PR 作成後または push 後に、Codex review と CI を同じ trigger boundary で観測する agent / operator。
 - 代表シナリオ:
-  - ...
+  - Agent が `wait_pr_observation.sh` を通常 wait flow で実行する。
+  - Script が fixed `@codex review` trigger を投稿し、CI と Codex review を poll する。
+  - Progress line を読んだ operator が、手動で追加 trigger を投稿すべきか、待機すべきかを判断する。
 
 ## スコープ
+
 - 必須:
-  - ...
+  - `progress_line(...)` が wait 中の review status を無条件に `observing` へ上書きしない。
+  - `review=` には、観測者側の状態ではなく、監視対象である Codex review の target state を表示する。
+  - Trigger comment は投稿済みだが、Codex review の completion / comment signal がまだ観測できない待機中状態を `review=pending_signal` と表示する。
+  - Unresolved review comments / threads がある場合は、`review=unresolved` と `comments` / `threads` / `unresolved` count が読める。
+  - Codex review が major issues なしで完了した場合は、progress line または final output でその target state が分かる。
+  - Provider-side source と dogfooding mirror の両方で変更内容を確認する。
+  - Existing final JSON contract、`decision` / `decision_fingerprint` の authoritative semantics を維持する。
 - 禁止:
-  - ...
+  - `review=` を観測者側の状態で上書きすること。
+  - `running` のように、GitHub / Codex 側の処理中シグナルがない状態を過剰に断定すること。
+  - `wait_pr_observation.sh` の default `post-once` 仕様を変更すること。
+  - Caller / agent が通常 wait flow で手動 `@codex review` を投稿する policy を弱めること。
+  - `fetch_pr_observation_snapshot.sh` の read-only contract を変更すること。
+  - PR repair triage / disposition logic、GitHub token 権限モデル、resume mode の semantics を変更すること。
 - 対象外:
-  - ...
+  - 自動 trigger reuse mode の追加。
+  - Review body collection や selected review inventory の再設計。
+  - Final readiness / merge-prepared decision の semantics 変更。
+  - PR observation 以外の SpecDock workflow 表示改善。
 
 ## 境界
+
 - 常に行う:
-  - ...
+  - Progress line は bounded ASCII key/value summary として維持する。
+  - `stdout` JSON を machine-readable authority、`stderr` progress を non-authoritative diagnostic として扱う。
+  - `decision` と `decision_fingerprint` を current trigger boundary の final-status authoritative inputs として維持する。
+  - `review_completion_unknown` は latency guards 後の human gate 状態として、通常 wait 中の `pending_signal` と区別する。
 - 判断が必要:
-  - ...
+  - `review=pending_signal` を導出する具体条件は design で固定する。
+  - Progress line の length cap / optional field drop order への影響は design / plan で検証対象にする。
 - 行わない:
-  - ...
+  - Observer state 用の `observer=` / `wait=` field は今回追加しない。
+  - `review=none` を trigger 済み signal 待ち状態の operator-facing 表示には使わない。
 
 ## 非交渉制約
-- ...
 
-## 前提
-- ...
+- `review=pending_signal` は、ユーザー回答に基づく採用済み operator-facing 表示名である。
+- `review=` は観測対象の状態を表示する。観測者側の状態を表示しない。
+- Existing public script entrypoint は `.sh` wrapper のまま維持する。
+- Provider-side source が shipped asset authority であり、dogfooding mirror は検証対象である。
 
 ## 受け入れ条件
+
 - AC-001:
-  - アクター:
-  - 前提:
-  - 操作:
-  - 期待結果:
-  - 観測点:
+  - アクター: PR observation wait script を見る operator / agent。
+  - 前提: `wait_pr_observation.sh` が wait phase にあり、trigger comment は投稿済みだが、Codex review の completion / comment signal はまだない。
+  - 操作: Progress line を確認する。
+  - 期待結果: `review=observing` ではなく `review=pending_signal` が表示される。
+  - 観測点: `stderr` progress line。
 - AC-002:
-  - ...
+  - アクター: PR observation wait script を見る operator / agent。
+  - 前提: Current trigger boundary に unresolved Codex review feedback がある。
+  - 操作: Progress line を確認する。
+  - 期待結果: `review=unresolved` と、`comments` / `threads` / `unresolved` count が読める。
+  - 観測点: `stderr` progress line。
+- AC-003:
+  - アクター: Downstream orchestration / agent。
+  - 前提: Wait result final JSON が生成される。
+  - 操作: `stdout` JSON の `decision` / `decision_fingerprint` / `recommended_next_action` を確認する。
+  - 期待結果: Existing authoritative final JSON contract は変更されていない。
+  - 観測点: `stdout` JSON と existing regression tests。
+- AC-004:
+  - アクター: SpecDock maintainer。
+  - 前提: Shipped PR observation asset を変更する。
+  - 操作: Provider-side source と dogfooding mirror を確認する。
+  - 期待結果: Provider-side source が変更され、dogfooding mirror も同等の behavior を持つ。
+  - 観測点: `src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/...`、`.agents/skills/github-pr-observation/...`、targeted tests。
 
 ## 例外・エッジケース
+
 - EC-001:
-  - 条件:
-  - 期待:
-  - 観測点:
+  - 条件: CI は passed だが、Codex review completion signal は latency guard 未満でまだ観測されていない。
+  - 期待: `review=pending_signal` として wait / resume path の状態が読める。`review_completion_unknown` へ早期昇格しない。
+  - 観測点: Progress line と final JSON。
 - EC-002:
-  - ...
+  - 条件: Latency guards を満たした後も trusted Codex review completion signal がなく、actionable review inventory も空である。
+  - 期待: Existing `review_completion_unknown` / `human_gate` semantics を維持し、通常 wait 中の `pending_signal` と区別できる。
+  - 観測点: Existing no-completion regression tests。
+- EC-003:
+  - 条件: Codex review は fallback issue comment だけで観測される。
+  - 期待: Existing fallback low-confidence human gate / wait_or_resume semantics を維持し、`review=` 表示変更が final decision を promote しない。
+  - 観測点: Existing fallback regression tests。
+- EC-004:
+  - 条件: Progress line が length cap に近い。
+  - 期待: `pending_signal` 表示により、既存の bounded summary / optional field dropping contract が破綻しない。
+  - 観測点: Existing line budget regression tests。
 
-## 入力→出力例（必要時）
+## 入力→出力例
+
 - EX-001:
-  - 入力:
-  - 出力:
+  - 入力: `phase=wait`, trigger comment posted, `review.status=none`, no completion / comment signal.
+  - 出力: `pr_obs ... phase=wait ... review=pending_signal comments=0 threads=0 unresolved=0 ...`
+- EX-002:
+  - 入力: `phase=wait`, current unresolved review feedback selected.
+  - 出力: `pr_obs ... phase=wait ... review=unresolved comments=4 threads=3 unresolved=3 ...`
+- EX-003:
+  - 入力: `phase=terminal`, Codex review completion passed / approved and CI passed.
+  - 出力: Progress line or final JSON shows the target review state without `review=observing`.
 
-## 用語（ドメイン語彙）
-- TERM-001:
-  - ...
+## 用語
+
+- `review=`:
+  - Progress line 上の key。監視対象である Codex review の target state を表示する。
+- `pending_signal`:
+  - Trigger comment は投稿済みだが、Codex review の completion / comment signal がまだ観測されていない wait 中の target state。
+- `observing`:
+  - 観測者側の状態を表すため、この issue の `review=` 表示では使わない。
+- `review_completion_unknown`:
+  - CI passed、head matched、actionable review inventory empty、trusted Codex review completion signal missing の状態が latency guards 後も続いた場合の non-pass human gate 状態。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+
+- Blocking:
+  - なし。
+- Non-blocking:
+  - `pending_signal` の exact derivation は design で固定する。
+  - Progress line の length budget への影響は plan の verification で固定する。

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
@@ -1069,9 +1069,10 @@ def progress_line(
     ci_status = ci_counts["status"]
     review_status = review_counts["status"]
     render_review = review_status
-    if phase == "wait" and not observation_complete and review_status in {"none", "pending", "unknown"}:
+    if phase == "wait" and not observation_complete:
         lifecycle = codex_review_lifecycle(payload)
         decision = decision_payload(payload)
+        pending_signal_candidate = review_status in {"none", "pending", "unknown", "approved", "passed"}
         completion_signal = decision.get("completion_signal") or lifecycle.get("completion_signal")
         lifecycle_status = lifecycle.get("status")
         has_actionable_feedback = any(
@@ -1079,7 +1080,8 @@ def progress_line(
             for key in ("comments", "threads", "unresolved", "requested")
         )
         if (
-            not has_actionable_feedback
+            pending_signal_candidate
+            and not has_actionable_feedback
             and completion_signal in {None, "", "none"}
             and lifecycle_status in {None, "", "none", "pending", "unknown"}
         ):

--- a/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
+++ b/src/spec_dock/assets/install_root/.agents/skills/github-pr-observation/scripts/lib/pr_observation_wait.py
@@ -1069,8 +1069,21 @@ def progress_line(
     ci_status = ci_counts["status"]
     review_status = review_counts["status"]
     render_review = review_status
-    if phase == "wait" and not observation_complete:
-        render_review = "observing"
+    if phase == "wait" and not observation_complete and review_status in {"none", "pending", "unknown"}:
+        lifecycle = codex_review_lifecycle(payload)
+        decision = decision_payload(payload)
+        completion_signal = decision.get("completion_signal") or lifecycle.get("completion_signal")
+        lifecycle_status = lifecycle.get("status")
+        has_actionable_feedback = any(
+            int(review_counts.get(key, 0) or 0) > 0
+            for key in ("comments", "threads", "unresolved", "requested")
+        )
+        if (
+            not has_actionable_feedback
+            and completion_signal in {None, "", "none"}
+            and lifecycle_status in {None, "", "none", "pending", "unknown"}
+        ):
+            render_review = "pending_signal"
 
     fields: list[tuple[str, str, bool]] = [
         ("poll", str(poll), False),

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -20200,7 +20200,7 @@ print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
                 timeout_seconds=3,
                 quiet_seconds=1,
                 same_fingerprint_count=2,
-                progress="none",
+                progress="stderr-summary",
                 trigger_created_at=trigger["created_at"],
             )
 
@@ -20212,6 +20212,7 @@ print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
             assert payload["observation_complete"] is False
             assert payload["wait"]["review_completion_unknown_latency_satisfied"] is False
             assert payload["wait"]["review_trigger_age_seconds"] < 300
+            assert "phase=wait ci=passed review=pending_signal" in result.stderr
 
     def test_issue_187_s204_wait_does_not_promote_unknown_before_ci_passed_age(self) -> None:
         evidence = {

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -13514,34 +13514,7 @@ JSON
             """#!/usr/bin/env bash
 set -euo pipefail
 printf 'snapshot %s\\n' "$*" >> "$S04_WAIT_LOG"
-python3 - "$@" <<'PY'
-import json
-import os
-import sys
-
-args = sys.argv[1:]
-trigger_id = None
-trigger_created_at = None
-while args:
-    arg = args.pop(0)
-    if arg == "--trigger-comment-id":
-        trigger_id = int(args.pop(0))
-    elif arg == "--trigger-created-at":
-        trigger_created_at = args.pop(0)
-    elif arg == "--out":
-        args.pop(0)
-    elif args:
-        args.pop(0)
-
-payload = json.loads(os.environ["S04_WAIT_PAYLOAD"])
-payload.setdefault(
-    "trigger",
-    {"source": "explicit", "comment_id": trigger_id, "created_at": trigger_created_at},
-)
-payload["trigger"]["comment_id"] = trigger_id
-payload["trigger"]["created_at"] = trigger_created_at
-print(json.dumps(payload, separators=(",", ":")))
-PY
+printf '%s\\n' "$S04_WAIT_PAYLOAD"
 """,
             encoding="utf-8",
         )
@@ -13716,7 +13689,7 @@ PY
                             "--trigger-created-at",
                             "2026-06-09T02:03:04Z",
                             "--timeout-seconds",
-                            "2",
+                            "7",
                             "--poll-interval-seconds",
                             "1",
                             "--quiet-seconds",
@@ -13730,7 +13703,7 @@ PY
                         capture_output=True,
                         text=True,
                         check=False,
-                        timeout=6,
+                        timeout=10,
                     )
 
                     assert result.returncode == 0, result.stdout + result.stderr
@@ -13742,8 +13715,9 @@ PY
                     assert payload["resume"]["trigger_created_at"] == "2026-06-09T02:03:04Z"
                     assert "--trigger-mode resume" in payload["resume"]["command_hint"]
                     assert "--trigger-comment-id 777" in payload["resume"]["command_hint"]
-                    assert payload["codex_review"]["lifecycle"]["status"] == "pending"
-                    assert "phase=wait ci=passed review=observing" in result.stderr
+                    if review_status == "pending":
+                        assert payload["codex_review"]["lifecycle"]["status"] == "pending"
+                    assert "phase=wait ci=passed review=pending_signal" in result.stderr
                     assert (out_dir / "result.json").read_text(encoding="utf-8") == result.stdout
                     assert not (out_dir / "summary.md").exists()
 

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -20167,52 +20167,54 @@ print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
             "comment_id": 99,
             "created_at": "2999-01-01T00:00:00Z",
         }
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            result, _out_dir = self._issue_174_run_wait_fake_snapshots(
-                Path(tmp_dir),
-                [
-                    {
-                        "ci": "passed",
-                        "review": "approved",
-                        "status": "pending",
-                        "overall_status": "pending",
-                        "normalized_status": "pending",
-                        "recommended_next_action": "wait_or_resume",
-                        "decision": decision,
-                        "decision_fingerprint": "no-completion-s204-young-trigger",
-                        "codex_review": {
-                            "lifecycle": {
-                                "status": "none",
-                                "completion_signal": "none",
-                                "confidence": "medium",
-                                "no_completion_evidence": evidence,
-                            },
-                            "collection_summary": {
-                                "review_threads": {"unresolved_count": 0, "unresolved_ids": []}
-                            },
-                        },
-                        "observed_at": "2000-01-01T00:00:00Z",
-                        "trigger": trigger,
-                        "check_runs": {"total": 1, "success": 1},
-                        "threads": {"total": 0, "unresolved": 0, "items": []},
-                    }
-                ],
-                timeout_seconds=3,
-                quiet_seconds=1,
-                same_fingerprint_count=2,
-                progress="stderr-summary",
-                trigger_created_at=trigger["created_at"],
-            )
+        for review_status in ("approved", "passed"):
+            with _case(review_status=review_status):
+                with tempfile.TemporaryDirectory() as tmp_dir:
+                    result, _out_dir = self._issue_174_run_wait_fake_snapshots(
+                        Path(tmp_dir),
+                        [
+                            {
+                                "ci": "passed",
+                                "review": review_status,
+                                "status": "pending",
+                                "overall_status": "pending",
+                                "normalized_status": "pending",
+                                "recommended_next_action": "wait_or_resume",
+                                "decision": decision,
+                                "decision_fingerprint": "no-completion-s204-young-trigger",
+                                "codex_review": {
+                                    "lifecycle": {
+                                        "status": "none",
+                                        "completion_signal": "none",
+                                        "confidence": "medium",
+                                        "no_completion_evidence": evidence,
+                                    },
+                                    "collection_summary": {
+                                        "review_threads": {"unresolved_count": 0, "unresolved_ids": []}
+                                    },
+                                },
+                                "observed_at": "2000-01-01T00:00:00Z",
+                                "trigger": trigger,
+                                "check_runs": {"total": 1, "success": 1},
+                                "threads": {"total": 0, "unresolved": 0, "items": []},
+                            }
+                        ],
+                        timeout_seconds=3,
+                        quiet_seconds=1,
+                        same_fingerprint_count=2,
+                        progress="stderr-summary",
+                        trigger_created_at=trigger["created_at"],
+                    )
 
-            assert result.returncode == 0, result.stdout + result.stderr
-            payload = json.loads(result.stdout)
-            assert payload["normalized_status"] != "human_gate"
-            assert payload["decision"]["status_reason"] != "review_completion_unknown"
-            assert payload["recommended_next_action"] == "wait_or_resume"
-            assert payload["observation_complete"] is False
-            assert payload["wait"]["review_completion_unknown_latency_satisfied"] is False
-            assert payload["wait"]["review_trigger_age_seconds"] < 300
-            assert "phase=wait ci=passed review=pending_signal" in result.stderr
+                    assert result.returncode == 0, result.stdout + result.stderr
+                    payload = json.loads(result.stdout)
+                    assert payload["normalized_status"] != "human_gate"
+                    assert payload["decision"]["status_reason"] != "review_completion_unknown"
+                    assert payload["recommended_next_action"] == "wait_or_resume"
+                    assert payload["observation_complete"] is False
+                    assert payload["wait"]["review_completion_unknown_latency_satisfied"] is False
+                    assert payload["wait"]["review_trigger_age_seconds"] < 300
+                    assert "phase=wait ci=passed review=pending_signal" in result.stderr
 
     def test_issue_187_s204_wait_does_not_promote_unknown_before_ci_passed_age(self) -> None:
         evidence = {

--- a/tests/unit/infra/test_init_update.py
+++ b/tests/unit/infra/test_init_update.py
@@ -1258,6 +1258,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00197-extract-pr-review-snapshot-python/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00210-epic-planning-system-architect-draft-cycles/.meta.json",
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00211-epic-execution-coordinator-skill/.meta.json",
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/.meta.json",
     )
     _CHECKED_IN_DOGFOODING_DEPENDS_ON_BY_META_PATH = {
         "spec-dock/initiatives/init-00079-minor-bugfix-maintenance/.meta.json": [],
@@ -1469,6 +1470,7 @@ class TestInitUpdate(CliRuntimeHarness):
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00197-extract-pr-review-snapshot-python/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00210-epic-planning-system-architect-draft-cycles/.meta.json": [],
         "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00211-epic-execution-coordinator-skill/.meta.json": [],
+        "spec-dock/initiatives/init-local-00003-architecture-maintenance-and-hardening/epics/epic-00158-agent-workflow-pdca-hardening/issues/iss-00214-pr-observation-review-target-state/.meta.json": [],
     }
     _CHECKED_IN_DOGFOODING_NON_EMPTY_ISSUE_DEPENDS_ON_MAP = {
         "iss-00035": ["iss-00036"],


### PR DESCRIPTION
## 概要

- PR observation の wait progress line で、`review=` が観測者側の状態ではなく観測対象の Codex review state を表示するようにした。
- no-signal wait state では `review=pending_signal` を表示し、unresolved feedback や final JSON decision semantics は維持する。
- issue #214 の requirement / design / plan / report と clarification evidence を SpecDock に記録した。

## 背景・目的

- 既存実装は wait 中の progress line で `review=observing` を表示しており、観測している側の作業状態が `review=` に混ざっていた。
- `review=` は観測対象の状態を示すべきなので、Codex review completion/comment signal がまだない待機状態を `pending_signal` として明示する。

## 変更内容

- `pr_observation_wait.py` の progress 表示導出を変更し、no-signal wait state を `review=pending_signal` として表示する。
- provider-side asset と dogfooding mirror の wait script を同じ内容に揃えた。
- latency-guard no-completion path で legacy/audit 由来の `approved` / `passed` review status が来る場合も、trusted completion signal がない wait progress では `pending_signal` として表示する。
- focused regression test と issue report の closure evidence を追加した。

## 影響範囲

- `wait_pr_observation.sh` の stderr progress line 表示に影響する。
- stdout JSON の `decision`、`decision_fingerprint`、trigger / resume / snapshot / auth behavior は変更しない。
- PR observation skill docs は stale な `review=observing` contract がないため更新不要と判断した。

## 検証

- [x] `uv run pytest tests/unit/infra/test_init_update.py -k "issue_176_s04_wait_ci_passed_codex_review_pending_times_out_with_resume_hint or issue_174_pr_observation_wait_compacts_terminal_ci_and_human_gate_review or issue_174_pr_observation_wait_preserves_output_boundary_and_line_budget or issue_187_s204_wait or issue_176_s04_wait_fallback_issue_comment_does_not_request_review_feedback or issue_187_s100_fallback_issue_comment_is_not_no_completion_evidence"` が成功
- [x] `./spec-dock/scripts/spec-dock validate` が成功
- [x] `./spec-dock/scripts/spec-dock sync --github` が成功し、差分なし
- [x] final QA / issue-wide code review / final spec review が pass

## リスク・注意点

- progress line は non-authoritative diagnostic であり、machine-readable authority は引き続き stdout JSON。
- trusted completion signal がない legacy/audit `approved` / `passed` 表示は wait progress では `pending_signal` に寄せるが、timeout/final phase には拡張していない。

## 確認観点

- actionable feedback がある場合に `review=unresolved` と counts が維持されること。
- no-completion / fallback / `review_completion_unknown` の final JSON semantics が変わっていないこと。
- provider-side asset と dogfooding mirror が drift していないこと。

## フォローアップ

- なし

Closes #214
