### PR TITLE
fix(artifacts): 保存済みArtifactのfilename検証をopen-world化

### DIFF
--- a/spec-dock/docs/authoring/artifacts.md
+++ b/spec-dock/docs/authoring/artifacts.md
@@ -19,6 +19,14 @@ Artifact は調査、対話、検討の evidence を残すための文書です�
 
 `decision-candidate` は未採用の選択肢です。判断を固定する必要がある場合は、明示的な判断を Requirement / Design / Plan に反映するか、ADR を使います。ADR も作成直後は `authority: draft`、`mirror_eligible: false` であり、明示的に `accepted` となるまで authority ではありません。
 
+## Stored Artifact validation
+
+Current creation catalogは`new artifact <type>`で選べるtypeを閉じるための契約です。一方、保存済みArtifactのvalidationはopen-worldです。有効なlowercase UTC timestamp、任意の`01..99` suffix、安全なnon-empty basenameを持つMarkdownは、既知typeに一致しなくてもuntyped evidenceとして受理します。`analysis`、`report`、`review`などのtype風ラベルや未知ラベルだけを理由にmalformedにはしません。
+
+untyped Artifactは後方互換のためruntime内部で`blank`と表現されますが、creation templateとしての`blank`とは別物です。known typed filenameはuntypedより先に認識され、ADR mirrorは明示的な`adr` filenameと必要なfrontmatter・eligibility条件を満たすものだけを対象にします。filenameがvalidであることやtype風ラベルを含むことは、内容の採用、review完了、canonical authorityを意味しません。
+
+`artifact import file`は`<ts>--<normalized-basename>`形式で任意拡張子とsource bytesをopaque evidenceとして保持します。generic importのfilenameや本文からtype、authority、採用状態を推測しません。
+
 ## Authority flow
 
 ```text

--- a/spec-dock/docs/reference_naming.md
+++ b/spec-dock/docs/reference_naming.md
@@ -89,6 +89,8 @@
 
 - Current で新規作成する artifact doc family は `blank` / `adr` / `disc` / `research` / `interview` / `decision-candidate` です。type 省略は `blank` と同じです。
 - `pr-repair-batch`、`draft-requirement`、`draft-design`、`draft-plan`、`scratch`、`note` は Historical です。既存 file は validation でその type だけを理由に malformed にしませんが、新規作成 catalog には含めません。
+- この type catalog は `new artifact <type>` の creation contract です。保存済み Markdown の validation は open-world であり、既知 typed 形式に一致しない filename も、有効な timestamp / suffix と安全な non-empty kebab-case basename を持てば untyped Artifact として受理します。`analysis`、`report`、`review` などの type 風ラベルや未知ラベルだけを理由に malformed にはしません。
+- untyped Artifact は後方互換のため runtime 内部で `blank` と表現されますが、`new artifact blank` が選ぶ creation template とは別の分類です。
 - original/source file は、対象 Initiative / Epic / Issue ノード配下の `artifacts/` に作成されます。
 - Historical の ADR original は `artifacts/` または legacy `discussions/` 配下にありえます。Historical を Current 作成候補や workflow routing へ自動昇格しません。
 - この節の basename 形式は validation / allocation contract の参照です。新規作成時に手で `<ts>-...` filename を組み立てず、`new artifact <type>` が返す generated path を使います。
@@ -110,6 +112,7 @@ same-second collision 形:
 - `nn = 01..99`
   - 同一 `artifacts/` directory 内で同じ秒を共有した artifact doc family collision の safety fallback suffix です
   - runtime は同じ timestamp slot が使われている場合、短い wait / retry で次の timestamp slot を優先し、bounded wait で解消できないときだけ suffix を使います
+  - timestamp 直後の数字だけの要素は suffix として予約され、`00`、`100` 以上、その他 `01..99` 以外の値は basename としてfallbackせず rejectします
 - Current `type = adr|disc|research|interview|decision-candidate`
 - `blank` は filename token を使わず、front matter の `template: "blank"` で template identity を示します。
 - grandfathered existing `scratch` / `note` filenames may also appear in validation.
@@ -122,6 +125,10 @@ same-second collision 形:
 - `20260329t123456z-decision-candidate-token-options.md`
 - `20260329t123456z-01-research-benchmark-summary.md`
 - `20260329t123456z-02-interview-rollout-policy.md`
+- `20260329t123457z-analysis-existing-boundary.md`（untyped stored Artifact）
+- `20260329t123458z-report-validation-result.md`（untyped stored Artifact）
+
+known type の認識はuntyped fallbackより先に行います。ただしfilenameがvalidであることやtype風ラベルを含むことは、本文が採用済み、review済み、またはcanonical authorityであることを意味しません。ADR mirrorも明示的な`adr` filenameと必要なfrontmatter・eligibility条件を満たす場合だけ生成します。
 
 ### 4.3 `artifact_id` と filename stem の境界
 

--- a/spec-dock/scripts/spec_dock_runtime/application/doctor.py
+++ b/spec-dock/scripts/spec_dock_runtime/application/doctor.py
@@ -120,7 +120,7 @@ def _finding_from_error(error_message: str) -> DoctorFinding:
             code="malformed_artifact",
             message=error_message,
             guidance=[
-                "対象 scope の artifacts 配下で明示 catalog に属さない Artifact filename を整理してください。",
+                "対象 scope の artifacts 配下で timestamp、separator、suffix、basename、ファイル種別を確認してください。",
                 "修正後に `spec-dock/scripts/spec-dock validate` を再実行してください。",
             ],
         )

--- a/spec-dock/scripts/spec_dock_runtime/domain/artifacts.py
+++ b/spec-dock/scripts/spec_dock_runtime/domain/artifacts.py
@@ -29,7 +29,6 @@ HISTORICAL_TIMESTAMP_TYPED_ARTIFACT_TYPES = (
     "note",
 )
 SUPPORTED_ARTIFACT_TYPES = (*CURRENT_CREATABLE_ARTIFACT_TYPES, *HISTORICAL_TIMESTAMP_TYPED_ARTIFACT_TYPES)
-UNSUPPORTED_ARTIFACT_TYPES = ("analysis",)
 
 _ARTIFACT_TIMESTAMP_INTENT_RE = re.compile(r"^[0-9]{8}[tT][0-9].*$")
 _ARTIFACT_DOC_TYPE_PATTERN = "|".join(
@@ -308,12 +307,13 @@ def parse_artifact_filename(name: str) -> ArtifactFilename | None:
     suffix = int(suffix_raw) if suffix_raw is not None else None
     slug = str(matched.group("slug"))
     parts = slug.split("-")
-    if re.fullmatch(r"[0-9]{2}", parts[0]) is not None:
+    if parts[0].isdigit():
         return None
-    for end in range(len(parts), 0, -1):
-        if "-".join(parts[:end]) in (*SUPPORTED_ARTIFACT_TYPES, *UNSUPPORTED_ARTIFACT_TYPES):
-            return None
     artifact_id = timestamp if suffix is None else f"{timestamp}-{suffix:02d}"
+    # Stored Markdown is open-world: a valid timestamp filename that does not
+    # match a known typed form is untyped evidence. Keep the historical
+    # "blank" representation for compatibility; this does not expand the
+    # closed creation type catalog.
     return ArtifactFilename(
         timestamp=timestamp,
         suffix=suffix,
@@ -369,7 +369,7 @@ def is_malformed_artifact_candidate(path: Path) -> bool:
         return True
     lowered = stem.lower()
     parts = lowered.split("-")
-    for artifact_type in (*SUPPORTED_ARTIFACT_TYPES, *UNSUPPORTED_ARTIFACT_TYPES):
+    for artifact_type in SUPPORTED_ARTIFACT_TYPES:
         if (
             lowered == artifact_type
             or lowered.startswith(f"{artifact_type}-")

--- a/src/spec_dock/assets/spec_dock/docs/authoring/artifacts.md
+++ b/src/spec_dock/assets/spec_dock/docs/authoring/artifacts.md
@@ -19,6 +19,14 @@ Artifact は調査、対話、検討の evidence を残すための文書です�
 
 `decision-candidate` は未採用の選択肢です。判断を固定する必要がある場合は、明示的な判断を Requirement / Design / Plan に反映するか、ADR を使います。ADR も作成直後は `authority: draft`、`mirror_eligible: false` であり、明示的に `accepted` となるまで authority ではありません。
 
+## Stored Artifact validation
+
+Current creation catalogは`new artifact <type>`で選べるtypeを閉じるための契約です。一方、保存済みArtifactのvalidationはopen-worldです。有効なlowercase UTC timestamp、任意の`01..99` suffix、安全なnon-empty basenameを持つMarkdownは、既知typeに一致しなくてもuntyped evidenceとして受理します。`analysis`、`report`、`review`などのtype風ラベルや未知ラベルだけを理由にmalformedにはしません。
+
+untyped Artifactは後方互換のためruntime内部で`blank`と表現されますが、creation templateとしての`blank`とは別物です。known typed filenameはuntypedより先に認識され、ADR mirrorは明示的な`adr` filenameと必要なfrontmatter・eligibility条件を満たすものだけを対象にします。filenameがvalidであることやtype風ラベルを含むことは、内容の採用、review完了、canonical authorityを意味しません。
+
+`artifact import file`は`<ts>--<normalized-basename>`形式で任意拡張子とsource bytesをopaque evidenceとして保持します。generic importのfilenameや本文からtype、authority、採用状態を推測しません。
+
 ## Authority flow
 
 ```text

--- a/src/spec_dock/assets/spec_dock/docs/reference_naming.md
+++ b/src/spec_dock/assets/spec_dock/docs/reference_naming.md
@@ -89,6 +89,8 @@
 
 - Current で新規作成する artifact doc family は `blank` / `adr` / `disc` / `research` / `interview` / `decision-candidate` です。type 省略は `blank` と同じです。
 - `pr-repair-batch`、`draft-requirement`、`draft-design`、`draft-plan`、`scratch`、`note` は Historical です。既存 file は validation でその type だけを理由に malformed にしませんが、新規作成 catalog には含めません。
+- この type catalog は `new artifact <type>` の creation contract です。保存済み Markdown の validation は open-world であり、既知 typed 形式に一致しない filename も、有効な timestamp / suffix と安全な non-empty kebab-case basename を持てば untyped Artifact として受理します。`analysis`、`report`、`review` などの type 風ラベルや未知ラベルだけを理由に malformed にはしません。
+- untyped Artifact は後方互換のため runtime 内部で `blank` と表現されますが、`new artifact blank` が選ぶ creation template とは別の分類です。
 - original/source file は、対象 Initiative / Epic / Issue ノード配下の `artifacts/` に作成されます。
 - Historical の ADR original は `artifacts/` または legacy `discussions/` 配下にありえます。Historical を Current 作成候補や workflow routing へ自動昇格しません。
 - この節の basename 形式は validation / allocation contract の参照です。新規作成時に手で `<ts>-...` filename を組み立てず、`new artifact <type>` が返す generated path を使います。
@@ -110,6 +112,7 @@ same-second collision 形:
 - `nn = 01..99`
   - 同一 `artifacts/` directory 内で同じ秒を共有した artifact doc family collision の safety fallback suffix です
   - runtime は同じ timestamp slot が使われている場合、短い wait / retry で次の timestamp slot を優先し、bounded wait で解消できないときだけ suffix を使います
+  - timestamp 直後の数字だけの要素は suffix として予約され、`00`、`100` 以上、その他 `01..99` 以外の値は basename としてfallbackせず rejectします
 - Current `type = adr|disc|research|interview|decision-candidate`
 - `blank` は filename token を使わず、front matter の `template: "blank"` で template identity を示します。
 - grandfathered existing `scratch` / `note` filenames may also appear in validation.
@@ -122,6 +125,10 @@ same-second collision 形:
 - `20260329t123456z-decision-candidate-token-options.md`
 - `20260329t123456z-01-research-benchmark-summary.md`
 - `20260329t123456z-02-interview-rollout-policy.md`
+- `20260329t123457z-analysis-existing-boundary.md`（untyped stored Artifact）
+- `20260329t123458z-report-validation-result.md`（untyped stored Artifact）
+
+known type の認識はuntyped fallbackより先に行います。ただしfilenameがvalidであることやtype風ラベルを含むことは、本文が採用済み、review済み、またはcanonical authorityであることを意味しません。ADR mirrorも明示的な`adr` filenameと必要なfrontmatter・eligibility条件を満たす場合だけ生成します。
 
 ### 4.3 `artifact_id` と filename stem の境界
 

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/application/doctor.py
@@ -120,7 +120,7 @@ def _finding_from_error(error_message: str) -> DoctorFinding:
             code="malformed_artifact",
             message=error_message,
             guidance=[
-                "対象 scope の artifacts 配下で明示 catalog に属さない Artifact filename を整理してください。",
+                "対象 scope の artifacts 配下で timestamp、separator、suffix、basename、ファイル種別を確認してください。",
                 "修正後に `spec-dock/scripts/spec-dock validate` を再実行してください。",
             ],
         )

--- a/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/domain/artifacts.py
+++ b/src/spec_dock/assets/spec_dock/scripts/spec_dock_runtime/domain/artifacts.py
@@ -29,7 +29,6 @@ HISTORICAL_TIMESTAMP_TYPED_ARTIFACT_TYPES = (
     "note",
 )
 SUPPORTED_ARTIFACT_TYPES = (*CURRENT_CREATABLE_ARTIFACT_TYPES, *HISTORICAL_TIMESTAMP_TYPED_ARTIFACT_TYPES)
-UNSUPPORTED_ARTIFACT_TYPES = ("analysis",)
 
 _ARTIFACT_TIMESTAMP_INTENT_RE = re.compile(r"^[0-9]{8}[tT][0-9].*$")
 _ARTIFACT_DOC_TYPE_PATTERN = "|".join(
@@ -308,12 +307,13 @@ def parse_artifact_filename(name: str) -> ArtifactFilename | None:
     suffix = int(suffix_raw) if suffix_raw is not None else None
     slug = str(matched.group("slug"))
     parts = slug.split("-")
-    if re.fullmatch(r"[0-9]{2}", parts[0]) is not None:
+    if parts[0].isdigit():
         return None
-    for end in range(len(parts), 0, -1):
-        if "-".join(parts[:end]) in (*SUPPORTED_ARTIFACT_TYPES, *UNSUPPORTED_ARTIFACT_TYPES):
-            return None
     artifact_id = timestamp if suffix is None else f"{timestamp}-{suffix:02d}"
+    # Stored Markdown is open-world: a valid timestamp filename that does not
+    # match a known typed form is untyped evidence. Keep the historical
+    # "blank" representation for compatibility; this does not expand the
+    # closed creation type catalog.
     return ArtifactFilename(
         timestamp=timestamp,
         suffix=suffix,
@@ -369,7 +369,7 @@ def is_malformed_artifact_candidate(path: Path) -> bool:
         return True
     lowered = stem.lower()
     parts = lowered.split("-")
-    for artifact_type in (*SUPPORTED_ARTIFACT_TYPES, *UNSUPPORTED_ARTIFACT_TYPES):
+    for artifact_type in SUPPORTED_ARTIFACT_TYPES:
         if (
             lowered == artifact_type
             or lowered.startswith(f"{artifact_type}-")

--- a/tests/cli_runtime/test_artifact_import_file.py
+++ b/tests/cli_runtime/test_artifact_import_file.py
@@ -241,6 +241,27 @@ class TestArtifactImportFile(CliRuntimeHarness):
             assert generic.read_bytes() == b"generic sentinel"
             assert (target / payload["destination"]).read_bytes() == b"generic body"
 
+    def test_json_with_spaces_in_original_basename_remains_opaque_generic_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            assert main(["init", str(target)]) == 0
+            self._write_runtime_clock(target)
+            source = target / "Evidence FINAL.json"
+            body = b'{"authority":"not-inferred"}\n'
+            source.write_bytes(body)
+
+            completed = self._run_runtime_capture(
+                target,
+                ["artifact", "import", "file", "--root", "--file", source.name, "--json"],
+            )
+
+            assert completed.returncode == 0, completed.stdout + completed.stderr
+            payload = json.loads(completed.stdout)
+            assert payload["artifact_id"] == "20260730t010203z--Evidence FINAL.json"
+            assert payload["canonical"] is False
+            assert (target / payload["destination"]).read_bytes() == body
+            assert source.read_bytes() == body
+
     def test_shared_slot_exhaustion_is_not_committed_and_preserves_existing_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             target = Path(tmp)

--- a/tests/cli_runtime/test_validate.py
+++ b/tests/cli_runtime/test_validate.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import stat
 import tempfile
 import time
 
@@ -33,6 +34,10 @@ _S06_HISTORICAL_POSITIVE_FILENAMES = (
     ("artifacts", "20260810t010112z-disc-options.md"),
     ("artifacts", "20260810t010113z-decision-candidate-choice.md"),
     ("artifacts", "20260810t010114z-adr-decision.md"),
+    ("artifacts", "20260810t010117z-analysis-boundary-review.md"),
+    ("artifacts", "20260810t010118z-report-validation-result.md"),
+    ("artifacts", "20260810t010119z-review-final-gate.md"),
+    ("artifacts", "20260810t010120z-external-document.md"),
     ("discussions", "20260810t010115z-disc-legacy.md"),
     ("discussions", "20260810t010116z-01-note-legacy.md"),
     ("discussions", "001-adr-legacy.md"),
@@ -42,12 +47,22 @@ _S06_HISTORICAL_POSITIVE_FILENAMES = (
 )
 
 _S06_MALFORMED_ARTIFACT_FILENAMES = (
-    "20260810t010101z-analysis-unknown.md",
     "20260810T010101z-adr-upper-t.md",
+    "20260810t010101Z-adr-upper-z.md",
+    "20260810t010101-adr-missing-z.md",
+    "20260810t010101z_analysis-bad-separator.md",
+    "20260810t010101z-.md",
     "20260810t01010z-adr-short-time.md",
     "20261340t256199z-adr-impossible-time.md",
     "20260810t010101z-00-note-bad-slot.md",
+    "20260810t010101z-100-note-bad-slot.md",
     "001-scratch-not-in-sequential-catalog.md",
+)
+
+_OPEN_WORLD_ANALYSIS_FILENAMES = (
+    "20260811t091549z-analysis-operational-state-eventstore-readmodel-boundary.md",
+    "20260811t095606z-analysis-event-sourcing-synchronous-current-state-projection.md",
+    "20260811t113200z-analysis-existing-projection-uow-reuse.md",
 )
 
 
@@ -155,7 +170,7 @@ class TestCliValidate(CliRuntimeHarness):
         "malformed_name",
         (
             None,
-            "20260810t010101z-analysis-direct-control.md",
+            "20260810t010101z-100-analysis-direct-control.md",
             "20260230t120000z--capture.html",
         ),
     )
@@ -196,6 +211,24 @@ class TestCliValidate(CliRuntimeHarness):
             else:
                 assert validated.returncode == 0, validated.stdout + validated.stderr
                 assert diagnosed.returncode == 0, diagnosed.stdout + diagnosed.stderr
+            assert _path_sha256_snapshot(target) == before
+
+    def test_validate_and_doctor_accept_existing_analysis_artifacts_together_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+            assert main(["init", str(target)]) == 0
+            self._create_same_repo_linked_hierarchy(target)
+            artifacts_dir = _s06_issue_dir(target) / "artifacts"
+            artifacts_dir.mkdir(parents=True, exist_ok=True)
+            for filename in _OPEN_WORLD_ANALYSIS_FILENAMES:
+                (artifacts_dir / filename).write_bytes(f"existing:{filename}\n".encode())
+            before = _path_sha256_snapshot(target)
+
+            validated = self._run_runtime_capture(target, ["validate"])
+            diagnosed = self._run_runtime_capture(target, ["doctor"])
+
+            assert validated.returncode == 0, validated.stdout + validated.stderr
+            assert diagnosed.returncode == 0, diagnosed.stdout + diagnosed.stderr
             assert _path_sha256_snapshot(target) == before
 
     @pytest.mark.parametrize(("surface", "filename"), _S06_HISTORICAL_POSITIVE_FILENAMES)
@@ -258,6 +291,14 @@ class TestCliValidate(CliRuntimeHarness):
                 "Duplicate artifact timestamp slot detected",
             ),
             (
+                ("20260810t010101z-adr-first.md", "20260810t010101z-analysis-second.md"),
+                "Duplicate artifact timestamp slot detected",
+            ),
+            (
+                ("20260810t010101z-analysis-first.md", "20260810t010101z--second.bin"),
+                "Duplicate artifact timestamp slot detected",
+            ),
+            (
                 ("001-adr-first.md", "001-adr-second.md"),
                 "Duplicate artifact id detected",
             ),
@@ -292,6 +333,8 @@ class TestCliValidate(CliRuntimeHarness):
         "unsafe_kind",
         (
             "artifact-file-symlink",
+            "artifact-file-directory",
+            "artifact-file-fifo",
             "artifacts-directory-symlink",
             "dangling-artifacts-directory-symlink",
         ),
@@ -312,9 +355,17 @@ class TestCliValidate(CliRuntimeHarness):
             external_file = external / "outside.md"
             if external.exists():
                 external_file.write_bytes(b"external artifact\n")
-            if unsafe_kind == "artifact-file-symlink":
+            if unsafe_kind in ("artifact-file-symlink", "artifact-file-directory", "artifact-file-fifo"):
                 artifacts_dir.mkdir(parents=True, exist_ok=True)
-                (artifacts_dir / "20260810t010101z-note-external.md").symlink_to(external_file)
+                unsafe_path = artifacts_dir / "20260810t010101z-analysis-external.md"
+                if unsafe_kind == "artifact-file-symlink":
+                    unsafe_path.symlink_to(external_file)
+                elif unsafe_kind == "artifact-file-directory":
+                    unsafe_path.mkdir()
+                else:
+                    if not hasattr(os, "mkfifo"):
+                        pytest.skip("FIFO creation is unavailable")
+                    os.mkfifo(unsafe_path)
             else:
                 shutil.rmtree(artifacts_dir)
                 artifacts_dir.symlink_to(external, target_is_directory=True)
@@ -333,6 +384,8 @@ class TestCliValidate(CliRuntimeHarness):
             assert "[unsafe_artifact]" in diagnosed.stderr
             assert "Unsafe artifact" in diagnosed.stderr
             assert _path_sha256_snapshot(target) == before
+            if unsafe_kind == "artifact-file-fifo":
+                assert stat.S_ISFIFO(unsafe_path.stat(follow_symlinks=False).st_mode)
             if unsafe_kind == "dangling-artifacts-directory-symlink":
                 assert artifacts_dir.is_symlink()
                 assert artifacts_dir.readlink() == external

--- a/tests/unit/domain/test_artifacts.py
+++ b/tests/unit/domain/test_artifacts.py
@@ -114,11 +114,15 @@ def test_existing_generic_import_catalog_is_recognized_as_opaque_identity(tmp_pa
 @pytest.mark.parametrize(
     "filename",
     (
-        "20260810t010101z-analysis-unknown.md",
         "20260810T010101z-adr-upper-t.md",
+        "20260810t010101Z-adr-upper-z.md",
+        "20260810t010101-adr-missing-z.md",
+        "20260810t010101z_analysis-bad-separator.md",
+        "20260810t010101z-.md",
         "20260810t01010z-adr-short-time.md",
         "20261340t256199z-adr-impossible-time.md",
         "20260810t010101z-00-note-bad-slot.md",
+        "20260810t010101z-100-note-bad-slot.md",
         "001-scratch-not-in-sequential-catalog.md",
     ),
 )
@@ -127,6 +131,32 @@ def test_existing_catalog_rejects_timestamp_intent_and_sequential_controls(tmp_p
 
     assert artifacts.parse_existing_artifact_filename(filename) is None
     assert artifacts.is_malformed_artifact_candidate(tmp_path / filename) is True
+
+
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "20260811t091549z-analysis-operational-state-eventstore-readmodel-boundary.md",
+        "20260811t095606z-analysis-event-sourcing-synchronous-current-state-projection.md",
+        "20260811t113200z-analysis-existing-projection-uow-reuse.md",
+        "20260811t113201z-report-validation-result.md",
+        "20260811t113202z-review-final-gate.md",
+        "20260811t113203z-external-document.md",
+    ),
+)
+def test_existing_timestamp_markdown_with_unknown_type_like_label_is_accepted_as_untyped(
+    tmp_path: Path,
+    filename: str,
+) -> None:
+    artifacts = _artifacts_module()
+
+    parsed = artifacts.parse_existing_artifact_filename(filename)
+
+    assert parsed is not None
+    # Stored untyped Markdown retains the historical "blank" representation;
+    # this does not make its leading label part of the creation type catalog.
+    assert parsed.artifact_type == "blank"
+    assert artifacts.is_malformed_artifact_candidate(tmp_path / filename) is False
 
 
 def test_historical_tokens_are_not_misclassified_as_blank_slugs() -> None:
@@ -166,14 +196,17 @@ def test_out_of_band_non_markdown_attachment_is_distinct_from_generic_import_and
     artifacts = _artifacts_module()
     attachment = "20260810t010101z-disc-export.html"
     generic = "20260810t010102z--export.html"
-    malformed = "20260810t010103z-analysis-managed.md"
+    untyped = "20260810t010103z-analysis-managed.md"
 
     assert artifacts.parse_existing_artifact_filename(attachment) is None
     assert artifacts.is_malformed_artifact_candidate(tmp_path / attachment) is False
     generic_parsed = artifacts.parse_existing_artifact_filename(generic)
     assert generic_parsed is not None
     assert generic_parsed.artifact_id == generic
-    assert artifacts.is_malformed_artifact_candidate(tmp_path / malformed) is True
+    untyped_parsed = artifacts.parse_existing_artifact_filename(untyped)
+    assert untyped_parsed is not None
+    assert untyped_parsed.artifact_type == "blank"
+    assert artifacts.is_malformed_artifact_candidate(tmp_path / untyped) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/presentation/test_runtime_sync_s07.py
+++ b/tests/unit/presentation/test_runtime_sync_s07.py
@@ -494,6 +494,14 @@ class TestRuntimeSyncS07:
                 authority="accepted",
                 mirror_eligible=True,
             )
+            untyped_adr_like_doc = self._write_valid_artifact_adr_doc(
+                issue_db_dir,
+                "20260312t010214z-analysis-accepted-adr-looking.md",
+                doc_id="20260312t010214z-adr",
+                scope_id="iss-local-00002",
+                authority="accepted",
+                mirror_eligible=True,
+            )
             self._write_valid_artifact_adr_doc(
                 issue_db_dir,
                 "20260312t010212z-disc-artifact-discussion.md",
@@ -577,6 +585,7 @@ class TestRuntimeSyncS07:
 
             assert {source.source_path for source in sources} == {initiative_doc, epic_doc, issue_doc, artifact_doc}
             assert draft_artifact_doc not in {source.source_path for source in sources}
+            assert untyped_adr_like_doc not in {source.source_path for source in sources}
             assert {source.basename for source in sources} == {
                 "20260312t010203z-adr-init-decision.md",
                 "20260312t010204z-adr-epic-decision.md",


### PR DESCRIPTION
## 背景

`new artifact`の作成type catalogと、既に保存されているArtifact filenameのvalidationが同じclosed-world規則に結び付いていたため、有効なtimestamp Markdownであっても、`analysis`などcatalog外のtype風prefixを含むfilenameがmalformedとして拒否されていました。

## 変更内容

- 既知のtyped filenameを先に解析し、一致しない有効なtimestamp Markdownをuntyped evidenceとして受理
- untyped Artifactは互換性のため内部的に`artifact_type="blank"`として扱いつつ、creation templateの`blank`とは異なることをコメント・テスト・文書で明示
- `analysis`固有の拒否と、既知type風prefixを理由にfallbackを拒否する処理を削除
- 正規の`01..99` suffixとして解析されなかった数字だけの先頭要素を拒否し、`00`や`100`以上を継続して拒否
- doctorの案内をcatalog基準からfilename構造・安全性基準へ変更
- Naming ReferenceとArtifact Guideに、closed-worldなcreation catalog、open-worldな保存済みvalidation、authorityとの非連動、generic importのopaque evidence契約を追記
- provider側の変更をdogfooding projectionへ同期

## 影響範囲

- 保存済みArtifact filenameの解析、duplicate slot検出、`validate`、`doctor`
- Artifactの命名・authoring documentation
- provider assetとdogfooding projection

`new artifact`のcreation catalog、既知typed ArtifactのID、generic import、ADR mirror条件は変更していません。既存Artifactのrename・rewriteやartifact IDの全面変更も行いません。

## 検証

- `make lint`: 成功
- `uv run pytest`: 1033 passed / 1042 policy skipped
- 対象CLI full-regression選択: 21件成功
- `uvx --from . spec-dock update .`: providerからdogfooding projectionを同期
- `./spec-dock/scripts/spec-dock validate`: 成功（nodes=222）
- `./spec-dock/scripts/spec-dock doctor`: 成功（findings=0、GitHub capability info=1）
- `git diff --check`: 成功
- provider / dogfooding projection: byte一致を確認

回帰テストでは、提示された3つの`analysis` filename、`report`、`review`、未知ラベルの受理、`new artifact analysis`の拒否、既知typeの不変性、ADR mirror条件、timestamp/separator/suffix不正、typed・untyped・generic間のslot重複、symlink・directory・POSIX FIFOの拒否、generic importのopaque bytes保持を確認しています。また、3つの`analysis`実ファイルを同一の一時consumer repoへ配置し、`validate`と`doctor`の成功および非変更性を確認しています。

## リスク

open-world化により、構造上有効なtimestamp Markdownはcatalog外のtype風ラベルを含んでもuntypedとして受理されます。ただし、filenameの受理は内容の採用、review完了、canonical authorityを意味せず、明示的なtyped ADRと適格frontmatterだけをmirror対象とする境界は維持しています。

全体の`uv run pytest --run-full-regression`は今回実施していません。

## 確認観点

- known typedを先に解析することで既存のtyped identityが維持されているか
- untypedの`blank`内部表現がcreation catalogやADR mirrorへ漏れていないか
- `00`、`100`以上、不正timestamp・separatorなどの安全性境界が維持されているか
- providerとdogfooding projectionの内容が一致しているか

## フォローアップ

- 必要に応じて、merge後の独立したProvider Full Regressionで`uv run pytest --run-full-regression`を実行する
